### PR TITLE
ci(dockerfile): bake python3 + sudo into base image (#58 step 1/2)

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -34,7 +34,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # helpers (install_tmux.sh etc.) cascade-fail with "tmux: command not
 # found". An earlier image revision left sudo out and install-matrix.yml
 # had to apt-install it at runtime as a workflow bootstrap step (see
-# closed issue #58); baking it in here removes that round-trip.
+# issue #58); baking it in here removes that round-trip.
 #
 # python3 (not python3-minimal): Dotbot is a Python script
 # (dotbot/bin/dotbot exec's python3 "$0") and does `import json` /

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -27,13 +27,28 @@ FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Container runs as root (no USER directive). sudo is intentionally not
-# installed — it would be dead code at root and adds CVE surface.
+# Container runs as root (no USER directive). sudo is still required even
+# at root because helpers/install_packages.sh on Linux invokes
+# `sudo apt-get install ...` — at root sudo acts as a no-op trampoline
+# but the binary must resolve on PATH or the helper aborts and downstream
+# helpers (install_tmux.sh etc.) cascade-fail with "tmux: command not
+# found". An earlier image revision left sudo out and install-matrix.yml
+# had to apt-install it at runtime as a workflow bootstrap step (see
+# closed issue #58); baking it in here removes that round-trip.
+#
+# python3 (not python3-minimal): Dotbot is a Python script
+# (dotbot/bin/dotbot exec's python3 "$0") and does `import json` /
+# `import yaml` at startup. python3-minimal strips the stdlib, so
+# `import json` raises ModuleNotFoundError. The full python3
+# metapackage pulls libpython3-stdlib (~45MB) and matches what
+# Ubuntu Server (the VPS production target) ships out of the box.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
         git \
+        python3 \
+        sudo \
         zsh \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

- Bake \`python3\` and \`sudo\` into \`ci/Dockerfile\` so the install-matrix Linux leg can drop its runtime \`apt-get install\` bootstrap step (closes the chicken-and-egg in #58).
- Correct the prior \"sudo is intentionally not installed\" comment, which was load-bearing-wrong: \`helpers/install_packages.sh\` requires \`sudo\` on PATH even when the container runs as root (no-op trampoline). Documenting the corrected reasoning so a future reader doesn't strip it again.
- Use full \`python3\` (not \`python3-minimal\`) — Dotbot does \`import json\` / \`import yaml\` at startup; minimal strips libpython3-stdlib and \`import json\` raises \`ModuleNotFoundError\`.

## Why two PRs

This PR has to merge first to trigger \`publish-ci-image.yml\` and republish the image with a new sha256 digest. A follow-up PR will (a) bump the digest pin in \`install-matrix.yml\` and (b) delete the \"Install bootstrap deps\" step, fully closing #58.

Doing both inside one PR would either red-CI this PR (the install-matrix workflow on this branch still pins the *old* digest, which lacks python3+sudo, but no longer has the runtime apt-install step to compensate) or require maintaining the bootstrap step as conditional, which is more complexity than the round-trip.

## Test plan

- [ ] CI green on this PR (install-matrix.yml pins the old image but bootstraps python3+sudo at runtime — should pass unchanged; this PR doesn't touch install-matrix.yml).
- [ ] After merge, \`publish-ci-image.yml\` runs and emits a new digest in its run summary.
- [ ] Follow-up PR (step 2/2) bumps the pin + removes the bootstrap step, both legs green.

## Image size impact

~45MB (libpython3-stdlib via the python3 metapackage). Matches Ubuntu Server's baseline, the VPS production target.

## Related

- Closes #58 (after step 2/2 lands).
- Issue body: bake python3 + sudo into ci/Dockerfile.