### PR TITLE
fix(forge-bridge): chown 1000:1000 after ssh-as-root archive moves

### DIFF
--- a/claude/commands/handoff.md
+++ b/claude/commands/handoff.md
@@ -116,7 +116,9 @@ If opted in:
 
 5. **Log the sync** to shared/comms for audit trail:
    ```bash
-   printf '%s\n' "[Forge bridge] Synced N items from {project-key} session" | ssh root@openclaw-prod 'cat >> /var/lib/docker/volumes/d95veq7chb3d8gllyj6vhpqy_openclaw-state/_data/shared/comms/YYYY-MM-DD.md'
+   # Trailing chown keeps the comms log writable by the container node user
+   # (uid 1000). Same first-write ownership trap as Step 5/6 — see dotfiles#47/#50.
+   printf '%s\n' "[Forge bridge] Synced N items from {project-key} session" | ssh root@openclaw-prod 'DEST=/var/lib/docker/volumes/d95veq7chb3d8gllyj6vhpqy_openclaw-state/_data/shared/comms/YYYY-MM-DD.md; cat >> "$DEST"; chown 1000:1000 "$DEST"'
    ```
 
 If there are no durable learnings worth pushing, skip silently — not every session produces cross-project knowledge.

--- a/claude/commands/handoff.md
+++ b/claude/commands/handoff.md
@@ -118,7 +118,10 @@ If opted in:
    ```bash
    # Trailing chown keeps the comms log writable by the container node user
    # (uid 1000). Same first-write ownership trap as Step 5/6 — see dotfiles#47/#50.
-   printf '%s\n' "[Forge bridge] Synced N items from {project-key} session" | ssh root@openclaw-prod 'DEST=/var/lib/docker/volumes/d95veq7chb3d8gllyj6vhpqy_openclaw-state/_data/shared/comms/YYYY-MM-DD.md; cat >> "$DEST"; chown 1000:1000 "$DEST"'
+   # `cat >> ... && chown` so an append failure (disk full, I/O error) propagates
+   # through the pipeline; otherwise ssh would return chown's exit and the
+   # `.forge-pending` fallback below would never fire.
+   printf '%s\n' "[Forge bridge] Synced N items from {project-key} session" | ssh root@openclaw-prod 'DEST=/var/lib/docker/volumes/d95veq7chb3d8gllyj6vhpqy_openclaw-state/_data/shared/comms/YYYY-MM-DD.md; cat >> "$DEST" && chown 1000:1000 "$DEST"'
    ```
 
 If there are no durable learnings worth pushing, skip silently — not every session produces cross-project knowledge.

--- a/claude/commands/pickup.md
+++ b/claude/commands/pickup.md
@@ -85,7 +85,12 @@ ssh root@openclaw-prod "echo '===FORGE_SHARED===' && \
 **If inbox files exist:**
 1. Read each file's content (in the same or a follow-up SSH call)
 2. Display the messages to the user under a "Messages for Forge:" header
-3. Archive them: `mkdir -p $VOLBASE/shared/inbox/forge/archive && mv -n $VOLBASE/shared/inbox/forge/*.md $VOLBASE/shared/inbox/forge/archive/ 2>/dev/null`
+3. Archive them (trailing `chown` keeps the archive subtree writable by the container node user — see dotfiles#47/#50):
+   ```bash
+   ssh root@openclaw-prod "mkdir -p $VOLBASE/shared/inbox/forge/archive && \
+     mv -n $VOLBASE/shared/inbox/forge/*.md $VOLBASE/shared/inbox/forge/archive/ 2>/dev/null; \
+     chown -R 1000:1000 $VOLBASE/shared/inbox/forge/archive"
+   ```
 
 **If pending ticket files exist:**
 1. Read each ticket file's content
@@ -94,9 +99,13 @@ ssh root@openclaw-prod "echo '===FORGE_SHARED===' && \
 4. If approved, run the `/ticket` skill (or `gh issue create`) with the title and body from the file
 5. After creation, move the file to `pending/done/`:
    ```bash
+   # Trailing chown keeps pending/done/ writable by the container node user
+   # (uid 1000). ssh-as-root mkdir + mv otherwise creates a root-owned `done/`
+   # that Forge cannot manage from inside the container. See dotfiles#47/#50.
    ssh root@openclaw-prod "mkdir -p $VOLBASE/workspace-forge/projects/{PROJECT_KEY}/pending/done && \
      mv -n $VOLBASE/workspace-forge/projects/{PROJECT_KEY}/pending/{FILENAME} \
-       $VOLBASE/workspace-forge/projects/{PROJECT_KEY}/pending/done/"
+       $VOLBASE/workspace-forge/projects/{PROJECT_KEY}/pending/done/ && \
+     chown -R 1000:1000 $VOLBASE/workspace-forge/projects/{PROJECT_KEY}/pending/done"
    ```
 
 **If SSH fails:** Note "Forge bridge unavailable — using local context only" and continue. Do NOT block pickup.

--- a/claude/commands/pickup.md
+++ b/claude/commands/pickup.md
@@ -87,8 +87,13 @@ ssh root@openclaw-prod "echo '===FORGE_SHARED===' && \
 2. Display the messages to the user under a "Messages for Forge:" header
 3. Archive them (trailing `chown` keeps the archive subtree writable by the container node user — see dotfiles#47/#50):
    ```bash
+   # Uses `find ... -exec mv -t DEST {} +` (plus form, not `\;`): empty inbox
+   # is a natural no-op (exit 0), a real mv failure propagates to find's exit,
+   # and the outer && chain only runs chown if everything above succeeded.
+   # The `\;` form silently discards mv's exit code — use `+` here.
    ssh root@openclaw-prod "mkdir -p $VOLBASE/shared/inbox/forge/archive && \
-     mv -n $VOLBASE/shared/inbox/forge/*.md $VOLBASE/shared/inbox/forge/archive/ 2>/dev/null; \
+     find $VOLBASE/shared/inbox/forge -maxdepth 1 -type f -name '*.md' \
+       -exec mv -n -t $VOLBASE/shared/inbox/forge/archive/ {} + && \
      chown -R 1000:1000 $VOLBASE/shared/inbox/forge/archive"
    ```
 


### PR DESCRIPTION
Closes #50. Follow-up to #48.

## Summary

- Three more ssh-as-root sites in `/pickup` and `/handoff` now trailing-`chown 1000:1000` after writes, matching the invariant established in #48.
- One-time VPS repair on `workspace-forge/projects/wedding-site/pending/done/` (was `root:root`) applied out-of-band.

## Sites patched

1. **`claude/commands/pickup.md:88`** — Forge inbox archival. `mkdir -p ...inbox/forge/archive && mv -n ...` now followed by `chown -R 1000:1000 ...archive`. Also wrapped the one-liner in an explicit `ssh root@openclaw-prod "..."` block for consistency with the sibling ssh snippets in the file (the original was a bare inline snippet that expected the reader to add the ssh wrapper).
2. **`claude/commands/pickup.md:97-99`** — pending-ticket archival. `chown -R 1000:1000 ...pending/done` appended at the end of the existing ssh block.
3. **`claude/commands/handoff.md:119`** — Step 5.5 Forge-bridge sync log. `DEST=...; cat >> "$DEST"; chown 1000:1000 "$DEST"` pattern, matching the shape now used in Step 5 (`_shared/*.md`) and Step 6 (`cadence-log.md`).

## Root cause (same as #48)

`ssh root@openclaw-prod 'mkdir -p <path>'` creates absent directories as root on the host. `ssh root@openclaw-prod 'cat >> <path>'` creates absent files as root. Subsequent in-container writes by the node user (uid 1000) then fail with permission denied. Fix is to trailing-chown immediately after the write to establish the 1000:1000 invariant.

## One-time VPS ownership survey

```
shared/inbox/forge/archive/          1000:1000  (incidental — Forge created it container-side first)
shared/comms/*.md                    1000:1000  (all clean)
projects/dotfiles/pending/done/      1000:1000  (repaired 2026-04-24 morning, part of #47/#48)
projects/openclaw-forge/pending/done 1000:1000
projects/wedding-site/pending/done   0:0       ← REPAIRED in this PR
```

## Verification

The invariant is the same pattern already exercised live in this session's `/handoff` run (Step 6 cadence-log append preserved `1000:1000` across first-write and append). These three sites just extend it to the sibling code paths. No new test harness added — the SOP changes are textual with equivalent semantics.

## Test plan

- [x] All three SOP sites now trailing-chown after the write
- [x] Wedding-site pending/done repaired on VPS
- [x] Survey confirms no other Forge-project pending/done/ is root-owned
- [ ] Reviewer: optional — trigger a `/pickup` cycle that exercises the inbox archive and verify ownership holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)