### PR TITLE
feat: dim window glyph on inactive tabs to match title color

### DIFF
--- a/tmux/tmux.display.conf
+++ b/tmux/tmux.display.conf
@@ -64,12 +64,16 @@ set -g status-right-length 40
 # Window tab rendering priority (left glyph → title text):
 #   1. @claude_status=waiting -> yellow warning glyph (highest priority)
 #   2. @claude_status=<frame> -> orange spinner frame (Claude working)
-#   3. @win_glyph set         -> custom glyph in @win_glyph_color
+#   3. @win_glyph set         -> custom glyph; colored on active tab, dim on inactive
 #   4. otherwise              -> no prefix
-# Title text always uses default colors (#4B5263 inactive, #7DACD3 active)
-# so inactive tabs naturally dim. Only the glyph carries palette color.
-# Custom glyph + color are set by the tmux-window-namer Claude skill.
-setw -g window-status-format " #[fg=#4B5263#,nobold]#I:#{?#{==:#{@claude_status},waiting},#[fg=#E5C07B#,bold]  #[fg=#4B5263#,nobold],#{?#{!=:#{@claude_status},},#[fg=#D97757#,bold] #{@claude_status} #[fg=#4B5263#,nobold],#{?#{!=:#{@win_glyph},},#[fg=#{?#{!=:#{@win_glyph_color},},#{@win_glyph_color},#4B5263}#,bold] #{@win_glyph} #[fg=#4B5263#,nobold], }}}#W "
+# Active tabs render @win_glyph in @win_glyph_color (the palette pop that
+# draws the eye to the focused window). Inactive tabs render @win_glyph in
+# the same dim #4B5263,nobold as the title — so the whole inactive tab
+# reads as a uniform muted unit, and only the active tab carries palette
+# color. The claude_status indicators (waiting=yellow, spinner=orange)
+# keep their semantic colors regardless of focus — they're attention
+# signals, the whole point is to draw the eye to an inactive tab.
+setw -g window-status-format " #[fg=#4B5263#,nobold]#I:#{?#{==:#{@claude_status},waiting},#[fg=#E5C07B#,bold]  #[fg=#4B5263#,nobold],#{?#{!=:#{@claude_status},},#[fg=#D97757#,bold] #{@claude_status} #[fg=#4B5263#,nobold],#{?#{!=:#{@win_glyph},}, #{@win_glyph} , }}}#W "
 setw -g window-status-current-format " #[fg=#7DACD3#,bold]#I:#{?#{==:#{@claude_status},waiting},#[fg=#E5C07B#,bold]  #[fg=#7DACD3#,bold],#{?#{!=:#{@claude_status},},#[fg=#D97757#,bold] #{@claude_status} #[fg=#7DACD3#,bold],#{?#{!=:#{@win_glyph},},#[fg=#{?#{!=:#{@win_glyph_color},},#{@win_glyph_color},#7DACD3}#,bold] #{@win_glyph} #[fg=#7DACD3#,bold], }}}#W "
 setw -g window-status-activity-style "fg=#E5C07B"
 


### PR DESCRIPTION
## Summary

Inactive window tabs now render `@win_glyph` in the same dim `#4B5263,nobold` as the title text, instead of carrying palette color. Active tabs still render the glyph in `@win_glyph_color` — so focus is the single thing in the tab bar that carries palette color, and inactive tabs read as uniform muted units.

Net-simplification in `tmux/tmux.display.conf`: the inactive branch loses its `#[fg=palette,bold]` directive and the redundant reset after the glyph, inheriting dim+nobold from the opening of the format. Active format (`window-status-current-format`) is unchanged. Claude-status indicators (waiting=yellow, spinner=orange) keep their semantic colors on inactive tabs — they're attention signals meant to draw the eye.

## Testing

- [x] Visual check on local Mac tmux after `tmux source-file ~/.config/tmux/tmux.conf` — inactive tab glyphs now match text color, active tab glyph still pops with palette
- [ ] Post-merge: VPS sync → reload on VPS → confirm inner bar's inactive tabs render the same way

## Post-Deploy Monitoring & Validation

- **What to monitor/search**
  - Logs: GitHub Actions `sync-vps.yml` step summary
- **Validation checks**
  - `ssh root@openclaw-prod 'tmux source-file ~/.config/tmux/tmux.conf && tmux show-option -wv window-status-format'` — confirm the simplified glyph ternary is present
  - Visual: inner VPS tmux bar after reload — inactive tabs uniform dim, active tab keeps colored glyph
- **Expected healthy behavior**
  - Inactive tab shows: index + `:` + dim glyph + space + dim title
  - Active tab unchanged from before
- **Failure signal / rollback trigger**
  - Trigger: tmux refuses to parse the format (error on `source-file`), OR inactive tab glyph becomes invisible/broken
  - Action: `git revert <sha>`, re-run VPS sync
- **Validation window & owner**
  - Window: one reload cycle on VPS
  - Owner: @villavicencio

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)