### PR TITLE
feat: blue session-name pill (#2563EB / white) for focus clarity

### DIFF
--- a/tmux/tmux.display.conf
+++ b/tmux/tmux.display.conf
@@ -46,7 +46,7 @@ set -g status-left "\
 #{?client_prefix,#[bg=#7DACD3#,fg=#031B21#,bold] PREFIX ,\
 #{?pane_in_mode,#[bg=#E5C07B#,fg=#031B21#,bold] COPY ,\
 #{?pane_synchronized,#[bg=#C98389#,fg=#031B21#,bold] SYNC ,\
-#[bg=#21252B#,fg=#ABB2BF#,bold] #S }}}\
+#[bg=#2563EB#,fg=#FFFFFF#,bold] #S }}}\
 #[bg=default] "
 
 # Continuum's save script is inlined here instead of relying on TPM to inject


### PR DESCRIPTION
## Summary

Replace the muted `#21252B` background on the status-left session-name pill with blue `#2563EB` and text color with white `#FFFFFF`. Gives the session identity a crisp visual pill on the left of both outer (Mac) and inner (VPS) status bars.

Affects both hosts via the shared `tmux/tmux.display.conf`. Validated live as a runtime override first; committing after operator approval.

## On the "only when active" ask

Evaluated and rejected: tmux has no reliable cross-server primitive to tell the inner tmux whether it has user keystroke focus in a nested setup. `focus-events` tracks terminal-level focus (iTerm2 window in/out), not which nested tmux is receiving keys. Faking it with timing heuristics or SSH side-channels would be fragile. The outer tmux's active-pane styling already signals which pane has focus, which resolves the underlying question in practice.

Always-blue is the practical answer; PREFIX / COPY / SYNC pills retain their own backgrounds and continue to override.

## Testing

- [x] Runtime override on Mac — approved visually
- [x] Runtime override on VPS — rendered identically
- [x] Local `tmux source-file ~/.config/tmux/tmux.conf` after edit — file-driven version matches
- [ ] Post-merge: VPS sync → reload → confirm inner bar renders `vps` with the same blue pill
- [ ] Work Mac: next `./install` on FedEx Mac picks up the change (carry-forward from earlier sync test, no action needed here)

## Post-Deploy Monitoring & Validation

- **Validation checks**
  - `ssh root@openclaw-prod 'tmux source-file ~/.config/tmux/tmux.conf && tmux show-option -gv status-left | grep -o "bg=#2563EB"'` — expect `bg=#2563EB`
  - Visual: VPS inner bar shows `vps` in white on blue
- **Failure signal / rollback** — `git revert <sha>` + re-run VPS sync; or runtime `tmux set -g status-left '...old...'` for immediate Mac-side revert
- **Validation window & owner** — one reload cycle on each host, @villavicencio

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)