### PR TITLE
feat: transparent status bar background

### DIFF
--- a/tmux/tmux.display.conf
+++ b/tmux/tmux.display.conf
@@ -30,7 +30,12 @@ set -g monitor-activity on
 set -g visual-activity off
 
 # ── Status bar (One Dark theme, matched to iTerm2) ─────────────
-set -g status-style "bg=#031B21,fg=#ABB2BF"
+# bg=default lets the bar inherit the pane/terminal background, which
+# makes the theme uniform with panes (window-style below) and lets the
+# inner VPS tmux fuse into the outer Mac tmux chrome when nested.
+# The inline pills in status-left (PREFIX/COPY/SYNC/session) keep their
+# explicit backgrounds so they still pop against the transparent bar.
+set -g status-style "bg=default,fg=#ABB2BF"
 
 # Mode-aware status left:
 #   Normal  → subtle session name


### PR DESCRIPTION
## Summary

Swap `status-style bg=#031B21` for `bg=default` in `tmux/tmux.display.conf` so the status bar inherits the pane/terminal background. Makes the theme consistent with `window-style` (which already uses `bg=default`) and fuses the inner VPS tmux bar into the outer Mac tmux chrome when nested.

Pills in `status-left` (PREFIX/COPY/SYNC/session) keep their own explicit backgrounds, so they still read as filled pills against the transparent bar. Tabs and the `HH:MM | Mon DD` block on the right inherit from `status-style`, so they go transparent too.

Affects both Mac and VPS (shared config).

## Testing

- [x] Visual check on local outer tmux after `tmux source-file ~/.config/tmux/tmux.conf` — approved
- [ ] Post-merge: VPS sync → attach/reload on VPS → confirm inner bar fuses with outer chrome when nested

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: GitHub Actions `sync-vps.yml` step summary
- **Validation checks**
  - `ssh root@openclaw-prod 'tmux show-option -gv status-style'` — expect `bg=default,fg=#ABB2BF`
  - Visual: attach to VPS tmux, confirm status bar is transparent and fuses with outer tmux when nested
- **Expected healthy behavior**
  - `status-style` read from VPS reports `bg=default`
  - Session pill still visible with its own pill background
- **Failure signal(s) / rollback trigger**
  - Trigger: tmux refuses to parse the config (error on source-file), OR status bar becomes illegible
  - Action: `git revert <sha>`, re-run VPS sync; or manual `tmux set -g status-style "bg=#031B21,fg=#ABB2BF"` for quick local revert
- **Validation window & owner**
  - Window: one reattach cycle on VPS
  - Owner: @villavicencio
- **If no operational impact**
  - N/A — this is a cosmetic change with no behavioral impact

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)