### PR TITLE
fix: prevent brew shellenv's path_helper from clobbering PATH priority

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -20,7 +20,15 @@ bindkey -M menuselect 'j' vi-down-line-or-history
 # Oh My Zsh settings
 export USER="$USER" # Ensure USER is exported for completion system
 
-[[ -x "$BREW_PREFIX/bin/brew" ]] && eval "$("$BREW_PREFIX/bin/brew" shellenv)"
+# `brew shellenv` sets HOMEBREW_PREFIX/CELLAR/REPOSITORY + FPATH + MANPATH/
+# INFOPATH, all of which we want. BUT it also emits an `eval path_helper -s`
+# line that, via macOS's path_helper, rebuilds PATH with /opt/homebrew/bin
+# prepended — undoing the user-scope-first ordering established in zshenv.
+# Filter out the path_helper eval (the real PATH clobberer here) and keep
+# everything else.
+if [[ -x "$BREW_PREFIX/bin/brew" ]]; then
+  eval "$("$BREW_PREFIX/bin/brew" shellenv | grep -vE '^eval .*path_helper')"
+fi
 
 # NVM configuration
 


### PR DESCRIPTION
## Summary

Follow-up to PR #36. The previous PR reordered `zshenv`'s PATH to put user-scope bins first, but interactive shells still resolved `claude` to the stale Homebrew cask at 2.1.98. Tracing the PATH across shell init stages revealed the real culprit: `brew shellenv` in `zshrc:23` runs an `eval path_helper -s` line that rebuilds PATH from `/etc/paths{,.d}`, prepending `/opt/homebrew/bin` to the front — undoing the careful zshenv ordering on every interactive shell startup.

The first fix attempt filtered `^export PATH=`, but the PATH clobbering happens via the nested `path_helper` eval, not a direct `export PATH=` statement. This PR filters that line instead.

## Verification

```
$ zsh -i -c 'command -v claude; md5 -q $(command -v claude)'
/Users/dvillavicencio/.local/bin/claude
a98e42936d677697d779078b9abdb1fa   ← matches 2.1.114 (was resolving to 2.1.98)

$ zsh -i -c 'echo $PATH | tr : "\n" | head -6'
/Users/dvillavicencio/.antigravity/antigravity/bin
/Users/dvillavicencio/.pyenv/bin
/Users/dvillavicencio/bin              ← user-scope, position 3 (was gone)
/Users/dvillavicencio/.local/bin       ← user-scope, position 4 (was absent)
/opt/homebrew/opt/curl/bin
/opt/homebrew/bin                      ← Homebrew, position 6 (was position 2)
```

HOMEBREW_PREFIX, FPATH, MANPATH, INFOPATH all still set — only the path_helper re-ordering is suppressed.

## Root-cause for future reference

On macOS, `brew shellenv` emits:
```
eval "$(/usr/bin/env PATH_HELPER_ROOT='/opt/homebrew' /usr/libexec/path_helper -s)"
```

`path_helper -s` reads `/etc/paths` + `/etc/paths.d/*` and outputs a full `PATH="..."; export PATH;` statement with `/opt/homebrew/bin` at the front (because of `PATH_HELPER_ROOT`). That output is evaluated inside the outer eval, so a regex on `brew shellenv`'s stdout that only matches `^export PATH=` will miss it entirely. The path clobber is nested one eval deep.

## Testing

- [x] `zsh -i -c` PATH trace: Homebrew now at position 6
- [x] `claude` resolves to `~/.local/bin/claude` in interactive shells
- [x] md5 match: 2.1.114
- [x] HOMEBREW_PREFIX still set
- [ ] Post-merge: open new tmux pane, verify `claude` opens v2.1.114 banner with Opus 4.7 in `/model`

## Post-Deploy Monitoring & Validation

- **Validation:** `command -v claude` in a fresh interactive shell should resolve to `~/.local/bin/claude` if the native installer symlink exists
- **Failure signal:** if anyone complains that a Homebrew-installed tool stopped working after this change, it would mean that tool has a user-scope bin that shadows. Rollback: revert this PR.
- **No VPS impact** — shell config, Mac-only.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)