### PR TITLE
feat(claude-statusline): version in dotfiles + add git-branch segment

### DIFF
--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+input=$(cat)
+cwd=$(echo "$input" | jq -r '.workspace.current_dir // .cwd // ""')
+model=$(echo "$input" | jq -r '.model.display_name // ""')
+used=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+
+# Shorten home directory to ~
+home="$HOME"
+short_cwd="${cwd/#$home/\~}"
+
+# Build status line with ANSI colors
+# Cyan for directory, dim white for model, color-coded context usage
+printf "\033[36m%s\033[0m" "$short_cwd"
+
+# Git branch — hidden when not inside a repo or on detached HEAD.
+# master/main render dim (default-branch, low visual weight); any other
+# branch renders magenta so the working-branch name pops.
+if [ -n "$cwd" ]; then
+  branch=$(git -C "$cwd" symbolic-ref --short -q HEAD 2>/dev/null)
+  if [ -n "$branch" ]; then
+    case "$branch" in
+      master|main) branch_color="\033[2m\033[37m" ;;
+      *)           branch_color="\033[35m" ;;
+    esac
+    # U+E0A0 (Powerline branch glyph) — encoded as UTF-8 \xee\x82\xa0 because
+    # /bin/sh / bash 3.2 printf does not interpret \uXXXX. Literal PUA chars
+    # in the source would also be stripped by the Claude Code Write tool (see
+    # docs/solutions/code-quality/claude-code-bash-tool-strips-pua-glyphs.md).
+    printf " \033[2m|\033[0m ${branch_color}\xee\x82\xa0 %s\033[0m" "$branch"
+  fi
+fi
+
+if [ -n "$model" ]; then
+  printf " \033[2m|\033[0m \033[37m%s\033[0m" "$model"
+fi
+
+if [ -n "$used" ]; then
+  used_int=$(printf "%.0f" "$used")
+  if [ "$used_int" -ge 80 ]; then
+    color="\033[31m"  # red
+  elif [ "$used_int" -ge 50 ]; then
+    color="\033[33m"  # yellow
+  else
+    color="\033[32m"  # green
+  fi
+  printf " \033[2m|\033[0m ${color}ctx:%d%%\033[0m" "$used_int"
+fi

--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -70,6 +70,7 @@
 - link:
     ~/.claude/CLAUDE.md: claude/CLAUDE.md
     ~/.claude/settings.json: claude/settings.json
+    ~/.claude/statusline-command.sh: claude/statusline-command.sh
     ~/.claude/hooks/tmux-attention.sh: claude/hooks/tmux-attention.sh
     ~/.claude/commands/handoff.md: claude/commands/handoff.md
     ~/.claude/commands/pickup.md: claude/commands/pickup.md


### PR DESCRIPTION
## Summary

Two concerns, one commit:

- **Versioning coverage.** `~/.claude/statusline-command.sh` was previously unmanaged — only existed on the personal Mac. Moved into `claude/statusline-command.sh` and linked via `install.conf.yaml` so it lands on any Darwin host via Dotbot (Darwin-only per the existing `~/.claude/*` convention).
- **Branch segment.** New block between path and model segments rendering the current git branch with the Powerline branch glyph (U+E0A0). `master`/`main` render dim white (default, low visual weight); any other branch renders magenta so the working-branch name pops. Hidden when not in a git repo or on detached HEAD.

Live preview on a feature branch:

```
~/Projects/Personal/dotfiles |  feat/statusline-git-branch-segment | Opus 4.7 (1M context) | ctx:22%
```

## Implementation notes

- U+E0A0 encoded as literal UTF-8 bytes (`\xee\x82\xa0`) in the `printf` format — bash 3.2's `printf` does not interpret `\uXXXX`, and the Claude Code Write tool strips PUA-range characters anyway (see `docs/solutions/code-quality/claude-code-bash-tool-strips-pua-glyphs.md`).
- Branch color picked via `case` statement, keeping the script POSIX `/bin/sh` clean.
- `git -C "$cwd" symbolic-ref --short -q HEAD` — fails silently on non-repos and detached HEAD, so the segment just disappears in those cases.

## Test plan

- [x] Dry-run preview from Dotbot on the personal Mac showed `Would remove ~/.claude/statusline-command.sh` + `Would create symlink …` — clean swap
- [x] Live symlink in place after real run; statusline renders the branch segment immediately (no session restart needed)
- [ ] On next branch switch, feature branch should render magenta; on `master` it should render dim white
- [ ] Work Mac smoke test: `./install` picks up the new link entry and replaces any pre-existing regular file cleanly
- [ ] Linux VPS smoke test: `./install` (via `install-linux.conf.yaml`) skips this entry entirely — `~/.claude/*` is Darwin-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)