### PR TITLE
docs(compound): Tailscale grants vs ssh block for raw OpenSSH

### DIFF
--- a/docs/solutions/cross-machine/tailscale-grants-vs-ssh-block-raw-ssh-2026-04-20.md
+++ b/docs/solutions/cross-machine/tailscale-grants-vs-ssh-block-raw-ssh-2026-04-20.md
@@ -1,0 +1,305 @@
+---
+title: "Tailscale ACL: raw OpenSSH over tailnet needs a `grants` entry, not just an `ssh` rule"
+date: 2026-04-20
+category: cross-machine
+module: sync-vps workflow, Tailscale ACL policy
+problem_type: workflow_issue
+component: tooling
+severity: high
+applies_when:
+  - "Tailscale ACL is in grants mode (the newer schema — all new tailnets default to this)"
+  - "A tagged source needs to reach another node via anything other than `tailscale ssh`"
+  - "Adding CI/CD access (GitHub Actions, GitLab runners, Buildkite) to production nodes"
+  - "Restructuring an existing ACL and the diff touches `grants`, `ssh`, or `tests`"
+tags:
+  - tailscale
+  - acl
+  - grants
+  - github-actions
+  - ssh
+  - vps
+  - sync-vps
+  - magicdns
+related_issues:
+  - "GH issue #42 — sync-vps workflow: tag:gh-actions cannot see tag:prod in tailnet peer list (filed + closed 2026-04-20)"
+  - "docs/solutions/cross-machine/tailscale-tag-acl-ssh-failure-modes.md (companion — different ACL failure modes in the same family)"
+  - "docs/solutions/cross-machine/vps-dotfiles-target.md (operational runbook — its ACL snippet teaches an incomplete pattern, see Refresh Notes)"
+verification_run: "https://github.com/villavicencio/dotfiles/actions/runs/24694912948"
+status: Resolved
+---
+
+# Tailscale ACL: raw OpenSSH over tailnet needs a `grants` entry, not just an `ssh` rule
+
+## Context
+
+Tailscale's grants-mode ACL has two authorization surfaces that look similar
+but govern different things. A workflow running on a `tag:gh-actions` GitHub
+runner needs to OpenSSH into `tag:prod` on port 22 (raw sshd, for
+`rsync`/`scp`-style deploys). The initial ACL was:
+
+```json
+"grants": [
+    {"src": ["autogroup:admin"], "dst": ["*"], "ip": ["*"]}
+],
+"ssh": [
+    {"action": "accept", "src": ["tag:gh-actions"], "dst": ["tag:prod"], "users": ["root"]}
+]
+```
+
+— no corresponding entry in `grants` for `tag:gh-actions → tag:prod`. The
+`sync-vps.yml` workflow failed intermittently at the `Join tailnet` step with
+what looked like DNS / MagicDNS flakiness:
+
+```
+error looking up IP of "openclaw-prod": lookup openclaw-prod on 127.0.0.53:53: server misbehaving
+```
+
+Three successive fixes on `fix/sync-vps-dns-race` (SSH-retry loop with
+`ConnectTimeout=5`, `tailscale ip -4` hostname pinning to `/etc/hosts`, and
+finally a full diagnostic dump) made the real cause visible. The handoff had
+mis-labeled this as "tailnet ping flakiness" and recommended pinning the
+action version or adding retries — both theory-based fixes that would never
+have worked.
+
+Session history shows this workflow also failed twice in the 2026-04-17 →
+2026-04-18 window and was both times dismissed as "ephemeral OAuth tailscale
+join flakiness on the runner" — direct SSH from the Mac still worked (the
+Mac sits in `autogroup:admin` with the wildcard grant), so the VPS appeared
+healthy and the runner failure was misread as transient noise. The carry-
+forward list from both prior handoffs had "investigate sync-vps tailnet
+ping flakiness" at the top. _(session history)_
+
+The diagnostic commit that finally cracked it printed `tailscale status`
+from inside the runner. Ground truth:
+
+```
+100.96.253.112  github-runnervmeorf1   (self)
+100.94.39.11    iphone181
+100.66.203.8    mac-q4hmv2qrcx
+100.94.140.44   zs-macbook-pro
+```
+
+`openclaw-prod` was **absent from the runner's tailnet peer list**. From
+the user's laptop the same moment, `tailscale status` listed
+`100.75.213.64 openclaw-prod` healthy and tagged `tag:prod`. The VPS was
+up, tagged correctly, reachable from every other node — it was just
+invisible to `tag:gh-actions`.
+
+## Guidance
+
+Two rules for any Tailscale ACL managing machine-to-machine access in
+grants mode:
+
+**1. If a source needs raw IP connectivity to a destination (port 22
+OpenSSH, HTTP, database, anything that isn't `tailscale ssh`), it MUST
+appear in `grants`.**
+
+The `ssh` block only authorizes Tailscale SSH — a separate auth layer
+invoked via `tailscale ssh <host>`. It does **not** grant raw IP
+reachability and does **not** cause the destination to appear in the
+source's tailnet peer list. Missing a grant is strictly stronger than
+"access denied" — the node doesn't appear in the peer list at all, which
+surfaces as DNS lookup failures for the tailnet short name.
+
+**2. Add a regression test every time you add a grant.**
+
+Tailscale validates `tests[]` at save-time and refuses to save an ACL where
+a test fails. A one-line test is how you prevent a future ACL refactor
+from collaterally removing the grant — which is exactly what happened on
+2026-04-17, during an unrelated `tests[].src requires concrete user, not
+autogroup` restructure.
+
+Concrete fix for the sync-vps case:
+
+```json
+"grants": [
+    {"src": ["autogroup:admin"], "dst": ["*"], "ip": ["*"]},
+    // ↓ add this:
+    {"src": ["tag:gh-actions"], "dst": ["tag:prod"], "ip": ["tcp:22"]}
+],
+"ssh": [
+    {"action": "accept", "src": ["tag:gh-actions"], "dst": ["tag:prod"], "users": ["root"]}
+],
+"tests": [
+    {"src": "villavicencio.david@gmail.com", "accept": ["tag:prod:22"]},
+    // ↓ add this regression guard:
+    {"src": "tag:gh-actions", "accept": ["tag:prod:22"]}
+]
+```
+
+Scope the grant minimally: `"ip": ["tcp:22"]`, not `"ip": ["*"]`. The
+runner only needs sshd; no reason to widen the blast radius.
+
+## Why This Matters
+
+The silent failure mode is what makes this high-value to document. If a
+missing grant produced `connection refused` or `permission denied`, nobody
+would misdiagnose it — the error message would point at authorization.
+Instead, a missing grant strips the destination from the source's peer
+list *before any connection attempt happens*. The MagicDNS resolver
+(100.100.100.100) has no record to return for `openclaw-prod`, and
+`getent hosts openclaw-prod` fails.
+
+From the runner's perspective, this is **indistinguishable from a real DNS
+problem.** Every diagnostic you'd run against a DNS race — retry loops,
+hostname pinning, resolver debug — appears to confirm the DNS hypothesis
+while being orthogonal to the actual fix. The sync-vps team (me) burned
+three commits on `fix/sync-vps-dns-race` before adding an observation-only
+diagnostic step that printed `tailscale status` on the runner itself and
+revealed the peer-list gap.
+
+The silent failure also contaminates prior handoffs. The 04-17 and 04-18
+failures were dismissed as "OAuth tailscale join flakiness" because direct
+SSH from the Mac still worked — but `autogroup:admin` had the wildcard
+grant all along, so the Mac was never a valid control. The asymmetric
+observability between admin-user and tag:gh-actions masked the bug's
+nature for three days. _(session history)_
+
+### Meta-pattern
+
+When a handoff labels a bug with a timing/race/flakiness hypothesis and
+two theory-driven fixes fail in the same ~30ms window, **stop theorizing
+and add an observation step** before writing fix #3. Print runtime state —
+`tailscale status`, peer list, resolver config, whatever is closest to
+ground truth. The cost is one CI run; the payoff is ground truth instead
+of another collision with the real cause.
+
+This reinforces two earlier shared learnings:
+
+- **2026-04-14 reproduce-then-attribute** — when compounding a fix,
+  reproduce the failure before attributing a root cause.
+- **2026-04-16 inspect runtime truth** — for claims of the form "config
+  knob X causes runtime behavior Y", identify a source of runtime truth
+  and inspect it before documenting causation.
+
+Observation-first is cheaper than a fourth wrong fix, every time.
+
+## When to Apply
+
+Apply the **grants-not-just-ssh rule** whenever:
+
+- A Tailscale ACL uses grants mode (all new tailnets default to this)
+- A machine, tagged source, or service account needs to reach another
+  node via anything other than `tailscale ssh`
+- You're adding CI/CD access (GitHub Actions, GitLab runners, Buildkite
+  agents) to production nodes
+- You're restructuring an existing ACL and the diff touches `grants`,
+  `ssh`, or `tests` — re-verify each tagged source still has every grant
+  it needs
+
+Apply the **regression-test-every-grant rule** whenever you add or modify
+any `grants` entry. The test is cheap (one line) and the validator runs
+it at save-time for free.
+
+Apply the **observe-before-third-fix meta-pattern** whenever:
+
+- A handoff hands you a hypothesis (especially timing/race/flakiness)
+- Two fixes based on that hypothesis fail with identical symptoms
+- You're about to write fix #3 against the same theory
+
+## Examples
+
+### Example 1 — the failure this documents
+
+Runner's `tailscale status` on the failing run (24694134310) showed 4
+peers: itself, two iPhones, one Mac. `openclaw-prod` was absent. Same
+moment, from the user's laptop, `tailscale status` showed
+`100.75.213.64 openclaw-prod` listed healthy and tagged. The VPS was up,
+tagged correctly, reachable from every other node — just invisible to
+`tag:gh-actions`. Adding the `tcp:22` grant restored visibility; run
+[24694912948](https://github.com/villavicencio/dotfiles/actions/runs/24694912948)
+went green in 15 seconds.
+
+### Example 2 — what the regression test catches
+
+On 2026-04-17 the ACL was edited to fix a separate validation error
+(`tests[].src requires concrete user, not autogroup` — documented in
+cross-project Forge learnings). During the restructure, the
+`tag:gh-actions` grant was collaterally removed. Had the ACL already
+contained `{"src": "tag:gh-actions", "accept": ["tag:prod:22"]}` in
+`tests`, Tailscale's save-time validator would have rejected the save
+with a clear message, and the regression would never have shipped.
+
+The VPS cgroup-OOM incident on 2026-04-18 forced a full reboot. Prior to
+that, the runner may occasionally have succeeded against a cached peer
+table; post-reboot the gap became consistent. The test prevents both
+modes of regression — permanent and cached-lag. _(session history)_
+
+### Example 3 — generalizing to other protocols
+
+The same pattern applies to any non-Tailscale-SSH access. If
+`tag:monitoring` needs to scrape Prometheus on `tag:prod:9090`:
+
+```json
+"grants": [
+    {"src": ["tag:monitoring"], "dst": ["tag:prod"], "ip": ["tcp:9090"]}
+],
+"tests": [
+    {"src": "tag:monitoring", "accept": ["tag:prod:9090"]}
+]
+```
+
+An `ssh` block for that pair would be meaningless — Prometheus doesn't
+speak Tailscale SSH.
+
+### Example 4 — applying the meta-pattern
+
+Next time a handoff says "flaky DNS" or "timing race" and fix #1 and
+fix #2 both fail in the same ~30ms window, the next commit should not
+be fix #3. It should be a diagnostic step:
+
+```yaml
+- name: Diagnose tailnet state (TEMP)
+  run: |
+    echo "=== tailscale status ==="
+    tailscale status 2>&1 || true
+    echo "=== tailscale status --json (peers only) ==="
+    tailscale status --json 2>&1 \
+      | jq '.Peer | to_entries | map({host: .value.HostName, dns: .value.DNSName, ips: .value.TailscaleIPs, online: .value.Online})' \
+      || true
+    echo "=== resolvectl status ==="
+    resolvectl status 2>&1 | head -40 || true
+    echo "=== tailscale ip -4 ${{ inputs.host }} ==="
+    tailscale ip -4 "${{ inputs.host }}" 2>&1 || true
+    echo "=== getent hosts ${{ inputs.host }} ==="
+    getent hosts "${{ inputs.host }}" 2>&1 || true
+```
+
+One CI run, ~5 seconds, reveals whether the target is even in the peer
+list. Revert the step after the real fix lands.
+
+## Related
+
+- [`docs/solutions/cross-machine/tailscale-tag-acl-ssh-failure-modes.md`](./tailscale-tag-acl-ssh-failure-modes.md)
+  — companion doc covering three other ACL failure modes (key expiry,
+  `autogroup:self` on tagged nodes, self-advertised-tag approval limbo).
+  This doc is effectively a fourth failure mode in the same family, but
+  distinct enough to warrant its own page: different ACL block (`grants`
+  vs `ssh`), different symptom surface (peer-invisibility vs explicit
+  "policy does not permit"), and different affected path (raw OpenSSH
+  vs `tailscale ssh`).
+- [`docs/solutions/cross-machine/vps-dotfiles-target.md`](./vps-dotfiles-target.md)
+  — operational runbook. **Note:** its "Tailscale OAuth + ACL setup"
+  section currently shows an `ssh`-only ACL snippet that reproduces this
+  bug on fresh setup. See Refresh Notes below.
+- Tailscale docs:
+  [Grants](https://tailscale.com/kb/1324/acl-grants),
+  [Tailscale SSH](https://tailscale.com/kb/1193/tailscale-ssh),
+  [ACL tags](https://tailscale.com/kb/1068/acl-tags).
+
+## Refresh Notes
+
+The Related Docs Finder flagged
+[`vps-dotfiles-target.md`](./vps-dotfiles-target.md) as a high-priority
+refresh candidate — its ACL snippet teaches the `ssh`-only pattern that
+caused this incident. A future operator following that runbook would
+reintroduce issue #42. Suggested next action:
+
+```
+/ce:compound-refresh vps-dotfiles-target
+```
+
+The
+[`tailscale-tag-acl-ssh-failure-modes.md`](./tailscale-tag-acl-ssh-failure-modes.md)
+doc would also benefit from a short "Failure 4" cross-reference pointing
+here, so someone hitting the grant-gap symptom finds both docs.

--- a/docs/solutions/cross-machine/tailscale-tag-acl-ssh-failure-modes.md
+++ b/docs/solutions/cross-machine/tailscale-tag-acl-ssh-failure-modes.md
@@ -1,6 +1,7 @@
 ---
 title: "Tailscale tag + ACL + expiry interactions that broke SSH to a tagged node"
 date: 2026-04-15
+last_updated: 2026-04-20
 category: cross-machine
 tags:
   - tailscale
@@ -157,6 +158,40 @@ tailscale status --json | jq '.Peer | to_entries[]
 If it's `null` despite the UI showing the tag, you're in the
 pending-approval limbo. Admin-assign the tag directly to move past it.
 
+### Failure 4: `grants` block missing for raw OpenSSH over tailnet
+
+Discovered later (2026-04-20) and documented in its own page because it
+sits in a different ACL block and fails with a different symptom surface.
+Summarized here for parallel discoverability:
+
+**What happened:** after the three fixes above, `tailscale ssh root@host`
+from the user's laptop worked perfectly. But a GitHub Actions workflow
+joining the tailnet as `tag:gh-actions` could not reach the VPS — the
+target didn't even appear in the runner's tailnet peer list. Symptom
+surface was DNS failure (`lookup openclaw-prod on 127.0.0.53:53: server
+misbehaving`), which looked nothing like an ACL problem.
+
+**Root cause:** the `ssh` block governs only **Tailscale SSH** (a
+separate auth layer invoked as `tailscale ssh <host>`). Raw OpenSSH over
+tailnet — what the workflow actually uses (`ssh root@openclaw-prod` on
+port 22) — requires a `grants` block entry. Missing a grant is strictly
+stronger than "access denied" — the destination node is entirely
+invisible in the source's peer list, so MagicDNS has no record to return.
+
+**Fix:** add a `grants` entry AND a regression test:
+
+```json
+"grants": [
+  {"src": ["tag:gh-actions"], "dst": ["tag:prod"], "ip": ["tcp:22"]}
+],
+"tests": [
+  {"src": "tag:gh-actions", "accept": ["tag:prod:22"]}
+]
+```
+
+**Full writeup:**
+[tailscale-grants-vs-ssh-block-raw-ssh-2026-04-20.md](tailscale-grants-vs-ssh-block-raw-ssh-2026-04-20.md).
+
 ## Why these failure modes stack
 
 Setting up a tagged host for the first time exercises the full chain:
@@ -268,9 +303,13 @@ ssh -v root@HOSTNAME 'echo ok' 2>&1 | tail -40
 
 ## Related
 
+- [tailscale-grants-vs-ssh-block-raw-ssh-2026-04-20.md](tailscale-grants-vs-ssh-block-raw-ssh-2026-04-20.md)
+  — Failure 4 in full detail: `grants` vs `ssh` block distinction for raw
+  OpenSSH over tailnet.
 - [VPS dotfiles sync target](vps-dotfiles-target.md) — operational runbook
   that references this ACL/tag setup.
-- Tailscale docs: [Tailscale SSH](https://tailscale.com/kb/1193/tailscale-ssh),
+- Tailscale docs: [Grants](https://tailscale.com/kb/1324/acl-grants),
+  [Tailscale SSH](https://tailscale.com/kb/1193/tailscale-ssh),
   [ACL tags](https://tailscale.com/kb/1068/acl-tags).
 
 ## Sources

--- a/docs/solutions/cross-machine/vps-dotfiles-target.md
+++ b/docs/solutions/cross-machine/vps-dotfiles-target.md
@@ -1,6 +1,7 @@
 ---
 title: "Sync dotfiles to a Linux VPS via GitHub Actions over Tailscale"
 date: 2026-04-14
+last_updated: 2026-04-20
 category: cross-machine
 tags:
   - vps
@@ -114,6 +115,16 @@ In https://login.tailscale.com/admin/acls/file, add or merge:
     "tag:gh-actions": ["autogroup:admin"],
     "tag:prod":       ["autogroup:admin"]
   },
+  "grants": [
+    // GH Actions runner needs raw OpenSSH (tcp:22) to the VPS. The ssh{}
+    // block below only governs Tailscale SSH (separate auth path); this
+    // grant is what gives tag:gh-actions peer-list visibility AND tcp:22
+    // connectivity to tag:prod. Omitting it makes the runner unable to
+    // see openclaw-prod in its tailnet peer list, which surfaces as DNS
+    // lookup failures — see
+    // tailscale-grants-vs-ssh-block-raw-ssh-2026-04-20.md.
+    {"src": ["tag:gh-actions"], "dst": ["tag:prod"], "ip": ["tcp:22"]}
+  ],
   "ssh": [
     {
       "action": "accept",
@@ -121,6 +132,12 @@ In https://login.tailscale.com/admin/acls/file, add or merge:
       "dst":    ["tag:prod"],
       "users":  ["root"]
     }
+  ],
+  "tests": [
+    // Save-time regression guard. Tailscale refuses to save an ACL where
+    // a test fails, so if a future edit drops the grant above, the save
+    // will surface the regression instead of silently shipping it.
+    {"src": "tag:gh-actions", "accept": ["tag:prod:22"]}
   ]
 }
 ```
@@ -128,6 +145,14 @@ In https://login.tailscale.com/admin/acls/file, add or merge:
 Any node tagged `tag:prod` from now on will be SSH-root-accessible from
 the GitHub Actions runner. **Do not apply `tag:prod` to a new node without
 reviewing this ACL first.**
+
+**Why both `grants` and `ssh`?** They govern two different auth paths.
+`grants` controls raw IP connectivity (OpenSSH on port 22, which the
+workflow uses via `ssh root@openclaw-prod`). `ssh` controls Tailscale
+SSH (invoked via `tailscale ssh <host>`, a separate auth layer). The
+runbook keeps the `ssh` block for operator convenience (`tailscale ssh`
+from your laptop), but the workflow-critical path is the `grants`
+entry.
 
 ### 3. Create the OAuth client
 
@@ -148,26 +173,38 @@ Repo → Settings → Secrets and variables → Actions → **New repository sec
 
 ### 5. Smoke test before any workflow run
 
-From a tailnet-connected client (personal Mac):
+From a tailnet-connected client (personal Mac), test the **exact path
+the workflow uses** — raw OpenSSH over tailnet, not Tailscale SSH:
 
 ```bash
-tailscale ssh root@openclaw-prod 'echo ok'
+ssh root@openclaw-prod 'echo ok'
 ```
 
-Should print `ok`. If it fails, diagnose the ACL or tag before running
-the workflow. Tailscale SSH auth uses tailnet identity — no SSH keys,
-no `known_hosts` management. `StrictHostKeyChecking=accept-new` in the
-workflow is cosmetic; Tailscale SSH does not use OpenSSH host keys.
+Should print `ok`. If it fails, diagnose the ACL grant (not the `ssh`
+block) or tag before running the workflow.
+
+**Important:** deliberately use plain `ssh`, not `tailscale ssh`. The
+workflow invokes `ssh root@openclaw-prod` against sshd on port 22 —
+that's raw OpenSSH-over-tailnet, which needs the `grants` entry above.
+`tailscale ssh` takes a different auth path (the `ssh` block), so a
+passing `tailscale ssh` smoke test can mask a missing `grants` entry —
+exactly the failure mode that caused issue #42 (2026-04-20).
+`StrictHostKeyChecking=accept-new` in the workflow IS functional for
+raw OpenSSH — the runner caches the VPS host key on first contact.
 
 ## Pre-Deploy Go/No-Go Checklist
 
 Run top-to-bottom before every `dry_run=false` workflow invocation,
 especially the first. Any FAIL = STOP.
 
-1. **ACL still works** (tailnet health):
+1. **ACL still works** for the workflow path (raw OpenSSH, not Tailscale SSH):
    ```bash
-   tailscale ssh root@openclaw-prod 'echo ok'
+   ssh root@openclaw-prod 'echo ok'
    ```
+   Use plain `ssh` here to match what the workflow does. `tailscale ssh`
+   exercises a different ACL path (`ssh` block) and can pass while the
+   workflow-critical `grants` entry is missing — see the note in the
+   [smoke test section](#5-smoke-test-before-any-workflow-run).
 
 2. **GitHub secrets still present**:
    ```bash
@@ -306,10 +343,18 @@ minimized):
 
 - Plan: [docs/plans/2026-04-14-feat-vps-dotfiles-sync-target-plan.md](../../plans/2026-04-14-feat-vps-dotfiles-sync-target-plan.md)
 - Brainstorm: [docs/brainstorms/2026-04-14-vps-dotfiles-target-brainstorm.md](../../brainstorms/2026-04-14-vps-dotfiles-target-brainstorm.md)
+- [tailscale-grants-vs-ssh-block-raw-ssh-2026-04-20.md](tailscale-grants-vs-ssh-block-raw-ssh-2026-04-20.md)
+  — why the ACL needs both a `grants` entry and an `ssh` block, and why
+  a missing grant looks like a DNS failure.
+- [tailscale-tag-acl-ssh-failure-modes.md](tailscale-tag-acl-ssh-failure-modes.md)
+  — other Tailscale ACL failure modes encountered during VPS bring-up
+  (key expiry, `autogroup:self` on tagged nodes, self-advertised-tag
+  approval limbo).
 - Dotbot `--dry-run` support: https://github.com/anishathalye/dotbot
   (vendored at v1.24.1 — native `--dry-run` covers `link`/`create`/`clean`/`shell`.
   The wrapper also exports `DOTFILES_DRY_RUN=1` as defense-in-depth for helpers
   invoked directly outside Dotbot.)
 - Tailscale GitHub Action v4: https://github.com/tailscale/github-action
 - Tailscale SSH: https://tailscale.com/kb/1193/tailscale-ssh
+- Tailscale Grants: https://tailscale.com/kb/1324/acl-grants
 - Configuration Audit Logs: https://login.tailscale.com/admin/logs


### PR DESCRIPTION
## Summary

- Capture the learning from issue #42 as a compound doc — Tailscale grants-mode ACLs require a `grants` entry for raw OpenSSH, separate from the `ssh` block (which governs only Tailscale SSH). A missing grant strips the destination from the source's peer list, masquerading as a DNS failure.
- Refresh two adjacent docs whose ACL snippets / smoke tests reproduced the bug on fresh setup (`vps-dotfiles-target.md`) or only covered three of the four ACL failure modes (`tailscale-tag-acl-ssh-failure-modes.md`).
- Incorrect teaching removed: the claim that `StrictHostKeyChecking=accept-new` is "cosmetic because Tailscale SSH doesn't use host keys" — that paragraph was conflating the two auth paths.

## Files

| File | Change |
| --- | --- |
| `docs/solutions/cross-machine/tailscale-grants-vs-ssh-block-raw-ssh-2026-04-20.md` | New — 305 lines |
| `docs/solutions/cross-machine/vps-dotfiles-target.md` | ACL snippet gains `grants` + `tests`; smoke test + pre-deploy checklist switch to raw `ssh` (matching what the workflow does); `last_updated` added |
| `docs/solutions/cross-machine/tailscale-tag-acl-ssh-failure-modes.md` | New "Failure 4" summary + cross-reference; `last_updated` added |

## Test plan

- [ ] Rendered markdown reads cleanly in each of the 3 files
- [ ] Cross-references resolve (the three docs link to each other correctly)
- [ ] The ACL snippet in `vps-dotfiles-target.md` matches the ACL that actually works in production (verified earlier via run [24694912948](https://github.com/villavicencio/dotfiles/actions/runs/24694912948) — all green in 15s)
- [ ] No stale teaching remains: `grep -n "tailscale ssh root@openclaw-prod" docs/solutions/cross-machine/vps-dotfiles-target.md` should only appear in operator-side verification commands, not in the workflow-critical smoke test

Resolves #42 (already closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)