### PR TITLE
fix(tmux-attention): add asking state + close spinner-cleanup race

### DIFF
--- a/claude/hooks/tmux-attention.sh
+++ b/claude/hooks/tmux-attention.sh
@@ -1,16 +1,21 @@
 #!/usr/bin/env bash
 # Drives a per-window tmux marker so the tab in the status bar reflects
-# what Claude Code is doing inside it. Three states:
+# what Claude Code is doing inside it. Four states:
 #
-#   waiting  -> set @claude_status=waiting (yellow warning glyph)
+#   waiting  -> set @claude_status=waiting (yellow warning glyph) for
+#               generic permission requests
+#   asking   -> set @claude_status=asking (yellow question-mark glyph)
+#               for AskUserQuestion tool calls; disambiguated from
+#               waiting by reading tool_name from the hook's stdin JSON
 #   spinner  -> background loop cycling through frames, written to
 #               @claude_status (orange spinner)
 #   clear    -> kill any spinner, unset @claude_status (no icon)
 #
 # Wired up via claude/settings.json hooks:
-#   UserPromptSubmit, PreToolUse              -> spinner
-#   Notification, PermissionRequest           -> waiting
-#   Stop                                      -> clear
+#   UserPromptSubmit, PreToolUse, PostToolUse -> spinner
+#   PermissionRequest                         -> waiting (may switch to
+#                                                asking based on stdin)
+#   SessionStart, Stop                        -> clear
 #
 # For emoji-in-name windows (e.g., "🦞 OpenClaw"), the leading emoji is
 # temporarily stripped so the spinner/waiting glyph replaces its visual
@@ -96,9 +101,23 @@ restore_original_name() {
 
 case "$action" in
   waiting)
+    # Peek hook-event JSON to disambiguate AskUserQuestion (yellow ?)
+    # from generic permission requests (yellow warning). Time-bounded
+    # so manual invocations without stdin don't hang.
+    event_json=$(timeout 0.3 cat 2>/dev/null || true)
+    tool_name=$(printf '%s' "$event_json" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get('tool_name', ''), end='')
+except Exception:
+    pass
+" 2>/dev/null)
+    state="waiting"
+    [ "$tool_name" = "AskUserQuestion" ] && state="asking"
     stop_spinner
     strip_leading_emoji
-    set_status "waiting"
+    set_status "$state"
     ;;
 
   spinner)
@@ -128,7 +147,14 @@ case "$action" in
         i=$((i + 1))
         sleep 0.15
       done
-      # Cleanup: restore original name and clear status.
+      # If sentinel is gone, another action is already managing state —
+      # exit without touching anything or we race the caller that just
+      # set waiting/asking (blank-icon bug).
+      if [ ! -f "$sentinel" ]; then
+        exit 0
+      fi
+      # Parent died or max-iter cap hit — we own cleanup.
+      rm -f "$sentinel"
       orig=$(tmux show-options -wv -t "$pane" @win_original_name 2>/dev/null) || true
       if [ -n "$orig" ]; then
         tmux rename-window -t "$pane" "$orig" 2>/dev/null

--- a/tmux/tmux.display.conf
+++ b/tmux/tmux.display.conf
@@ -62,19 +62,20 @@ set -g status-right-length 40
 
 # Window tabs
 # Window tab rendering priority (left glyph → title text):
-#   1. @claude_status=waiting -> yellow warning glyph (highest priority)
-#   2. @claude_status=<frame> -> orange spinner frame (Claude working)
-#   3. @win_glyph set         -> custom glyph; colored on active tab, dim on inactive
-#   4. otherwise              -> no prefix
+#   1. @claude_status=asking  -> bright yellow question-mark (AskUserQuestion)
+#   2. @claude_status=waiting -> amber warning glyph (generic permission)
+#   3. @claude_status=<frame> -> orange spinner frame (Claude working)
+#   4. @win_glyph set         -> custom glyph; colored on active tab, dim on inactive
+#   5. otherwise              -> no prefix
 # Active tabs render @win_glyph in @win_glyph_color (the palette pop that
 # draws the eye to the focused window). Inactive tabs render @win_glyph in
 # the same dim #4B5263,nobold as the title — so the whole inactive tab
 # reads as a uniform muted unit, and only the active tab carries palette
-# color. The claude_status indicators (waiting=yellow, spinner=orange)
-# keep their semantic colors regardless of focus — they're attention
-# signals, the whole point is to draw the eye to an inactive tab.
-setw -g window-status-format " #[fg=#4B5263#,nobold]#I:#{?#{==:#{@claude_status},waiting},#[fg=#E5C07B#,bold]  #[fg=#4B5263#,nobold],#{?#{!=:#{@claude_status},},#[fg=#D97757#,bold] #{@claude_status} #[fg=#4B5263#,nobold],#{?#{!=:#{@win_glyph},}, #{@win_glyph} , }}}#W "
-setw -g window-status-current-format " #[fg=#7DACD3#,bold]#I:#{?#{==:#{@claude_status},waiting},#[fg=#E5C07B#,bold]  #[fg=#7DACD3#,bold],#{?#{!=:#{@claude_status},},#[fg=#D97757#,bold] #{@claude_status} #[fg=#7DACD3#,bold],#{?#{!=:#{@win_glyph},},#[fg=#{?#{!=:#{@win_glyph_color},},#{@win_glyph_color},#7DACD3}#,bold] #{@win_glyph} #[fg=#7DACD3#,bold], }}}#W "
+# color. The claude_status indicators (asking=bright-yellow, waiting=amber,
+# spinner=orange) keep their semantic colors regardless of focus — they're
+# attention signals, the whole point is to draw the eye to an inactive tab.
+setw -g window-status-format " #[fg=#4B5263#,nobold]#I:#{?#{==:#{@claude_status},asking},#[fg=#F5C300#,bold]  #[fg=#4B5263#,nobold],#{?#{==:#{@claude_status},waiting},#[fg=#E5C07B#,bold]  #[fg=#4B5263#,nobold],#{?#{!=:#{@claude_status},},#[fg=#D97757#,bold] #{@claude_status} #[fg=#4B5263#,nobold],#{?#{!=:#{@win_glyph},}, #{@win_glyph} , }}}}#W "
+setw -g window-status-current-format " #[fg=#7DACD3#,bold]#I:#{?#{==:#{@claude_status},asking},#[fg=#F5C300#,bold]  #[fg=#7DACD3#,bold],#{?#{==:#{@claude_status},waiting},#[fg=#E5C07B#,bold]  #[fg=#7DACD3#,bold],#{?#{!=:#{@claude_status},},#[fg=#D97757#,bold] #{@claude_status} #[fg=#7DACD3#,bold],#{?#{!=:#{@win_glyph},},#[fg=#{?#{!=:#{@win_glyph_color},},#{@win_glyph_color},#7DACD3}#,bold] #{@win_glyph} #[fg=#7DACD3#,bold], }}}}#W "
 setw -g window-status-activity-style "fg=#E5C07B"
 
 # Pane borders — same color, nearly invisible


### PR DESCRIPTION
## Summary

Two intertwined bugs, surfaced by `AskUserQuestion`'s long-hold UI:

### Race condition (blank-tab bug)

The spinner background loop unconditionally unset `@claude_status` on exit. When `waiting` fired:

1. Main thread `stop_spinner` → removes sentinel + `pkill`
2. Main thread `set_status "waiting"`
3. Background loop, seeing the sentinel gone, exits `while` naturally and runs its cleanup block → **`tmux set-option -u @claude_status`** — stomps the value the main thread just set

Result: a blank tab for the duration of any permission request. Bash prompts resolve in under a second so the flash was invisible. `AskUserQuestion` holds the UI open for tens of seconds and makes the race visible the whole time.

**Fix:** the background loop's cleanup now only runs when it exited for *parent-death* or *max-iter* (the leak-protection paths where it genuinely owns state). If the sentinel was removed, another action is already managing `@claude_status` — exit without touching anything.

### New `asking` state

Empirically verified (via a throwaway stdin-capture in the hook) that `AskUserQuestion` fires `PermissionRequest` with `tool_name=AskUserQuestion`. The `waiting` case now peeks hook-event JSON via a timeout-bounded `cat` + `python3 json.load`, routing `AskUserQuestion` to a distinct `asking` state.

- Hook: new state-branching logic in the `waiting` case
- Tmux: new `asking` ternary branch ahead of `waiting`, rendering `U+F128` (circled question-mark) in `#F5C300`
- Glyph injection: literal `\uf128` inserted via `python3` heredoc to bypass Claude Code's known Write/Edit PUA-stripping (see `docs/solutions/code-quality/claude-code-bash-tool-strips-pua-glyphs.md`)

Verified live in this session via a real `AskUserQuestion` — yellow `?` renders correctly.

## Stale-comment cleanup

The file header mentioned a `Notification` hook that was never wired in `settings.json`. Updated the comment block to reflect actual state (4 states, correct hook mapping).

## Test plan

- [x] `bash -n claude/hooks/tmux-attention.sh` — syntax OK
- [x] `tmux source-file ~/.config/tmux/tmux.conf` — no reload errors
- [x] Hot-tested: `AskUserQuestion` during this PR renders the new yellow `?` glyph
- [ ] Multi-day soak: confirm no blank-tab regression on ordinary Bash permission prompts
- [ ] Personal Mac + VPS: confirm renders consistently; PUA glyph bytes survive Dotbot symlink + tmux config reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)