### PR TITLE
feat: rename VPS window 4 tui → OpenClaw

### DIFF
--- a/tmux/window-meta.linux.json
+++ b/tmux/window-meta.linux.json
@@ -3,6 +3,6 @@
     "ops":      { "glyph": "⚙",  "glyph_color": "#56B6C2" },
     "logs":     { "glyph": "≡",  "glyph_color": "#4B5263" },
     "openclaw": { "glyph": "🦀", "glyph_color": "#D97757" },
-    "tui":      { "glyph": "▤",  "glyph_color": "#7DACD3" }
+    "OpenClaw": { "glyph": "", "glyph_color": "#FF4500" }
   }
 }


### PR DESCRIPTION
## Summary

Replace the `tui` seed entry for VPS window 4 with `OpenClaw` — new glyph `\uee0d`, new color `#FF4500` (OrangeRed). Reflects what the window is actually used for on the VPS (operator's OpenClaw-stack view). Window 3 stays named `openclaw` (lowercase) — tmux treats the names as distinct.

## Deployment plan (post-merge)

Because the VPS's `main` session is persistent and the `client-attached` hook won't re-fire on a rename, two live commands after sync:

```bash
ssh root@openclaw-prod '
  tmux rename-window -t main:4 OpenClaw
  bash ~/.config/tmux/scripts/restore-window-meta.sh
'
```

Rename first (so the seed lookup finds the new `OpenClaw` key), then invoke the restore script to apply `@win_glyph` + `@win_glyph_color`.

## Post-Deploy Monitoring & Validation

- **Validation checks**
  - `ssh root@openclaw-prod 'tmux list-windows -t main -F "#{window_index}: #{window_name}"'` — expect `4: OpenClaw`
  - `ssh root@openclaw-prod 'tmux show-option -wv -t main:4 @win_glyph'` — expect the new glyph
  - `ssh root@openclaw-prod 'tmux show-option -wv -t main:4 @win_glyph_color'` — expect `#FF4500`
- **Failure signal / rollback** — `git revert <sha>` restores the `tui` seed, then `tmux rename-window -t main:4 tui` + restore script on VPS

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)