### PR TITLE
chore: enable Vercel plugin for Claude Code

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -79,7 +79,8 @@
   },
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
-    "compound-engineering@compound-engineering-plugin": true
+    "compound-engineering@compound-engineering-plugin": true,
+    "vercel@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "claude-code-plugins": {
@@ -92,6 +93,12 @@
       "source": {
         "source": "github",
         "repo": "EveryInc/compound-engineering-plugin"
+      }
+    },
+    "claude-plugins-official": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-plugins-official"
       }
     }
   },


### PR DESCRIPTION
## Summary

Enables `vercel@claude-plugins-official` in the global Claude Code user settings (symlinked to `~/.claude/settings.json` via Dotbot, so applies machine-wide across all projects).

Primary motivator: the **Wedding Site** project is deployed on Vercel and benefits from the plugin's deploy/preview tooling. Dotfiles work doesn't use it directly, but since `claude/settings.json` is the global-user-level config, enabling here makes it available everywhere.

Also declares the `claude-plugins-official` marketplace explicitly in `extraKnownMarketplaces`, matching what Claude Code's auto-drift did when the plugin was first toggled. The existing `frontend-design@claude-plugins-official` plugin worked without the explicit declaration (implicit resolution), but being explicit is more robust.

## Test plan

- [x] `python3 -c "import json; json.load(open('claude/settings.json'))"` — JSON valid
- [ ] Claude Code session picks up the plugin after a /reload or next startup
- [ ] No-op in dotfiles sessions (plugin sits inert unless invoked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)