### PR TITLE
fix(handoff): propagate append failures at Step 5.3 and Step 6.2

### DIFF
--- a/claude/commands/handoff.md
+++ b/claude/commands/handoff.md
@@ -107,7 +107,7 @@ If opted in:
    # out of subsequent in-container updates. See dotfiles#47.
    # `cat >> ... && chown` so an append failure (disk full, I/O error) propagates
    # through ssh's exit code; otherwise ssh returns chown's status and the
-   # `.forge-pending` fallback in step 4 above never fires. See dotfiles#52.
+   # `.forge-pending` fallback in step 4 below never fires. See dotfiles#52.
    printf '%s\n' "- [YYYY-MM-DD] LEARNING_TEXT" | ssh root@openclaw-prod 'DEST=/var/lib/docker/volumes/d95veq7chb3d8gllyj6vhpqy_openclaw-state/_data/workspace-forge/projects/{TARGET_FILE}; cat >> "$DEST" && chown 1000:1000 "$DEST"'
    ```
 

--- a/claude/commands/handoff.md
+++ b/claude/commands/handoff.md
@@ -105,7 +105,10 @@ If opted in:
    # Trailing chown keeps the file writable by the container node user (uid 1000).
    # ssh-as-root + `>>` creates absent files as root on first write, locking Forge
    # out of subsequent in-container updates. See dotfiles#47.
-   printf '%s\n' "- [YYYY-MM-DD] LEARNING_TEXT" | ssh root@openclaw-prod 'DEST=/var/lib/docker/volumes/d95veq7chb3d8gllyj6vhpqy_openclaw-state/_data/workspace-forge/projects/{TARGET_FILE}; cat >> "$DEST"; chown 1000:1000 "$DEST"'
+   # `cat >> ... && chown` so an append failure (disk full, I/O error) propagates
+   # through ssh's exit code; otherwise ssh returns chown's status and the
+   # `.forge-pending` fallback in step 4 above never fires. See dotfiles#52.
+   printf '%s\n' "- [YYYY-MM-DD] LEARNING_TEXT" | ssh root@openclaw-prod 'DEST=/var/lib/docker/volumes/d95veq7chb3d8gllyj6vhpqy_openclaw-state/_data/workspace-forge/projects/{TARGET_FILE}; cat >> "$DEST" && chown 1000:1000 "$DEST"'
    ```
 
 4. **If SSH fails**, save approved items to `.forge-pending` in the project root as JSON-lines:
@@ -119,8 +122,10 @@ If opted in:
    # Trailing chown keeps the comms log writable by the container node user
    # (uid 1000). Same first-write ownership trap as Step 5/6 — see dotfiles#47/#50.
    # `cat >> ... && chown` so an append failure (disk full, I/O error) propagates
-   # through the pipeline; otherwise ssh would return chown's exit and the
-   # `.forge-pending` fallback below would never fire.
+   # the real exit through ssh — otherwise ssh returns chown's status and the
+   # operator (or any caller) sees a successful sync that didn't actually write
+   # the audit log. No automated fallback for this audit-log path; this step's
+   # only safety net is the propagated exit code being visible.
    printf '%s\n' "[Forge bridge] Synced N items from {project-key} session" | ssh root@openclaw-prod 'DEST=/var/lib/docker/volumes/d95veq7chb3d8gllyj6vhpqy_openclaw-state/_data/shared/comms/YYYY-MM-DD.md; cat >> "$DEST" && chown 1000:1000 "$DEST"'
    ```
 
@@ -153,7 +158,10 @@ After the handoff is written and Forge write-back is done (or skipped), append a
    # Trailing chown keeps cadence-log.md writable by the container node user (uid 1000).
    # ssh-as-root + `>>` creates absent files as root on first write, locking Forge
    # out of subsequent in-container updates. See dotfiles#47.
-   ssh root@openclaw-prod "DEST=$VOLBASE/workspace-forge/projects/{PROJECT_KEY}/cadence-log.md; mkdir -p \"\$(dirname \"\$DEST\")\"; { echo ''; cat; } >> \"\$DEST\"; chown 1000:1000 \"\$DEST\"" <<'EOF'
+   # `>> "$DEST" && chown` so an append failure propagates through ssh's exit;
+   # otherwise the failure path below ("note the failure and continue") would
+   # never trigger because ssh would return chown's success status. See dotfiles#52.
+   ssh root@openclaw-prod "DEST=$VOLBASE/workspace-forge/projects/{PROJECT_KEY}/cadence-log.md; mkdir -p \"\$(dirname \"\$DEST\")\"; { echo ''; cat; } >> \"\$DEST\" && chown 1000:1000 \"\$DEST\"" <<'EOF'
    ## YYYY-MM-DD — {PROJECT_KEY} session briefing
    SESSION_BRIEFING_HERE
    EOF


### PR DESCRIPTION
Closes #52. Follow-up to #51's review nit.

## Summary

- `handoff.md:108` (Step 5.3 `_shared/*.md` write-back): `cat >> "$DEST"; chown` → `cat >> "$DEST" && chown`. A failed append now propagates through ssh's exit code so the `.forge-pending` fallback in Step 4 actually fires.
- `handoff.md:151` (Step 6.2 cadence-log append): same flip — append failure now propagates so the "note the failure and continue" path in Step 6.3 actually triggers.
- `handoff.md:119` (Step 5.5 audit-log comment): reworded the misleading "fallback below" sentence per the reviewer nit on #51. The Step 5 audit log has no automated fallback — propagated exit code is the operator-visible safety net.

## Why

Reviewer flagged the same `;`-vs-`&&` defect at #51 lines 88 and 121, which I fixed in PR #51. These two siblings are the rest of the same invariant — separated only because they landed on master via #48 and were outside #51's diff at review time.

## Test plan

- [x] `bash -n claude/commands/handoff.md` — N/A (markdown)
- [x] Three SSH-write sites in handoff.md now use `&&` between append and chown
- [x] Comment at line 119 accurately describes Step 5.5's failure-mode story (no automated fallback, exit code only)
- [ ] Reviewer: optional — exercise Step 5.3 with a forced failure (e.g., `chmod 0 _shared/patterns.md` first), confirm `.forge-pending` is created

## Notes

Pure surgical fix — no new behavior, no scope creep. Three lines changed, three comments expanded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)