### PR TITLE
fix(install_tmux): hoist handle_error/log_message above first use (SC2218)

### DIFF
--- a/helpers/install_tmux.sh
+++ b/helpers/install_tmux.sh
@@ -12,23 +12,23 @@ if [ "$(uname)" = "Darwin" ] && [ -f ./helpers/init_homebrew.sh ]; then
     . ./helpers/init_homebrew.sh
 fi
 
-# Set up logging
-LOG_FILE="install_tmux.log"
-touch "$LOG_FILE" || handle_error "Unable to create log file"
-
 # Function to log messages
 log_message() {
   echo "$1" | tee -a "$LOG_FILE"
 }
-
-TPM_INSTALL_DIR="$HOME/.config/tmux/plugins/tpm"
-TPM_REPO_URL="https://github.com/tmux-plugins/tpm"
 
 # Error handling function
 handle_error() {
   log_message "Error: $1" >&2
   exit 1
 }
+
+# Set up logging
+LOG_FILE="install_tmux.log"
+touch "$LOG_FILE" || handle_error "Unable to create log file"
+
+TPM_INSTALL_DIR="$HOME/.config/tmux/plugins/tpm"
+TPM_REPO_URL="https://github.com/tmux-plugins/tpm"
 
 log_message "Starting TMux installation..."
 


### PR DESCRIPTION
## Summary

- Hoists `handle_error()` and `log_message()` above their first use in `helpers/install_tmux.sh` so a failed `touch "$LOG_FILE"` aborts cleanly instead of emitting `command not found` and silently continuing.
- `log_message` is hoisted first because `handle_error` calls it.
- Pure ordering change — no behavioral difference on the happy path; only the error path is affected.

Closes #23.

## Test plan

- [x] `bash -n helpers/install_tmux.sh` — clean
- [x] `shellcheck -x helpers/install_tmux.sh` — no SC2218 (or anything else)
- [x] `./install` on personal Mac — tmux helper section completes successfully and idempotently (TPM already installed, plugins already installed; `log_message` invoked end-to-end with the new ordering)
- [ ] (optional, for fresh-machine reviewers) Bootstrap on a clean `HOME` to confirm error path still works if `touch` fails

## Notes

This is a latent-bug fix flagged by reviewer during PR #22. Filed as a separate ticket (#23) to keep that PR's scope tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)