### PR TITLE
fix(brewfile): remove deprecated homebrew/bundle and homebrew/services taps

### DIFF
--- a/brew/Brewfile
+++ b/brew/Brewfile
@@ -1,6 +1,4 @@
 tap "adoptopenjdk/openjdk"
-tap "homebrew/bundle"
-tap "homebrew/services"
 tap "rigellute/tap"
 brew "ack"
 brew "aria2"


### PR DESCRIPTION
## Summary

- Removes two `tap` declarations from `brew/Brewfile` that now produce hard errors (both taps were deprecated by Homebrew and their contents migrated into core).
- Unblocks `./install` on fresh machines — the previous behavior was `brew bundle` failing and cascading into a non-zero exit from `helpers/install_packages.sh`.

Closes #27.

## Test plan

- [x] `./install` on personal Mac completes cleanly with `` `brew bundle` complete! 101 Brewfile dependencies now installed. `` and `Successfully installed packages from Brewfile` (previously failed with deprecated-tap errors)
- [x] No other references to these taps in the live install pipeline (grep confirms only `osx/install.sh` has them, which is orphaned — follow-up #28)
- [ ] (work Mac verification deferred to the next cross-machine sync test from HANDOFF)

## Notes

Follow-up #28 tracks the same deprecated taps in `osx/install.sh`, which is dead code (last touched 2022-02-08, unreferenced anywhere in the install pipeline). Decision on delete/revive/ignore deferred to that ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)