### PR TITLE
feat: prioritize user-scope bins over Homebrew in PATH

### DIFF
--- a/zsh/zshenv
+++ b/zsh/zshenv
@@ -61,8 +61,15 @@ CARGO_BIN="$HOME/.cargo/bin"
 LOCAL_BIN="$HOME/bin"
 LOCAL_SHARE_BIN="$HOME/.local/bin"
 
-# Add paths in order of priority
-export PATH="$BREW_CURL:$BREW_BIN:$BREW_SBIN:$MYSQL_BIN:$RVM_BIN:$YARN_BIN:$CARGO_BIN:$LOCAL_BIN:$LOCAL_SHARE_BIN:${HOME}/perl5/bin${PATH:+:${PATH}}"
+# Add paths in order of priority.
+# `$LOCAL_BIN` (~/bin) and `$LOCAL_SHARE_BIN` (~/.local/bin) come BEFORE
+# Homebrew so user-scope installers (e.g., Anthropic's `claude` native
+# installer which symlinks into ~/.local/bin) take precedence over the
+# same tool installed via Homebrew cask. Fixes the situation where the
+# Homebrew cask lags Anthropic's in-app auto-updater and leaves a stale
+# `/opt/homebrew/bin/claude` shadowing the newer user-scope one. Standard
+# Unix convention: user-scope beats system-scope.
+export PATH="$LOCAL_BIN:$LOCAL_SHARE_BIN:$BREW_CURL:$BREW_BIN:$BREW_SBIN:$MYSQL_BIN:$RVM_BIN:$YARN_BIN:$CARGO_BIN:${HOME}/perl5/bin${PATH:+:${PATH}}"
 
 # Auto-deduplicate PATH entries
 [[ -n "$ZSH_VERSION" ]] && typeset -U PATH


### PR DESCRIPTION
## Summary

Move `$LOCAL_BIN` (~/bin) and `$LOCAL_SHARE_BIN` (~/.local/bin) ahead of Homebrew in `zsh/zshenv`'s PATH construction. Standard Unix convention: user-scope beats system-scope.

**Motivating case:** Anthropic's `claude` native installer symlinks `~/.local/bin/claude → ~/.local/share/claude/versions/<latest>` and is actively self-updated by the in-app updater. The Homebrew cask lags — today: cask is at 2.1.98 (definition last updated 2026-04-14), actual latest is 2.1.114. Before this change, `claude` resolved to the stale Homebrew binary. After: `claude` resolves to the auto-updated user-scope symlink.

Verified in a fresh subshell: `command -v claude` returns `~/.local/bin/claude`, md5 matches 2.1.114 (`a98e42936d677697d779078b9abdb1fa`).

## Real-world effect

The stale Homebrew 2.1.98 `/model` picker didn't know about Opus 4.7, defaulted to 4.6, and actively pushed users toward "downgrading" with a mislabeled "newer version available" hint. That whole class of confusion goes away with the fix in place.

## Testing

- [x] Fresh zsh subshell: `command -v claude` → `/Users/dvillavicencio/.local/bin/claude`
- [x] md5 verification: matches 2.1.114 binary
- [x] Work Mac (no native install yet): PATH still includes both locations, so falls through to Homebrew if `~/.local/bin/claude` doesn't exist — no regression
- [ ] Post-merge on personal Mac: source `~/.config/zsh/.zshenv` in a new shell and confirm `/model` now shows Opus 4.7 as default

## Post-Deploy Monitoring & Validation

- **What to monitor/search:** N/A — pure shell config change
- **Validation:** `command -v claude` in a fresh zsh shell should point at `~/.local/bin/claude` (if native installer has run) OR fall through to `/opt/homebrew/bin/claude` (on machines without native install)
- **Failure signal:** any other tool in `~/.local/bin` that unexpectedly shadows a Homebrew tool. Mitigation: move the specific file out or re-order that one tool.
- **Rollback:** `git revert <sha>` + `source ~/.config/zsh/.zshenv`

## Out of scope (follow-up)

Consider removing `claude-code` from `brew/Brewfile` since the native installer is the canonical path. Would need a `helpers/install_claude_code.sh` that runs `curl -fsSL https://claude.ai/install.sh | bash` on fresh machines. Worth a separate PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)