### PR TITLE
feat: seed VPS tmux window glyph metadata

### DIFF
--- a/docs/brainstorms/2026-04-17-vps-tmux-glyph-treatment-brainstorm.md
+++ b/docs/brainstorms/2026-04-17-vps-tmux-glyph-treatment-brainstorm.md
@@ -1,0 +1,131 @@
+# Brainstorm — VPS Tmux Glyph Treatment
+
+**Date:** 2026-04-17
+**Author:** David Villavicencio
+**Status:** Ready for planning
+
+---
+
+## What We're Building
+
+Give the **VPS's inner tmux status bar** the same glyph + palette treatment the
+Mac's outer tmux already has. When SSHed into `openclaw-prod` from a local
+tmux session, the nested VPS tmux currently shows plain `1: ops | 2: logs |
+3: openclaw | 4: tui` while the outer bar below shows colored glyph-prefixed
+tabs (✦ Home, 🌐 FedEx, 🎯 Eagle, ⚙ Dotfiles). The nesting itself stays —
+we want **visual parity**, not collapse.
+
+The VPS already symlinks `tmux/tmux.conf` (including the glyph ternary in
+`window-status-format`) and `restore-window-meta.sh` via
+`install-linux.conf.yaml`. The ternary checks `@win_glyph` /
+`@win_glyph_color` per-window user options — which are empty on the VPS
+because no one has ever run the `tmux-window-namer` skill there. The machinery
+is there; only the data is missing.
+
+## Why This Approach
+
+Chose **Approach A: static seed JSON, Linux-only symlink** over two
+alternatives:
+
+- **B — Inline `set-hook` in tmux.conf** would embed glyph data imperatively
+  in shell config. Harder to scan, splits data across two spellings (tmux
+  options + palette file).
+- **C — Make the skill VPS-aware** via a `--remote` flag that pushes over
+  SSH. Unified control plane, but huge lift for a 4-window layout that
+  essentially never changes. Classic YAGNI.
+
+**A wins** because it reuses the existing `restore-window-meta.sh` hook,
+costs zero new code, and is declarative/reviewable in git. The VPS's
+window set is stable (part of the OpenClaw stack), so a committed seed
+fits perfectly.
+
+Drift concern investigated and dismissed: `save-window-meta.sh` is
+invoked only by the Mac skill with explicit CLI args — there's no
+auto-save hook in `tmux.general.conf`. The VPS never writes back, so a
+symlink to a committed seed file stays pristine.
+
+## Key Decisions
+
+- **Repo path:** `tmux/window-meta.linux.json` — parallels
+  `install.conf.yaml` vs `install-linux.conf.yaml` naming.
+- **Target path on VPS:** `~/.config/tmux/window-meta.json` via Dotbot
+  symlink, added under the `- link:` block of `install-linux.conf.yaml`
+  alongside the existing `save-window-meta.sh` / `restore-window-meta.sh`
+  entries.
+- **Mac install untouched.** `install.conf.yaml` (Darwin) does NOT symlink
+  this file — Mac continues to manage its live `window-meta.json`
+  directly via the skill.
+- **Palette discipline:** glyph colors chosen from
+  `claude/skills/tmux-window-namer/references/palettes.md` only. No
+  freeform hex.
+- **Session name assumption:** VPS tmux session is `main` (confirmed from
+  screenshot). JSON top-level key is `"main"`.
+
+## Window Mappings (locked)
+
+| Window     | Glyph | Palette | Hex       |
+|------------|-------|---------|-----------|
+| `ops`      | ⚙    | ocean   | `#56B6C2` |
+| `logs`     | ≡    | smoke   | `#4B5263` |
+| `openclaw` | 🦀   | ember   | `#D97757` |
+| `tui`      | ▤    | sky     | `#7DACD3` |
+
+Rendered preview (matches `window-status-format` in `tmux.display.conf`,
+which renders `#I:` directly against the glyph):
+`main  1:⚙ ops  2:≡ logs  3:🦀 openclaw  4:▤ tui`.
+
+## Acceptance Criteria
+
+- After `./install` on openclaw-prod, attaching to the VPS tmux session
+  shows glyph-prefixed tabs in the inner status bar matching the Mac
+  style.
+- No change to the Mac's live `~/.config/tmux/window-meta.json`
+  behavior.
+- `./install --dry-run` on Linux reports a "would symlink" line for the
+  new file and zero mutations.
+- Seed file survives window renaming: if a VPS window is renamed outside
+  the seed's known keys, the tab simply falls back to the no-glyph
+  branch of the ternary (same as unseeded windows today).
+
+## Resolved Questions
+
+- **Q:** Will the seed file drift if the VPS ever writes back?
+  **A:** No. `save-window-meta.sh` is only invoked by the Mac skill with
+  CLI args; no tmux hook auto-triggers it. The symlink target stays
+  pristine.
+- **Q:** Final glyph + color pairing per window?
+  **A:** Locked in the mapping table above (⚙/ocean, ≡/smoke, 🦀/ember,
+  ▤/sky).
+- **Q:** What happens when a new VPS window appears?
+  **A:** Falls back to no-glyph rendering (same as any unseeded window
+  today). Update requires editing `tmux/window-meta.linux.json`.
+  Acceptable for a stable layout.
+- **Q:** Should we also de-style the VPS tmux status-left/right?
+  **A:** Out of scope — user's goal is style parity on window tabs, not
+  collapsing or restyling the outer bar.
+
+## Open Questions
+
+1. **Verify VPS tmux runs host-level, not inside a container.** This
+   brainstorm assumes the VPS tmux session is the host user's tmux,
+   reading `~/.config/tmux/tmux.conf` symlinked by Dotbot. Evidence
+   (operator-style window layout `ops/logs/openclaw/tui`) points that
+   way, but if it turns out the tmux is inside the OpenClaw container,
+   the host-side symlink is invisible to it and the approach changes
+   (mount the seed into the container, or adopt approach B/C).
+   Resolve at the start of `/ce:plan` with `ssh root@openclaw-prod
+   'tmux display -p "#{socket_path}"'` or an equivalent check.
+
+## Out of Scope
+
+- Changing which bars appear when nested (collapsing the VPS status
+  bar, hiding the outer bar on SSH, etc.).
+- Porting the `tmux-window-namer` skill to the VPS or any remote/SSH
+  mode for it.
+- Restyling the top agent/session header strip (that's Claude Code /
+  OpenClaw UI, not tmux — different layer, different repo).
+
+---
+
+**Next step:** `/ce:plan` will pick up this document and turn it into an
+implementation plan.

--- a/docs/plans/2026-04-17-feat-vps-tmux-window-glyph-seed-plan.md
+++ b/docs/plans/2026-04-17-feat-vps-tmux-window-glyph-seed-plan.md
@@ -1,0 +1,328 @@
+---
+title: Add VPS tmux window glyph seed
+type: feat
+status: active
+date: 2026-04-17
+origin: docs/brainstorms/2026-04-17-vps-tmux-glyph-treatment-brainstorm.md
+---
+
+# Add VPS tmux window glyph seed ✨
+
+## Overview
+
+Give the VPS's inner tmux status bar the same colored-glyph treatment
+the Mac's outer tmux already has. The tmux-side machinery (glyph
+ternary in `window-status-format`, `restore-window-meta.sh`
+client-attached hook, both meta scripts) is already deployed on the
+VPS via `install-linux.conf.yaml`; what's missing is data. This plan
+adds a committed seed file `tmux/window-meta.linux.json` and a
+Linux-only Dotbot symlink pointing `~/.config/tmux/window-meta.json`
+at it. Zero new code. Darwin install untouched.
+
+(See brainstorm:
+`docs/brainstorms/2026-04-17-vps-tmux-glyph-treatment-brainstorm.md`)
+
+## Problem Statement / Motivation
+
+When SSHed into `openclaw-prod` from a local tmux, the nested VPS
+tmux renders `main 1: ops 2: logs 3: openclaw 4: tui` — plain text —
+while the outer local bar renders glyph-prefixed colored tabs
+(`✦ Home`, `🌐 FedEx`, etc.). Visual parity across the two status
+bars is the goal. Collapsing the nested bar is **out of scope**
+(confirmed during brainstorm — user answered "Match the glyph +
+palette style").
+
+The outer Mac tmux gets its glyphs because the `tmux-window-namer`
+Claude skill writes to `~/.config/tmux/window-meta.json` interactively
+during Mac-side sessions. The VPS has no equivalent skill invocation,
+so `@win_glyph` / `@win_glyph_color` user options are never set and
+the ternary at `tmux/tmux.display.conf:67-68` falls through to the
+no-glyph branch.
+
+## Proposed Solution
+
+**Approach: static seed JSON, Linux-only Dotbot symlink.** Selected
+over (B) an inline `set-hook` config block and (C) making the skill
+VPS-aware over SSH. The VPS window set is stable (`ops`, `logs`,
+`openclaw`, `tui` are part of the operator's long-running OpenClaw
+layout), which makes a declarative committed seed the natural fit.
+(See brainstorm § Why This Approach.)
+
+**Architectural win worth naming:** the `tmux-window-namer` skill
+stays purely local (Mac-only, no remote-execution surface), the
+tmux config stays purely declarative (session-agnostic, same file
+both hosts), and Dotbot remains the sole host-aware layer. That
+three-way separation is the thing to preserve as the repo grows.
+
+### New file: `tmux/window-meta.linux.json`
+
+```json
+{
+  "main": {
+    "ops":      { "glyph": "⚙",  "glyph_color": "#56B6C2" },
+    "logs":     { "glyph": "≡",  "glyph_color": "#4B5263" },
+    "openclaw": { "glyph": "🦀", "glyph_color": "#D97757" },
+    "tui":      { "glyph": "▤",  "glyph_color": "#7DACD3" }
+  }
+}
+```
+
+Schema matches exactly what `tmux/scripts/restore-window-meta.sh:18-22`
+reads: top-level `.session.window.{glyph, glyph_color}`. Hexes taken
+from `claude/skills/tmux-window-namer/references/palettes.md:12-20`
+(ocean / smoke / ember / sky).
+
+### Edit: `install-linux.conf.yaml`
+
+Extend the existing link block at lines 80-82 (the one already
+symlinking the meta scripts):
+
+```yaml
+- link:
+    ~/.config/tmux/scripts/save-window-meta.sh: tmux/scripts/save-window-meta.sh
+    ~/.config/tmux/scripts/restore-window-meta.sh: tmux/scripts/restore-window-meta.sh
+    ~/.config/tmux/window-meta.json: tmux/window-meta.linux.json   # NEW
+    ~/.config/nvim/lua/custom:
+      path: nvim/custom
+      create: true
+```
+
+Darwin `install.conf.yaml:69-83` is untouched — verified clean, no
+existing `window-meta.json` entry there. Mac's live sidecar
+continues to be written by the skill as today.
+
+### Rendered result
+
+Inner VPS tmux bar after reattach (matches `window-status-format` —
+`#I:` renders directly against the glyph with no intervening space):
+
+```
+ main   1:⚙ ops   2:≡ logs   3:🦀 openclaw   4:▤ tui
+```
+
+## Technical Considerations
+
+- **Schema / encoding.** Restore script (`tmux/scripts/restore-window-meta.sh:18-26`)
+  uses `jq '.[$s][$w] // empty'` and guards on `[ -n "$glyph" ]` /
+  `[ -n "$glyph_color" ]`, so empty-string values silently skip. Our
+  seed keeps all four values non-empty. Commit with UTF-8 encoding
+  (git default for `.json`).
+- **Target-syntax correctness.** Restore uses
+  `target="${session}:${idx}"` (line 23), i.e. session-qualified
+  targeting, not a bare integer. Safe across multi-session hosts.
+  (Cross-checked against the "bare integer hits current window"
+  learning — not a concern here.)
+- **jq on VPS.** Installed via `helpers/install_packages.sh:23`.
+  Restore's missing-jq silent-no-op guard (line 13) won't trigger.
+- **`relink: true` semantics.** The Linux conf sets this at line 3.
+  If `~/.config/tmux/window-meta.json` exists on the VPS as a
+  non-symlink, Dotbot removes it and creates the symlink. The
+  brainstorm established that no skill runs on VPS and nothing
+  auto-writes this path today, so there's no live state to lose.
+  Preflight check included below for paranoia.
+- **Hook firing.** `set-hook -g client-attached` at
+  `tmux/tmux.general.conf:81` fires on every fresh attach. On a
+  pre-existing persistent VPS session, the hook does **not** retro-
+  actively fire — operator must detach/reattach OR run the restore
+  script once manually. (See
+  `docs/solutions/cross-machine/vps-dotfiles-target.md:265-268`.)
+- **Dry-run guarantee.** Dotbot v1.24.1 (submodule-pinned) handles
+  `--dry-run` natively for `link` directives and emits "Would create
+  symlink" lines with zero filesystem mutation. No helper-script
+  guards needed for this change. (See `CLAUDE.md:138-164`,
+  `docs/solutions/code-quality/dotbot-dry-run-requires-v1-23-or-later.md`.)
+
+## System-Wide Impact
+
+### Interaction graph
+
+`./install` on Linux → Dotbot applies `link` block → symlink at
+`~/.config/tmux/window-meta.json` → next `tmux attach` fires
+`client-attached` hook → `restore-window-meta.sh` reads JSON →
+loops `tmux list-windows -a -F …` → for each matching entry,
+`tmux set-option -w -t main:<idx> @win_glyph <g>` and
+`@win_glyph_color <hex>` → `window-status-format` ternary in
+`tmux/tmux.display.conf:67-68` renders colored glyph prefix on the
+tab (status line refreshes within 1s because
+`status-interval 1` is set in `tmux.display.conf:23`).
+
+### Error propagation
+
+- Malformed JSON → jq error to stderr; tmux hook completes, no
+  options set, tabs render without glyph. Not fatal.
+- Session-name mismatch (VPS session not `main`) → `.[$s][$w] // empty`
+  returns empty, loop skips that iteration. Tab renders without glyph.
+- Window-name mismatch (e.g. a new `db` window appears) → same as
+  above; no error.
+- Missing jq → restore script exits silently at line 13. No effect.
+  Not reachable on VPS (jq installed).
+
+### State lifecycle
+
+- Symlink persists until next `./install` re-applies it or operator
+  removes it.
+- No auto-hook invokes `save-window-meta.sh`; the script is called
+  only by the Mac skill with explicit CLI args. Seed file stays
+  pristine on VPS. (Cross-checked with
+  `grep -rn save-window-meta tmux/` during research — only the
+  shebang + the skill's SKILL.md reference it.)
+- If a future operator installs Claude Code on the VPS and runs the
+  namer skill, `save-window-meta.sh` would write through the symlink
+  to the repo file (drift). Explicitly out of scope — revisit
+  approach C from the brainstorm if that future arrives.
+
+### Integration test scenarios
+
+1. **Dry-run preserves mutation-free guarantee on fresh HOME.** Run
+   the fresh-HOME recipe from `CLAUDE.md:158-164`; expect one
+   "Would create symlink" line for the new entry and the post-run
+   `find | wc -l` to print `0`.
+2. **VPS symlink resolves correctly post-install:**
+   ```bash
+   ssh root@openclaw-prod \
+     'readlink ~/.config/tmux/window-meta.json'
+   # expected: /root/.dotfiles/tmux/window-meta.linux.json
+   ```
+3. **Hook applies options on fresh attach:**
+   ```bash
+   ssh root@openclaw-prod '
+     tmux detach-client -a 2>/dev/null
+     tmux new-session -t main \; detach
+     for w in ops logs openclaw tui; do
+       printf "%-10s " "$w"
+       tmux show-option -wv -t "main:$w" @win_glyph 2>/dev/null
+     done
+   '
+   # expected: ⚙ ≡ 🦀 ▤ — one per line
+   ```
+4. **Darwin untouched:** run a Mac-side dry-run; confirm no diff
+   would be produced for `~/.config/tmux/window-meta.json`.
+
+## Acceptance Criteria
+
+- [ ] `tmux/window-meta.linux.json` exists with the exact schema in
+      Proposed Solution
+- [ ] `install-linux.conf.yaml` adds exactly one new line under the
+      link block at 80-88; no other edits
+- [ ] `install.conf.yaml` (Darwin) has zero diff
+- [ ] Dry-run against fresh `$HOME` produces zero mutations and
+      emits "Would create symlink" for the new entry
+- [ ] After `./install` on VPS and a fresh attach to session `main`:
+      `tmux show-option -wv -t main:ops @win_glyph` prints `⚙`,
+      `…main:logs` prints `≡`, `…main:openclaw` prints `🦀`,
+      `…main:tui` prints `▤`
+- [ ] Visual check: inner VPS tmux bar renders
+      `main 1:⚙ ops 2:≡ logs 3:🦀 openclaw 4:▤ tui` with glyph
+      color matching the palette hex
+- [ ] Mac live `~/.config/tmux/window-meta.json` unchanged before
+      and after running `./install --dry-run` on Mac
+
+## Success Metrics
+
+- One-time visual change: operator sees colored glyph tabs in VPS
+  tmux after one `./install` + reattach cycle.
+- No Mac regression: skill-driven sessions continue to write
+  freely to the Mac's live sidecar.
+- Rollback reversible in under a minute (one `git revert` +
+  `./install`).
+
+## Dependencies & Risks
+
+**Dependencies:**
+- Dotbot v1.24.1 (vendored submodule; already pinned)
+- `jq` on VPS (installed by `helpers/install_packages.sh:23`)
+- UTF-8 terminal on both endpoints (iTerm2 on Mac, SSH default UTF-8)
+
+**Risks (ordered by likelihood × impact):**
+
+1. **Persistent session won't auto-pick up** (medium likelihood, low
+   impact). If the VPS's `main` session is already attached when
+   `./install` runs, the new symlink exists but options aren't set
+   until a client reattaches. Mitigation documented: `tmux detach-client -a`
+   then attach, OR `bash ~/.config/tmux/scripts/restore-window-meta.sh`
+   once by hand.
+2. **Session-name or window-name drift** (low likelihood, low
+   impact). If the VPS session is renamed away from `main` or a
+   window is renamed, matching entries go unused and tabs fall back
+   to no-glyph rendering. Silent, no error. Update the seed file if
+   it happens.
+3. **Precedent migration trigger** (process, not operational). The
+   `.linux.json` suffix is fine for one file. Rule for future:
+   **the second host-scoped state file is the moment to migrate
+   both into `hosts/<os>/`** — not now.
+4. **Hypothetical write-through drift** (very low likelihood,
+   medium impact if it occurs). If Claude Code is later installed
+   on VPS and someone runs the namer skill there, `save-window-meta.sh`
+   writes through the symlink and mutates the committed repo file.
+   Mitigation: don't install the skill on VPS; if the need arises,
+   this is the trigger to revisit Approach C from the brainstorm.
+
+**Rollback:** `git revert <sha>` → `./install` on VPS → symlink
+removed; next reattach leaves `@win_glyph` options set from the
+previous session (they persist in the tmux server until server
+restart, which is the desired quiet rollback — nothing user-visible
+regresses until reattach forces a redraw). For a hard reset:
+`ssh root@openclaw-prod 'for w in ops logs openclaw tui; do tmux set-option -uw -t main:$w @win_glyph; tmux set-option -uw -t main:$w @win_glyph_color; done'`.
+
+## Implementation Steps (execution order)
+
+1. Write `tmux/window-meta.linux.json` with the JSON above.
+2. Edit `install-linux.conf.yaml`: add
+   `~/.config/tmux/window-meta.json: tmux/window-meta.linux.json`
+   to the existing link block (line 82 area).
+3. Validate JSON locally: `jq . tmux/window-meta.linux.json`.
+4. Dry-run against fresh HOME (Integration test 1 above). Confirm
+   zero mutations.
+5. Ask user to test before committing (per user preference).
+6. Commit. Conventional title:
+   `feat: seed VPS tmux window glyph metadata`.
+7. Push. Trigger VPS sync with dry-run first:
+   `gh workflow run sync-vps.yml --repo villavicencio/dotfiles -f host=openclaw-prod -f dry_run=true`.
+   Review Actions step summary.
+8. Re-run with `-f dry_run=false` when summary looks clean.
+9. SSH to VPS, run Integration tests 2 and 3 above.
+10. Visually verify the inner status bar after reattach.
+11. Close any related GitHub issue (per user workflow memory).
+
+## Sources & References
+
+### Origin
+
+- **Brainstorm:** `docs/brainstorms/2026-04-17-vps-tmux-glyph-treatment-brainstorm.md`
+  — carried forward: (a) Approach A over B/C (static seed vs. inline
+  hook vs. SSH-aware skill), (b) locked glyph/palette mapping, (c)
+  drift analysis clearing the symlink-target-pristine assumption,
+  (d) the brainstorm's single open question (host-level vs.
+  in-container tmux) resolved by research — host-level, runs as
+  root from `/root/.dotfiles` per
+  `docs/solutions/cross-machine/vps-dotfiles-target.md:56,181`.
+
+### Internal code references
+
+- `tmux/scripts/restore-window-meta.sh:12-26` — JSON schema, no-op
+  guards, target syntax
+- `tmux/scripts/save-window-meta.sh` — confirmed no auto-hook
+  invocation (grep over tmux/ returned only docstring references)
+- `tmux/tmux.display.conf:23,67-68` — `status-interval 1`, glyph
+  ternary in `window-status-format`
+- `tmux/tmux.general.conf:81` — `client-attached` hook wiring
+- `install-linux.conf.yaml:80-88` — the link block to extend
+- `install.conf.yaml:69-83` — Darwin block, verified unchanged
+- `claude/skills/tmux-window-namer/references/palettes.md:12-20` —
+  palette hex source of truth
+- `helpers/install_packages.sh:23` — `jq` install confirmation
+
+### Institutional learnings
+
+- `docs/solutions/cross-machine/vps-dotfiles-target.md` — VPS runs
+  tmux on host, `./install` invocation pattern, persistent-session
+  caveat (lines 265-268), dry-run verification recipe (309-312)
+- `docs/solutions/code-quality/dotbot-dry-run-requires-v1-23-or-later.md`
+  — confirms native `--dry-run` support is in v1.24.1
+
+### Conventions (CLAUDE.md)
+
+- `CLAUDE.md:119-132` — tmux-window-namer skill architecture,
+  palette discipline, JSON sidecar contract
+- `CLAUDE.md:138-164` — `--dry-run` guarantees and verification
+  recipe

--- a/install-linux.conf.yaml
+++ b/install-linux.conf.yaml
@@ -80,6 +80,12 @@
 - link:
     ~/.config/tmux/scripts/save-window-meta.sh: tmux/scripts/save-window-meta.sh
     ~/.config/tmux/scripts/restore-window-meta.sh: tmux/scripts/restore-window-meta.sh
+    # Seed glyph + palette metadata for the VPS's static window layout
+    # (main: ops/logs/openclaw/tui). The client-attached hook in
+    # tmux/tmux.general.conf applies this on next attach. Darwin
+    # install.conf.yaml intentionally does NOT symlink this path —
+    # Mac's sidecar is written live by the tmux-window-namer skill.
+    ~/.config/tmux/window-meta.json: tmux/window-meta.linux.json
     # create: true ensures Dotbot mkdir -p's the parent `~/.config/nvim/lua`
     # before symlinking. Needed for fresh-host dry-run where install_nvim.sh
     # (which otherwise clones NvChad and creates this directory) is skipped.

--- a/tmux/window-meta.linux.json
+++ b/tmux/window-meta.linux.json
@@ -1,0 +1,8 @@
+{
+  "main": {
+    "ops":      { "glyph": "⚙",  "glyph_color": "#56B6C2" },
+    "logs":     { "glyph": "≡",  "glyph_color": "#4B5263" },
+    "openclaw": { "glyph": "🦀", "glyph_color": "#D97757" },
+    "tui":      { "glyph": "▤",  "glyph_color": "#7DACD3" }
+  }
+}


### PR DESCRIPTION
## Summary

Give the VPS's inner tmux status bar the same glyph + palette treatment the Mac's outer tmux already has. Adds a static seed JSON with locked mappings for the VPS's stable window layout (`ops`/`logs`/`openclaw`/`tui`) and a Linux-only Dotbot symlink pointing `~/.config/tmux/window-meta.json` at it. The existing `restore-window-meta.sh` client-attached hook applies the data to `@win_glyph` / `@win_glyph_color` user options, which `window-status-format` in `tmux/tmux.display.conf` already renders.

**Zero new code.** Machinery was already deployed; only data was missing.

## Key decisions

- **Approach A (static seed JSON)** chosen over inline `set-hook` (imperative, two spellings of the same data) and SSH-aware skill (YAGNI for a 4-row stable table).
- **Locked mappings:** ops=⚙/ocean `#56B6C2`, logs=≡/smoke `#4B5263`, openclaw=🦀/ember `#D97757`, tui=▤/sky `#7DACD3`. Hexes from `claude/skills/tmux-window-namer/references/palettes.md`.
- **Darwin install untouched.** Mac's `~/.config/tmux/window-meta.json` is a live file written by the skill; must not become a symlink to a repo file.
- **First committed host-scoped state file.** Rule for the future: when a second host-scoped state file is needed, migrate both to `hosts/<os>/`.

Full trail: `docs/brainstorms/2026-04-17-vps-tmux-glyph-treatment-brainstorm.md`, `docs/plans/2026-04-17-feat-vps-tmux-window-glyph-seed-plan.md`.

## Testing

- [x] `jq . tmux/window-meta.linux.json` parses
- [x] Fresh-$HOME dry-run against `install-linux.conf.yaml` emits `Would create symlink ~/.config/tmux/window-meta.json -> .../tmux/window-meta.linux.json` and mutates zero files
- [ ] Post-merge: VPS sync dry-run → full run → `readlink` resolves correctly → `tmux show-option -wv -t main:<w> @win_glyph` prints the right glyph for each of the 4 windows → visual confirmation after reattach

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: GitHub Actions `sync-vps.yml` step summary (dry-run first, then full run)
  - Metrics/Dashboards: N/A
- **Validation checks**
  - `ssh root@openclaw-prod 'readlink ~/.config/tmux/window-meta.json'` — expect `/root/.dotfiles/tmux/window-meta.linux.json`
  - `ssh root@openclaw-prod 'for w in ops logs openclaw tui; do printf "%-10s " "\$w"; tmux show-option -wv -t "main:\$w" @win_glyph 2>/dev/null; done'` — expect `⚙`, `≡`, `🦀`, `▤` respectively
  - Visual: attach to VPS tmux, see `main 1:⚙ ops 2:≡ logs 3:🦀 openclaw 4:▤ tui`
- **Expected healthy behavior**
  - Exactly one new symlink at `~/.config/tmux/window-meta.json` on the VPS
  - No diff on the Mac's live sidecar after running Mac-side `./install`
- **Failure signal(s) / rollback trigger**
  - Trigger: `readlink` returns empty / wrong target, OR restore script errors in `tmux display-message -p '#{hook}'`, OR any Mac-side diff to live sidecar
  - Immediate action: `git revert <sha>`, re-run VPS sync; or manually `tmux set-option -uw -t main:<w> @win_glyph` for each window
- **Validation window & owner**
  - Window: immediate post-sync, one reattach cycle
  - Owner: @villavicencio

## Before / After

Before (VPS inner tmux): `main  1: ops  2: logs  3: openclaw  4: tui`
After (expected):        `main  1:⚙ ops  2:≡ logs  3:🦀 openclaw  4:▤ tui`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)