### PR TITLE
feat(ci): install-matrix workflow + chsh CI gate (PR #1b of CE trifecta)

### DIFF
--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -71,6 +71,16 @@ defaults:
     # legs share the same shell so step bodies stay portable.
     shell: bash
 
+# PYTHONDONTWRITEBYTECODE: dotbot is a Python tool that imports pyyaml at
+# startup. Without this flag, `./install --dry-run` writes `__pycache__/`
+# directories under `dotbot/lib/pyyaml/` and `dotbot/src/dotbot/`. On
+# macOS where `$GITHUB_WORKSPACE` is *inside* `$HOME=/Users/runner`, those
+# writes show up in the R2 delta-diff and falsely fail the assertion.
+# Setting it at workflow level keeps both legs identical and is safe for
+# the apply step too — Python works fine without bytecode caches.
+env:
+  PYTHONDONTWRITEBYTECODE: '1'
+
 jobs:
   linux:
     runs-on: ubuntu-24.04
@@ -84,6 +94,21 @@ jobs:
       # for this repo, which ghcr.io requires.
       image: ghcr.io/${{ github.repository_owner }}/dotfiles-ci-ubuntu@sha256:8b0b7108e32229d7842c7cb876bc7f322f114e079d171d9725d1e71279dd3865
     steps:
+      - name: Install python3 (Dotbot runtime)
+        # Dotbot itself is a Python script (dotbot/bin/dotbot exec's
+        # python3 "$0"). The `ubuntu:24.04` base image used by ci/Dockerfile
+        # is the *minimal* Docker image that intentionally omits Python
+        # to keep size down. Production VPS Ubuntu Server images ship
+        # python3 as part of the base OS, which is why the VPS bootstrap
+        # works without an explicit install. Adding it here keeps the
+        # ci/Dockerfile minimal at the cost of ~5s per CI run.
+        # TODO: bake `python3-minimal` into ci/Dockerfile in a follow-up
+        # PR (chicken-and-egg with publish-ci-image — image rebuilds
+        # only fire on master push).
+        run: |
+          apt-get update -qq
+          apt-get install -y --no-install-recommends python3-minimal
+
       - name: Checkout
         # SHA-pinned to close the supply-chain vector where a force-pushed
         # mutable tag could compromise this workflow at run time.

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -102,12 +102,15 @@ jobs:
         # python3 as part of the base OS, which is why the VPS bootstrap
         # works without an explicit install. Adding it here keeps the
         # ci/Dockerfile minimal at the cost of ~5s per CI run.
-        # TODO: bake `python3-minimal` into ci/Dockerfile in a follow-up
-        # PR (chicken-and-egg with publish-ci-image — image rebuilds
-        # only fire on master push).
+        # NOTE: `python3-minimal` strips the stdlib (no `json`, etc.); we
+        # need the full `python3` so dotbot's `import json` works. This
+        # pulls libpython3-stdlib + minor deps, ~50MB.
+        # TODO: bake `python3` into ci/Dockerfile in a follow-up PR
+        # (chicken-and-egg with publish-ci-image — image rebuilds only
+        # fire on master push).
         run: |
           apt-get update -qq
-          apt-get install -y --no-install-recommends python3-minimal
+          apt-get install -y --no-install-recommends python3
 
       - name: Checkout
         # SHA-pinned to close the supply-chain vector where a force-pushed
@@ -131,9 +134,26 @@ jobs:
           # Pre-snapshot of $HOME for delta semantics. Works on a non-empty
           # $HOME (the macOS leg's runner $HOME has setup state); the diff
           # is what matters, not the absolute count.
-          pre=$(find "$HOME" -mindepth 1 -print 2>/dev/null | sort)
+          # Prune runner-noise subtrees from the snapshot:
+          # - $HOME/actions-runner: the GH Actions agent rotates its
+          #   own _diag log files during the step, generating false-
+          #   positive deltas.
+          # - $HOME/work: GitHub workspace (on macOS, $GITHUB_WORKSPACE
+          #   is inside $HOME); checkout/runtime state isn't an
+          #   "install mutation."
+          # - $HOME/Library: macOS background services rotate caches/
+          #   logs continuously.
+          # On Linux containers ($HOME=/github/home or /root), none of
+          # these paths exist as $HOME children — the prune is a no-op.
+          snapshot_home() {
+            find "$HOME" -mindepth 1 \
+              \( -path "$HOME/actions-runner" -o -path "$HOME/work" -o -path "$HOME/Library" \) -prune \
+              -o -print 2>/dev/null \
+              | sort
+          }
+          pre=$(snapshot_home)
           ./install --dry-run | tee "$DRY_LOG"
-          post=$(find "$HOME" -mindepth 1 -print 2>/dev/null | sort)
+          post=$(snapshot_home)
 
           # R2: zero-mutation delta assertion.
           if ! diff <(echo "$pre") <(echo "$post"); then
@@ -231,9 +251,26 @@ jobs:
           set -eo pipefail
           DRY_LOG=$(mktemp)
 
-          pre=$(find "$HOME" -mindepth 1 -print 2>/dev/null | sort)
+          # Prune runner-noise subtrees from the snapshot:
+          # - $HOME/actions-runner: the GH Actions agent rotates its
+          #   own _diag log files during the step, generating false-
+          #   positive deltas.
+          # - $HOME/work: GitHub workspace (on macOS, $GITHUB_WORKSPACE
+          #   is inside $HOME); checkout/runtime state isn't an
+          #   "install mutation."
+          # - $HOME/Library: macOS background services rotate caches/
+          #   logs continuously.
+          # On Linux containers ($HOME=/github/home or /root), none of
+          # these paths exist as $HOME children — the prune is a no-op.
+          snapshot_home() {
+            find "$HOME" -mindepth 1 \
+              \( -path "$HOME/actions-runner" -o -path "$HOME/work" -o -path "$HOME/Library" \) -prune \
+              -o -print 2>/dev/null \
+              | sort
+          }
+          pre=$(snapshot_home)
           ./install --dry-run | tee "$DRY_LOG"
-          post=$(find "$HOME" -mindepth 1 -print 2>/dev/null | sort)
+          post=$(snapshot_home)
 
           if ! diff <(echo "$pre") <(echo "$post"); then
             echo "::error::dry-run mutated \$HOME"

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -122,11 +122,15 @@ jobs:
           submodules: recursive
 
       - name: Mark workspace safe for git inside container
-        # actions/checkout already configures safe.directory, but Dotbot
+        # actions/checkout already configures safe.directory in its own
+        # temp HOME, but that's torn down post-checkout. Dotbot then
         # invokes `git submodule update --init --recursive` from inside
-        # the install pipeline against the same workspace — make the
-        # workspace globally safe for all subsequent git invocations.
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        # the install pipeline against the same workspace and trips
+        # "fatal: detected dubious ownership."
+        # Use --system (writes /etc/gitconfig) instead of --global
+        # (writes $HOME/.gitconfig) because the next step rm's
+        # $HOME/.gitconfig — system-level config survives that.
+        run: git config --system --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: R2 + R3 (mutation-free dry-run + symlink-resolution)
         run: |

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -94,23 +94,25 @@ jobs:
       # for this repo, which ghcr.io requires.
       image: ghcr.io/${{ github.repository_owner }}/dotfiles-ci-ubuntu@sha256:8b0b7108e32229d7842c7cb876bc7f322f114e079d171d9725d1e71279dd3865
     steps:
-      - name: Install python3 (Dotbot runtime)
-        # Dotbot itself is a Python script (dotbot/bin/dotbot exec's
-        # python3 "$0"). The `ubuntu:24.04` base image used by ci/Dockerfile
-        # is the *minimal* Docker image that intentionally omits Python
-        # to keep size down. Production VPS Ubuntu Server images ship
-        # python3 as part of the base OS, which is why the VPS bootstrap
-        # works without an explicit install. Adding it here keeps the
-        # ci/Dockerfile minimal at the cost of ~5s per CI run.
-        # NOTE: `python3-minimal` strips the stdlib (no `json`, etc.); we
-        # need the full `python3` so dotbot's `import json` works. This
-        # pulls libpython3-stdlib + minor deps, ~50MB.
-        # TODO: bake `python3` into ci/Dockerfile in a follow-up PR
-        # (chicken-and-egg with publish-ci-image — image rebuilds only
-        # fire on master push).
+      - name: Install bootstrap deps (python3, sudo)
+        # The `ubuntu:24.04` base image used by ci/Dockerfile is the
+        # *minimal* Docker image that omits both python3 and sudo.
+        # Production VPS Ubuntu Server images ship both as part of the
+        # base OS, which is why the VPS bootstrap works without these.
+        # Why both:
+        # - python3 (full, not -minimal — strips stdlib): Dotbot is a
+        #   Python script (dotbot/bin/dotbot exec's python3 "$0").
+        # - sudo: helpers/install_packages.sh on Linux uses `sudo
+        #   apt-get install ...` for the apt path. Container runs as
+        #   root, so sudo is a no-op trampoline, but it still has to
+        #   exist on PATH or the helper aborts and install_tmux.sh
+        #   later fails with "tmux: command not found" (cascading).
+        # TODO: bake `python3 sudo` into ci/Dockerfile in a follow-up
+        # PR (chicken-and-egg with publish-ci-image — image rebuilds
+        # only fire on master push).
         run: |
           apt-get update -qq
-          apt-get install -y --no-install-recommends python3
+          apt-get install -y --no-install-recommends python3 sudo
 
       - name: Checkout
         # SHA-pinned to close the supply-chain vector where a force-pushed
@@ -192,6 +194,16 @@ jobs:
             echo "::error::$missing symlink target(s) missing from repo"
             exit 1
           fi
+
+      - name: Clean actions/checkout side effects in $HOME
+        # actions/checkout configures git in $HOME during its own setup
+        # phase, leaving a regular `$HOME/.gitconfig` behind. Dotbot's
+        # `~/.gitconfig: git/gitconfig` link entry then fails the real
+        # install with "already exists but is a regular file or
+        # directory" — even with `relink: true`, Dotbot refuses to
+        # delete a regular file (only existing symlinks). Remove it
+        # explicitly so Dotbot can symlink cleanly.
+        run: rm -f "$HOME/.gitconfig"
 
       - name: Apply (./install)
         run: ./install
@@ -290,6 +302,16 @@ jobs:
             echo "::error::$missing symlink target(s) missing from repo"
             exit 1
           fi
+
+      - name: Clean actions/checkout side effects in $HOME
+        # actions/checkout configures git in $HOME during its own setup
+        # phase, leaving a regular `$HOME/.gitconfig` behind. Dotbot's
+        # `~/.gitconfig: git/gitconfig` link entry then fails the real
+        # install with "already exists but is a regular file or
+        # directory" — even with `relink: true`, Dotbot refuses to
+        # delete a regular file (only existing symlinks). Remove it
+        # explicitly so Dotbot can symlink cleanly.
+        run: rm -f "$HOME/.gitconfig"
 
       - name: Apply (./install)
         run: ./install

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -362,14 +362,26 @@ jobs:
       - name: R3 assertion 1 (no hardcoded user paths)
         run: |
           set -eo pipefail
-          files=$(git ls-files -- 'zsh/**' 'helpers/**' 'brew/**' 'git/**')
+          # Fail-closed scope check: a refactor that drops a pathspec
+          # would otherwise let the assertion silently no-op. claude/**
+          # is included because Dotbot symlinks claude/settings.json,
+          # claude/commands/*.md, and claude/hooks/*.sh into ~/.claude/
+          # — they're install-pipeline content for cross-platform
+          # purposes even though they live outside the helpers/zsh tree.
+          files=$(git ls-files -- 'zsh/**' 'helpers/**' 'brew/**' 'git/**' 'claude/**')
           if [ -z "$files" ]; then
             echo "::error::scoping returned no files — file-list bug"
             exit 1
           fi
-          # Match macOS (/Users/<user>/) and Linux (/home/<user>/) home
-          # prefixes. Either is a cross-platform divergence bug.
-          if echo "$files" | xargs grep -lE '(/Users/|/home/)[^/]+/'; then
+          # Match macOS-style hardcoded /Users/<user>/ paths. We do NOT
+          # include /home/<user>/ — that prefix matches legitimate
+          # upstream paths (Linuxbrew at /home/linuxbrew/.linuxbrew, the
+          # OpenClaw container's /home/node user) where the path is the
+          # actual install location, not a hardcoded user path.
+          # `git grep` (vs `xargs grep`) handles filenames with embedded
+          # whitespace and avoids the xargs no-input edge case.
+          if git grep -l --extended-regexp '/Users/[^/]+/' -- \
+              'zsh/**' 'helpers/**' 'brew/**' 'git/**' 'claude/**'; then
             echo "::error::found hardcoded user path(s) in install-pipeline files"
             exit 1
           fi

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -1,0 +1,249 @@
+# =============================================================================
+# Install matrix — validates the install pipeline on every PR against master.
+# =============================================================================
+#
+# Two top-level jobs (linux + macos), not a strategy matrix — container-based
+# Linux + bare macOS-15 mix poorly inside one matrix and the cleaner artifact
+# is two clearly-named jobs in the PR check list.
+#
+# Linux leg pulls a digest-pinned image published by publish-ci-image.yml
+# from ghcr.io/<owner>/dotfiles-ci-ubuntu. Updating the image (touching
+# ci/Dockerfile on master) republishes and changes the digest; the pin
+# below must be updated by hand in a follow-up PR.
+#
+# Architectural caveats — what this matrix does NOT validate
+# ----------------------------------------------------------
+# 1. Machine-local config: ~/env.sh, ~/.gitconfig.local, ~/.ssh/config are
+#    untracked and per-machine. CI does not exercise their integration.
+# 2. Tailscale: hosted runners aren't on the tailnet. The sync-vps workflow
+#    covers that path on its own.
+# 3. chsh: PAM auth fails on hosted macOS. install.conf.yaml's chsh
+#    directive is CI-gated via `[[ "${CI:-false}" != "true" ]]`. If chsh
+#    breaks on a real machine we won't catch it here.
+# 4. docker-desktop runtime: the cask installs but the daemon never
+#    starts in CI. If a future helper invokes `docker ps`, gate it on
+#    the same CI env-var pattern as chsh.
+# 5. Corporate-SSL paths (work-Mac via FedEx proxy) — would require a
+#    self-hosted runner or cert-redaction strategy. Not in scope.
+# 6. Credential-pattern detection: R3's grep covers `/Users/<user>/`
+#    paths only — not API keys, OAuth tokens, JWT blobs, or service
+#    account JSON. Considered and accepted: install-pipeline files have
+#    never housed credentials, gitleaks adds tooling surface for thin
+#    marginal value. Revisit if a near-miss surfaces.
+# 7. Fork-PR trust boundary: a fork PR modifying brew/Brewfile or any
+#    helper executes that code on a hosted runner with the same trust
+#    as a same-repo PR. Personal-author repo with single-author write
+#    makes practical risk low; pull_request_target was considered and
+#    rejected (its own footgun set is worse). Document in the PR
+#    review process.
+#
+# What the matrix DOES validate (cross-platform on every PR)
+# ----------------------------------------------------------
+# R2. `./install --dry-run` produces zero $HOME mutations (delta diff).
+# R3. `./install` exits zero, no hardcoded `/Users/<user>/` paths in
+#     tracked install-pipeline files, all Dotbot-declared symlinks
+#     resolve to files inside the repo.
+# R4. `zsh -i -c true` exits cleanly post-install.
+
+name: Install matrix
+
+run-name: "Install matrix on ${{ github.event.pull_request.head.ref || github.ref_name }} by @${{ github.actor }}"
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - 'claude/**/*.md'
+  workflow_dispatch:
+
+# Cancel superseded PR runs on the same ref. Latest commit wins for PR
+# validation — orphan in-flight runs would just pin a stale tree.
+concurrency:
+  group: install-matrix-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    # Container jobs default to `sh` unless overridden — bash is needed
+    # for `<(...)` process substitution in the assertion steps. Both
+    # legs share the same shell so step bodies stay portable.
+    shell: bash
+
+jobs:
+  linux:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    container:
+      # Pinned to the digest published by publish-ci-image.yml on the
+      # PR #1a merge commit (image rev: ci/Dockerfile + Ubuntu 24.04
+      # base manifest-list). Update this hash by hand whenever the
+      # image is republished — github.repository_owner is used so
+      # owner-rename / repo-transfer doesn't break CI; it's lowercase
+      # for this repo, which ghcr.io requires.
+      image: ghcr.io/${{ github.repository_owner }}/dotfiles-ci-ubuntu@sha256:8b0b7108e32229d7842c7cb876bc7f322f114e079d171d9725d1e71279dd3865
+    steps:
+      - name: Checkout
+        # SHA-pinned to close the supply-chain vector where a force-pushed
+        # mutable tag could compromise this workflow at run time.
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          submodules: recursive
+
+      - name: Mark workspace safe for git inside container
+        # actions/checkout already configures safe.directory, but Dotbot
+        # invokes `git submodule update --init --recursive` from inside
+        # the install pipeline against the same workspace — make the
+        # workspace globally safe for all subsequent git invocations.
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: R2 + R3 (mutation-free dry-run + symlink-resolution)
+        run: |
+          set -eo pipefail
+          DRY_LOG=$(mktemp)
+
+          # Pre-snapshot of $HOME for delta semantics. Works on a non-empty
+          # $HOME (the macOS leg's runner $HOME has setup state); the diff
+          # is what matters, not the absolute count.
+          pre=$(find "$HOME" -mindepth 1 -print 2>/dev/null | sort)
+          ./install --dry-run | tee "$DRY_LOG"
+          post=$(find "$HOME" -mindepth 1 -print 2>/dev/null | sort)
+
+          # R2: zero-mutation delta assertion.
+          if ! diff <(echo "$pre") <(echo "$post"); then
+            echo "::error::dry-run mutated \$HOME"
+            exit 1
+          fi
+
+          # R3 assertion 2: every "Would create symlink/hardlink X -> Y"
+          # target Y must exist in the repo. Strict prefix match against
+          # Dotbot's link-plugin emitter (see
+          # dotbot/src/dotbot/plugins/link.py:350 — format is
+          # "Would create {symlink|hardlink} {link_name} -> {target_path}").
+          # Color is auto-disabled when stdout is piped (use_color falls
+          # back to sys.stdout.isatty()), so no ANSI stripping needed.
+          #
+          # Fresh-runner sanity check: on a CI runner with empty $HOME,
+          # every link directive must produce a "Would create" line. Zero
+          # lines means either Dotbot's output format changed or $HOME is
+          # pre-populated — both should fail loudly, not silently pass.
+          created=$(grep -cE '^Would create (sym|hard)link ' "$DRY_LOG" || true)
+          if [ "${created:-0}" -eq 0 ]; then
+            echo "::error::expected ≥1 'Would create symlink' line in dry-run output (fresh CI runner). Output format change or pre-populated \$HOME?"
+            exit 1
+          fi
+
+          missing=0
+          while IFS= read -r line; do
+            target="${line##*-> }"
+            if [ -z "$target" ]; then continue; fi
+            if [ ! -e "$target" ]; then
+              echo "::error::Dotbot symlink target missing: $target  (from: $line)"
+              missing=$((missing + 1))
+            fi
+          done < <(grep -E '^Would create (sym|hard)link ' "$DRY_LOG" || true)
+          if [ "$missing" -gt 0 ]; then
+            echo "::error::$missing symlink target(s) missing from repo"
+            exit 1
+          fi
+
+      - name: Apply (./install)
+        run: ./install
+
+      - name: R3 assertion 1 (no hardcoded user paths)
+        run: |
+          set -eo pipefail
+          # Fail-closed: a scoping bug that returns an empty file list
+          # would otherwise let an empty xargs pipeline pass silently.
+          files=$(git ls-files -- 'zsh/**' 'helpers/**' 'brew/**' 'git/**')
+          if [ -z "$files" ]; then
+            echo "::error::scoping returned no files — file-list bug"
+            exit 1
+          fi
+          if echo "$files" | xargs grep -lE '/Users/[^/]+/'; then
+            echo "::error::found hardcoded user path(s) in install-pipeline files"
+            exit 1
+          fi
+
+      - name: R4 assertion (zsh -i -c true exits cleanly)
+        # Per docs/solutions/code-quality/zsh-dash-i-c-exit-false-positive-health-check.md:
+        # use `true` not `exit` — `exit` exits the shell before any plugin
+        # init that might fail can run, masking regressions.
+        run: zsh -i -c true
+
+  macos:
+    runs-on: macos-15
+    timeout-minutes: 45
+    env:
+      # Cuts metadata churn on a Brew-heavy install. CI=true is set by
+      # GitHub Actions but pinned for clarity — install.conf.yaml's chsh
+      # directive consults it.
+      HOMEBREW_NO_AUTO_UPDATE: '1'
+      HOMEBREW_NO_INSTALL_CLEANUP: '1'
+      CI: 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          submodules: recursive
+
+      - name: Cache Homebrew downloads + API
+        # Restore-keys deliberately omits a Brewfile-hash subset — that
+        # would let a stale cache survive a Brewfile change. Helper
+        # changes also bust the cache via hashFiles('helpers/**').
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        with:
+          path: |
+            ~/Library/Caches/Homebrew/downloads
+            ~/Library/Caches/Homebrew/api
+          key: ${{ runner.os }}-${{ runner.arch }}-brew-${{ hashFiles('brew/Brewfile', 'helpers/**') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-brew-
+
+      - name: R2 + R3 (mutation-free dry-run + symlink-resolution)
+        run: |
+          set -eo pipefail
+          DRY_LOG=$(mktemp)
+
+          pre=$(find "$HOME" -mindepth 1 -print 2>/dev/null | sort)
+          ./install --dry-run | tee "$DRY_LOG"
+          post=$(find "$HOME" -mindepth 1 -print 2>/dev/null | sort)
+
+          if ! diff <(echo "$pre") <(echo "$post"); then
+            echo "::error::dry-run mutated \$HOME"
+            exit 1
+          fi
+
+          missing=0
+          while IFS= read -r line; do
+            target="${line##*-> }"
+            if [ -z "$target" ]; then continue; fi
+            if [ ! -e "$target" ]; then
+              echo "::error::Dotbot symlink target missing: $target  (from: $line)"
+              missing=$((missing + 1))
+            fi
+          done < <(grep -E '^Would create (sym|hard)link ' "$DRY_LOG" || true)
+          if [ "$missing" -gt 0 ]; then
+            echo "::error::$missing symlink target(s) missing from repo"
+            exit 1
+          fi
+
+      - name: Apply (./install)
+        run: ./install
+
+      - name: R3 assertion 1 (no hardcoded user paths)
+        run: |
+          set -eo pipefail
+          files=$(git ls-files -- 'zsh/**' 'helpers/**' 'brew/**' 'git/**')
+          if [ -z "$files" ]; then
+            echo "::error::scoping returned no files — file-list bug"
+            exit 1
+          fi
+          if echo "$files" | xargs grep -lE '/Users/[^/]+/'; then
+            echo "::error::found hardcoded user path(s) in install-pipeline files"
+            exit 1
+          fi
+
+      - name: R4 assertion (zsh -i -c true exits cleanly)
+        run: zsh -i -c true

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -36,6 +36,11 @@
 #    makes practical risk low; pull_request_target was considered and
 #    rejected (its own footgun set is worse). Document in the PR
 #    review process.
+# 8. macos-15 / ubuntu-24.04 runner-image rotation: GitHub re-bakes
+#    these labels periodically (security patches, toolchain bumps).
+#    A surprise green-to-red on an unchanged commit usually means a
+#    runner-image refresh — consult the actions/runner-images repo's
+#    release notes before debugging the install pipeline.
 #
 # What the matrix DOES validate (cross-platform on every PR)
 # ----------------------------------------------------------
@@ -57,6 +62,13 @@ on:
       - '**.md'
       - 'claude/**/*.md'
   workflow_dispatch:
+
+# Least-privilege: the workflow only needs to read the repo. No issue
+# writes, no package writes, no token-scoped externalization. Sibling
+# publish-ci-image.yml asks for `packages: write` because it has to;
+# this one explicitly asks for nothing more than `contents: read`.
+permissions:
+  contents: read
 
 # Cancel superseded PR runs on the same ref. Latest commit wins for PR
 # validation — orphan in-flight runs would just pin a stale tree.
@@ -107,9 +119,9 @@ jobs:
         #   root, so sudo is a no-op trampoline, but it still has to
         #   exist on PATH or the helper aborts and install_tmux.sh
         #   later fails with "tmux: command not found" (cascading).
-        # TODO: bake `python3 sudo` into ci/Dockerfile in a follow-up
-        # PR (chicken-and-egg with publish-ci-image — image rebuilds
-        # only fire on master push).
+        # TODO(#58): bake `python3 sudo` into ci/Dockerfile in a
+        # follow-up PR (chicken-and-egg with publish-ci-image — image
+        # rebuilds only fire on master push).
         run: |
           apt-get update -qq
           apt-get install -y --no-install-recommends python3 sudo
@@ -215,22 +227,38 @@ jobs:
       - name: R3 assertion 1 (no hardcoded user paths)
         run: |
           set -eo pipefail
-          # Fail-closed: a scoping bug that returns an empty file list
-          # would otherwise let an empty xargs pipeline pass silently.
-          files=$(git ls-files -- 'zsh/**' 'helpers/**' 'brew/**' 'git/**')
+          # Fail-closed scope check: a refactor that drops a pathspec
+          # would otherwise let the assertion silently no-op. claude/**
+          # is included because Dotbot symlinks claude/settings.json,
+          # claude/commands/*.md, and claude/hooks/*.sh into ~/.claude/
+          # — they're install-pipeline content for cross-platform
+          # purposes even though they live outside the helpers/zsh tree.
+          files=$(git ls-files -- 'zsh/**' 'helpers/**' 'brew/**' 'git/**' 'claude/**')
           if [ -z "$files" ]; then
             echo "::error::scoping returned no files — file-list bug"
             exit 1
           fi
-          if echo "$files" | xargs grep -lE '/Users/[^/]+/'; then
+          # Match macOS-style hardcoded /Users/<user>/ paths. We do NOT
+          # include /home/<user>/ — that prefix matches legitimate
+          # upstream paths (Linuxbrew at /home/linuxbrew/.linuxbrew, the
+          # OpenClaw container's /home/node user) where the path is the
+          # actual install location, not a hardcoded user path.
+          # `git grep` (vs `xargs grep`) handles filenames with embedded
+          # whitespace and avoids the xargs no-input edge case.
+          if git grep -l --extended-regexp '/Users/[^/]+/' -- \
+              'zsh/**' 'helpers/**' 'brew/**' 'git/**' 'claude/**'; then
             echo "::error::found hardcoded user path(s) in install-pipeline files"
             exit 1
           fi
 
       - name: R4 assertion (zsh -i -c true exits cleanly)
         # Per docs/solutions/code-quality/zsh-dash-i-c-exit-false-positive-health-check.md:
-        # use `true` not `exit` — `exit` exits the shell before any plugin
-        # init that might fail can run, masking regressions.
+        # use `true` not `exit` — `zsh -i -c exit` returns the exit
+        # status of the last statement in .zshrc (because `exit` with no
+        # arg inherits $?), so a trailing `[[ -f /missing ]]` silently
+        # propagates 1 from a clean shell. `-c true` always exits 0
+        # unless init itself errored, making this a real "did init
+        # complete cleanly?" probe.
         run: zsh -i -c true
 
   macos:
@@ -293,6 +321,17 @@ jobs:
             exit 1
           fi
 
+          # Fresh-runner sanity check (mirrors the Linux leg): on a CI
+          # runner with empty $HOME, every link directive must produce a
+          # "Would create" line. Zero lines means either Dotbot's output
+          # format changed or $HOME is pre-populated — both should fail
+          # loudly, not silently pass.
+          created=$(grep -cE '^Would create (sym|hard)link ' "$DRY_LOG" || true)
+          if [ "${created:-0}" -eq 0 ]; then
+            echo "::error::expected ≥1 'Would create symlink' line in dry-run output (fresh CI runner). Output format change or pre-populated \$HOME?"
+            exit 1
+          fi
+
           missing=0
           while IFS= read -r line; do
             target="${line##*-> }"
@@ -328,7 +367,9 @@ jobs:
             echo "::error::scoping returned no files — file-list bug"
             exit 1
           fi
-          if echo "$files" | xargs grep -lE '/Users/[^/]+/'; then
+          # Match macOS (/Users/<user>/) and Linux (/home/<user>/) home
+          # prefixes. Either is a cross-platform divergence bug.
+          if echo "$files" | xargs grep -lE '(/Users/|/home/)[^/]+/'; then
             echo "::error::found hardcoded user path(s) in install-pipeline files"
             exit 1
           fi

--- a/claude/commands/handoff.md
+++ b/claude/commands/handoff.md
@@ -10,7 +10,7 @@ Optionally scope it: `/handoff hero section` or `/handoff PR 28 work`.
 
 ### Step 1 — Gather context
 ```bash
-export PATH="/Users/dvillavicencio/.config/nvm/versions/node/v24.13.0/bin:$PATH"
+export PATH="$HOME/.config/nvm/versions/node/v24.13.0/bin:$PATH"
 
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")
 

--- a/claude/commands/pickup.md
+++ b/claude/commands/pickup.md
@@ -18,7 +18,7 @@ git status --short
 
 ### Step 2 — Load supporting context
 ```bash
-export PATH="/Users/dvillavicencio/.config/nvm/versions/node/v24.13.0/bin:$PATH"
+export PATH="$HOME/.config/nvm/versions/node/v24.13.0/bin:$PATH"
 
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")
 

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -78,7 +78,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "sh /Users/dvillavicencio/.claude/statusline-command.sh"
+    "command": "sh \"$HOME/.claude/statusline-command.sh\""
   },
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,

--- a/claude/skills/tmux-window-namer/SKILL.md
+++ b/claude/skills/tmux-window-namer/SKILL.md
@@ -74,7 +74,7 @@ cd "<pane_current_path>" 2>/dev/null && git branch --show-current 2>/dev/null
 From these, synthesize a **one-line prediction** of what the window is
 about. Examples:
 
-- `pane_current_command=claude path=/Users/.../dotfiles` → "Claude Code session in the dotfiles repo"
+- `pane_current_command=claude path=.../dotfiles` → "Claude Code session in the dotfiles repo"
 - `pane_current_command=nvim path=.../every-site` + `Gemfile` + `app/` → "Rails backend for the Every site"
 - `pane_current_command=psql` → "postgres client"
 - `pane_current_command=btop` → "system monitor"

--- a/docs/solutions/cross-machine/install-matrix-seeded-failure-evidence-2026-05-03.md
+++ b/docs/solutions/cross-machine/install-matrix-seeded-failure-evidence-2026-05-03.md
@@ -1,0 +1,120 @@
+---
+title: "install-matrix.yml seeded-failure validation evidence (origin SC#1)"
+date: 2026-05-03
+category: cross-machine
+tags:
+  - github-actions
+  - install-matrix
+  - validation
+  - seeded-failure
+  - origin-sc1
+severity: Informational
+component: ".github/workflows/install-matrix.yml — R3 assertion 1 (no hardcoded user paths)"
+problem_type: "validation evidence"
+module: "install-matrix CI workflow"
+related_solutions:
+  - "docs/plans/2026-05-03-001-feat-ci-install-matrix-plan.md — the plan whose origin Success Criterion #1 this satisfies"
+  - "docs/solutions/cross-machine/sync-vps-dry-run-previews-current-head.md — sibling cross-machine workflow"
+---
+
+## Why this exists
+
+The plan for `feat/ci-install-matrix` (PR #57) requires manual seeded-failure
+validation per origin SC#1 — proving that a deliberate, in-scope regression
+red-CIs both Linux and macOS legs at the *correct* assertion before the matrix
+is allowed to merge. Without this round, we'd ship a CI workflow whose green
+status meant only "the workflow ran without errors," not "the assertions
+actually have teeth." This doc is the durable record so future readers can see
+what was tested and what fired.
+
+## What was tested
+
+A single line was added to `helpers/install_node.sh` (a tracked install-pipeline
+file inside the R3 grep scope):
+
+```
+# SEEDED-FAILURE-2026-05-03: deliberate hardcoded /Users/dvillavicencio/Downloads/foo
+# path to verify R3 assertion 1 trips on both legs. REVERT BEFORE MERGE.
+```
+
+The literal `/Users/dvillavicencio/Downloads/foo` substring matches the R3
+grep regex `/Users/[^/]+/`. No other change.
+
+## Why this bug class
+
+Origin SC#1 names three regression classes — cross-platform divergence,
+fresh-`$HOME` mutation, and shell-startup regression. A hardcoded user path is
+the canonical cross-platform divergence bug: the path resolves on one machine
+but breaks bootstrap on every other. R3 assertion 1 is the matrix's first line
+of defense against this exact class. It's also the cheapest assertion to
+exercise (a `grep` against tracked files, no install state required), so the
+evidence is unambiguous and not coupled to install-pipeline timing or runner
+flakiness.
+
+## Run details
+
+- **Run ID**: `25293491791` ([url](https://github.com/villavicencio/dotfiles/actions/runs/25293491791))
+- **Branch**: `feat/ci-install-matrix`
+- **Seeded commit**: `6db87f9` — *SEEDED FAILURE: hardcoded /Users/dvillavicencio/ in install_node.sh*
+- **Linux job**: `74148651331` — failed in **1m 6s**
+- **macOS job**: `74148651338` — failed in **10m 8s**
+
+## Step-by-step results (per leg)
+
+| Step | Linux conclusion | macOS conclusion |
+| --- | --- | --- |
+| Set up job | ✅ success | ✅ success |
+| Bootstrap deps (python3, sudo) / Cache restore | ✅ success | ✅ success |
+| Checkout | ✅ success | ✅ success |
+| Mark workspace safe (Linux only) | ✅ success | n/a |
+| **R2 + R3 dry-run / symlink-resolution** | ✅ success | ✅ success |
+| Clean `$HOME/.gitconfig` | ✅ success | ✅ success |
+| **Apply (./install)** | ✅ success | ✅ success |
+| **R3 assertion 1 (no hardcoded user paths)** | ❌ **failure** | ❌ **failure** |
+| R4 assertion (`zsh -i -c true`) | ⏭ skipped (R3 short-circuited) | ⏭ skipped (R3 short-circuited) |
+
+## Failure messages captured
+
+Both legs emitted the same xargs-grep output (the file with the offending path)
+followed by the workflow-level error annotation:
+
+**Linux (`74148651331`)**:
+```
+2026-05-03T23:09:45.9682610Z helpers/install_node.sh
+2026-05-03T23:09:45.9716645Z ##[error]found hardcoded user path(s) in install-pipeline files
+```
+
+**macOS (`74148651338`)**:
+```
+2026-05-03T23:18:44.2731270Z helpers/install_node.sh
+2026-05-03T23:18:44.2783110Z ##[error]found hardcoded user path(s) in install-pipeline files
+```
+
+## What this proves
+
+1. **R3 assertion 1 has teeth.** Both legs surfaced the offending file by name
+   and aborted the job at the correct step.
+2. **Apply succeeded before R3 fired.** The seeded comment didn't break
+   `./install` (it's a comment, no runtime impact), so the assertion failure is
+   genuinely catching a *would-be-merged* bug rather than collateral install
+   damage.
+3. **R4 short-circuited correctly.** Skipped on both legs because R3 failed
+   first; the matrix doesn't waste runtime on later assertions when an earlier
+   one trips.
+4. **Cross-platform parity.** Identical failure mode and output on Linux
+   container and macOS-15 bare runner.
+
+## Cleanup
+
+The seeded commit was reverted before merge (see commit immediately following
+`6db87f9` on this branch). The next CI run on this branch returned both legs
+to green.
+
+## Operational notes for future seeded rounds
+
+- This kind of validation belongs in PRs that change *what the matrix
+  asserts*, not every PR. R2/R3/R4 are stable and don't need re-validation
+  unless their assertion logic is materially edited.
+- For a future expansion (e.g., adding a credential-pattern grep), repeat
+  this dance with a seeded fake credential and a corresponding evidence doc
+  under this same directory.

--- a/helpers/install_node.sh
+++ b/helpers/install_node.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-# SEEDED-FAILURE-2026-05-03: deliberate hardcoded /Users/dvillavicencio/Downloads/foo
-# path to verify R3 assertion 1 trips on both legs. REVERT BEFORE MERGE.
 # fail-fast so a broken `nvm install` / `npm install -g` cannot fall through
 # to the symlink refresh below — stale links into a non-existent node tree
 # would otherwise look like a successful install to Dotbot.

--- a/helpers/install_node.sh
+++ b/helpers/install_node.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# SEEDED-FAILURE-2026-05-03: deliberate hardcoded /Users/dvillavicencio/Downloads/foo
+# path to verify R3 assertion 1 trips on both legs. REVERT BEFORE MERGE.
 # fail-fast so a broken `nvm install` / `npm install -g` cannot fall through
 # to the symlink refresh below — stale links into a non-existent node tree
 # would otherwise look like a successful install to Dotbot.

--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -38,7 +38,19 @@
     - command: bash helpers/install_omz.sh
       description: "Installing omz + plugins"
       quiet: true
-    - [chsh -s $(which zsh), Making zsh the default shell]
+    # chsh is CI-gated: PAM auth fails on hosted GitHub Actions macOS
+    # runners and would break .github/workflows/install-matrix.yml's
+    # exit-zero assertion. Skipping in CI is safe — the chsh path is
+    # exercised on real machines via the install runbook. Block style
+    # is intentional: the inline `[cmd, desc]` flow form trips YAML's
+    # `&` anchor parser on the `&&` here.
+    - command: |
+        if [ "${CI:-false}" != "true" ]; then
+          chsh -s $(which zsh)
+        else
+          echo "skipping chsh in CI"
+        fi
+      description: Making zsh the default shell (skipped in CI)
 
 - link:
     ~/.config/zsh/.zshenv: zsh/zshenv


### PR DESCRIPTION
## Summary

PR #1b of the [CE trifecta](https://github.com/villavicencio/dotfiles/blob/master/docs/brainstorms/2026-05-02-compound-engineering-trifecta-requirements.md) — consumes the image PR #1a published ([#56](https://github.com/villavicencio/dotfiles/pull/56)) and validates the install pipeline cross-platform on every PR.

- **`.github/workflows/install-matrix.yml`** — two top-level jobs (`linux:` + `macos:`), not a strategy matrix. Linux pulls the digest-pinned image (`ghcr.io/villavicencio/dotfiles-ci-ubuntu@sha256:8b0b7108…3865`). macOS-15 runs bare with a Brew downloads + API cache.
- **`install.conf.yaml`** — chsh directive CI-gated (`CI != true`) so PAM auth doesn't fail R3 on hosted macOS. Switched from inline `[cmd, desc]` flow to block style (the `&&` in the inline form trips YAML's `&` anchor parser).

Each leg asserts:
- **R2** — `./install --dry-run` produces zero `$HOME` mutations (delta diff of `find $HOME -mindepth 1`).
- **R3** — `./install` exits zero; no hardcoded `/Users/<user>/` paths in tracked install-pipeline files; every Dotbot-declared symlink target exists in the repo (parsed from `Would create symlink X -> Y` lines, with a fresh-runner sanity check that ≥1 such line emits).
- **R4** — `zsh -i -c true` exits cleanly post-install.

Third-party actions are SHA-pinned (`actions/checkout@34e114876b…`, `actions/cache@0057852bfa…`).

## Resolutions for plan RBIs

| RBI | Resolution | Rationale |
| --- | --- | --- |
| Fork-PR trust boundary | Accept + document in caveats block | Personal-author repo with single-author write; `pull_request_target` introduces a worse footgun set |
| Credential pattern detection (R3 expansion) | Accept the gap + document | Install-pipeline files have never housed credentials; gitleaks adds tooling surface for thin marginal value. Revisit on near-miss |
| Inline architectural-caveats comment block | Include (was U4 in the plan) | Top-of-file YAML comment block enumerates 7 caveats |

## Test plan

- [ ] Both CI legs run green on this PR's first commit.
- [ ] Manual seeded-failure validation: add a temp commit that breaks bootstrap (e.g., introduce hardcoded `/Users/foo/` in a helper, or `read || return 0` in zshrc), confirm both legs red-CI at the *correct* assertion, capture evidence under `docs/solutions/cross-machine/install-matrix-seeded-failure-evidence-2026-05-03.md`, revert before merge.
- [ ] Squash merge collapses to a single master commit.

## Deferred

- Image-digest auto-update workflow (manual updates for now).
- Standalone CI section in CLAUDE.md / README (caveats live as a YAML comment block at the top of the workflow).
- Gitleaks / credential-pattern detection (RBI accept).
- Stricter fork-PR trust boundary via `pull_request_target` (RBI accept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)