### PR TITLE
DRILL: rollback test (revert immediately after)

### DIFF
--- a/install-linux.conf.yaml
+++ b/install-linux.conf.yaml
@@ -62,6 +62,9 @@
     ~/.config/topgrade.toml: topgrade/topgrade.toml
 
 - shell:
+    # ROLLBACK DRILL — intentional fail-step. Will be reverted immediately
+    # after the drill workflow run completes. Do not leave this in master.
+    - [false, "DRILL-intentional-fail-to-validate-rollback"]
     - command: |
         if [ "${DOTFILES_DRY_RUN:-0}" = "1" ]; then
           echo "[dry-run] would source ~/.zshenv"


### PR DESCRIPTION
Intentional failing install step to validate PR #22's rollback path. Will be reverted immediately after the drill workflow run completes. See commit message for details.