### PR TITLE
ci(install-matrix): bump digest pin + locale-block correctness fixes

### DIFF
--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -99,33 +99,15 @@ jobs:
     timeout-minutes: 20
     container:
       # Pinned to the digest published by publish-ci-image.yml on the
-      # PR #1a merge commit (image rev: ci/Dockerfile + Ubuntu 24.04
-      # base manifest-list). Update this hash by hand whenever the
-      # image is republished — github.repository_owner is used so
-      # owner-rename / repo-transfer doesn't break CI; it's lowercase
-      # for this repo, which ghcr.io requires.
-      image: ghcr.io/${{ github.repository_owner }}/dotfiles-ci-ubuntu@sha256:8b0b7108e32229d7842c7cb876bc7f322f114e079d171d9725d1e71279dd3865
+      # most recent ci/Dockerfile master push. Update this hash by hand
+      # after each republish — fetch from `docker buildx imagetools
+      # inspect ghcr.io/<owner>/dotfiles-ci-ubuntu:24.04`. The image
+      # bakes in python3 + sudo (per #58) so no runtime apt-bootstrap
+      # is needed. github.repository_owner is used so owner-rename /
+      # repo-transfer doesn't break CI; it's lowercase for this repo,
+      # which ghcr.io requires.
+      image: ghcr.io/${{ github.repository_owner }}/dotfiles-ci-ubuntu@sha256:758af964844df9c58c87669d31812cbda6655e78e8c94f66387bd0338651a6d6
     steps:
-      - name: Install bootstrap deps (python3, sudo)
-        # The `ubuntu:24.04` base image used by ci/Dockerfile is the
-        # *minimal* Docker image that omits both python3 and sudo.
-        # Production VPS Ubuntu Server images ship both as part of the
-        # base OS, which is why the VPS bootstrap works without these.
-        # Why both:
-        # - python3 (full, not -minimal — strips stdlib): Dotbot is a
-        #   Python script (dotbot/bin/dotbot exec's python3 "$0").
-        # - sudo: helpers/install_packages.sh on Linux uses `sudo
-        #   apt-get install ...` for the apt path. Container runs as
-        #   root, so sudo is a no-op trampoline, but it still has to
-        #   exist on PATH or the helper aborts and install_tmux.sh
-        #   later fails with "tmux: command not found" (cascading).
-        # TODO(#58): bake `python3 sudo` into ci/Dockerfile in a
-        # follow-up PR (chicken-and-egg with publish-ci-image — image
-        # rebuilds only fire on master push).
-        run: |
-          apt-get update -qq
-          apt-get install -y --no-install-recommends python3 sudo
-
       - name: Checkout
         # SHA-pinned to close the supply-chain vector where a force-pushed
         # mutable tag could compromise this workflow at run time.

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -108,6 +108,24 @@ jobs:
       # which ghcr.io requires.
       image: ghcr.io/${{ github.repository_owner }}/dotfiles-ci-ubuntu@sha256:758af964844df9c58c87669d31812cbda6655e78e8c94f66387bd0338651a6d6
     steps:
+      - name: Warm up apt cache
+        # Even though python3 + sudo are now baked into the image
+        # (per #58 / PR #62 / commit 6a8cd43), we still need an early
+        # apt-get update to populate /var/lib/apt/lists/* (which the
+        # ci/Dockerfile RUN block strips after image build) before
+        # downstream apt invocations run.
+        #
+        # Empirically this also serves as a network warm-up: without
+        # it, individual apt-get invocations later in the pipeline
+        # (locale install, helpers/install_packages.sh) hang ~60s per
+        # parallel connection on IPv6 timeout fallback, compounding
+        # past the 20-min job timeout. See run 25347298749 for the
+        # failure mode evidence. Once we have a clean fix for the apt
+        # warmth issue at the image level, this step can be removed.
+        # The empty `apt-get install` is intentional — populates apt
+        # state without installing anything (python3 + sudo are
+        # already present from the image bake).
+        run: apt-get update -qq
       - name: Checkout
         # SHA-pinned to close the supply-chain vector where a force-pushed
         # mutable tag could compromise this workflow at run time.

--- a/helpers/install_packages.sh
+++ b/helpers/install_packages.sh
@@ -16,18 +16,10 @@ else
       exit 0
     fi
 
-    # Force IPv4 + short connect timeout for apt. GH Actions container
-    # IPv6 reachability to Ubuntu mirrors is unreliable; apt's default
-    # connect timeout is 120s per stuck connection, which compounds to
-    # the 20-min job timeout when many parallel slots all retry.
-    # No-op on the VPS where dual-stack works. See install-linux.conf.yaml
-    # locale block for the matching directive in /etc/apt/apt.conf.d/.
-    APT_OPTS="-o Acquire::ForceIPv4=true -o Acquire::http::Timeout=20"
-
-    sudo apt-get $APT_OPTS update -qq
+    sudo apt-get update -qq
 
     # Core CLI tools (apt equivalents of Brewfile)
-    sudo apt-get $APT_OPTS install -y \
+    sudo apt-get install -y \
         bat btop curl fd-find fzf gawk git jq \
         ncdu neovim ripgrep shellcheck tig tmux \
         tree watch wget zsh build-essential cmake \
@@ -40,7 +32,7 @@ else
             | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null
         echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
             | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-        sudo apt-get $APT_OPTS update -qq && sudo apt-get $APT_OPTS install -y gh
+        sudo apt-get update -qq && sudo apt-get install -y gh
     fi
 
     # Starship prompt

--- a/helpers/install_packages.sh
+++ b/helpers/install_packages.sh
@@ -16,10 +16,18 @@ else
       exit 0
     fi
 
-    sudo apt-get update -qq
+    # Force IPv4 + short connect timeout for apt. GH Actions container
+    # IPv6 reachability to Ubuntu mirrors is unreliable; apt's default
+    # connect timeout is 120s per stuck connection, which compounds to
+    # the 20-min job timeout when many parallel slots all retry.
+    # No-op on the VPS where dual-stack works. See install-linux.conf.yaml
+    # locale block for the matching directive in /etc/apt/apt.conf.d/.
+    APT_OPTS="-o Acquire::ForceIPv4=true -o Acquire::http::Timeout=20"
+
+    sudo apt-get $APT_OPTS update -qq
 
     # Core CLI tools (apt equivalents of Brewfile)
-    sudo apt-get install -y \
+    sudo apt-get $APT_OPTS install -y \
         bat btop curl fd-find fzf gawk git jq \
         ncdu neovim ripgrep shellcheck tig tmux \
         tree watch wget zsh build-essential cmake \
@@ -32,7 +40,7 @@ else
             | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null
         echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
             | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-        sudo apt-get update -qq && sudo apt-get install -y gh
+        sudo apt-get $APT_OPTS update -qq && sudo apt-get $APT_OPTS install -y gh
     fi
 
     # Starship prompt

--- a/install-linux.conf.yaml
+++ b/install-linux.conf.yaml
@@ -31,8 +31,17 @@
       quiet: true
     - command: |
         if [ "${DOTFILES_DRY_RUN:-0}" = "1" ]; then
-          echo "[dry-run] would apt-get update + install locales + locale-gen en_US.UTF-8 + update-locale"
+          echo "[dry-run] would force-IPv4 apt + apt-get update + install locales + locale-gen en_US.UTF-8 + update-locale"
         else
+          # Force-IPv4 for apt across the whole install pipeline.
+          # Some GH Actions runner network configs route container
+          # IPv6 to a black hole; apt then hangs ~60s per connection
+          # waiting for the IPv6 timeout before falling back to IPv4.
+          # Multiple apt invocations downstream (this block, plus
+          # helpers/install_packages.sh) compound the penalty into the
+          # 20-min job timeout. On the VPS Ubuntu Server has working
+          # dual-stack so this is a no-op there.
+          echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4 >/dev/null
           # apt-get update is required: this command runs BEFORE
           # install_packages.sh (which does its own update), and the
           # ci/Dockerfile minimal base strips /var/lib/apt/lists/*.

--- a/install-linux.conf.yaml
+++ b/install-linux.conf.yaml
@@ -41,14 +41,19 @@
           # helpers/install_packages.sh) compound the penalty into the
           # 20-min job timeout. On the VPS Ubuntu Server has working
           # dual-stack so this is a no-op there.
-          echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4 >/dev/null
+          # Visible echo so CI logs confirm the file was written.
+          echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4
+          # Belt + suspenders: pass `-o Acquire::ForceIPv4=true` on each
+          # apt invocation directly so the directive applies even if
+          # apt's conf-d read order shifts in a future Ubuntu release.
+          APT_OPTS="-o Acquire::ForceIPv4=true -o Acquire::http::Timeout=20"
           # apt-get update is required: this command runs BEFORE
           # install_packages.sh (which does its own update), and the
           # ci/Dockerfile minimal base strips /var/lib/apt/lists/*.
           # On the VPS Ubuntu Server has lists populated; in CI the
           # cache is empty and `apt-get install locales` would fail
           # with "Unable to locate package locales".
-          sudo apt-get update -qq
+          sudo apt-get $APT_OPTS update -qq
           # DEBIAN_FRONTEND=noninteractive must be passed THROUGH sudo
           # via the leading env-prefix syntax — sudo's default env_reset
           # strips the env var set by ci/Dockerfile. The `locales`
@@ -57,7 +62,7 @@
           # hangs on a non-tty CI runner waiting for stdin that never
           # comes. The VPS doesn't hit this because Ubuntu Server ships
           # the package preinstalled.
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y locales
+          sudo DEBIAN_FRONTEND=noninteractive apt-get $APT_OPTS install -y locales
           sudo locale-gen en_US.UTF-8
           sudo update-locale LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
         fi

--- a/install-linux.conf.yaml
+++ b/install-linux.conf.yaml
@@ -33,27 +33,13 @@
         if [ "${DOTFILES_DRY_RUN:-0}" = "1" ]; then
           echo "[dry-run] would force-IPv4 apt + apt-get update + install locales + locale-gen en_US.UTF-8 + update-locale"
         else
-          # Force-IPv4 for apt across the whole install pipeline.
-          # Some GH Actions runner network configs route container
-          # IPv6 to a black hole; apt then hangs ~60s per connection
-          # waiting for the IPv6 timeout before falling back to IPv4.
-          # Multiple apt invocations downstream (this block, plus
-          # helpers/install_packages.sh) compound the penalty into the
-          # 20-min job timeout. On the VPS Ubuntu Server has working
-          # dual-stack so this is a no-op there.
-          # Visible echo so CI logs confirm the file was written.
-          echo 'Acquire::ForceIPv4 "true";' | sudo tee /etc/apt/apt.conf.d/99force-ipv4
-          # Belt + suspenders: pass `-o Acquire::ForceIPv4=true` on each
-          # apt invocation directly so the directive applies even if
-          # apt's conf-d read order shifts in a future Ubuntu release.
-          APT_OPTS="-o Acquire::ForceIPv4=true -o Acquire::http::Timeout=20"
           # apt-get update is required: this command runs BEFORE
           # install_packages.sh (which does its own update), and the
           # ci/Dockerfile minimal base strips /var/lib/apt/lists/*.
           # On the VPS Ubuntu Server has lists populated; in CI the
           # cache is empty and `apt-get install locales` would fail
           # with "Unable to locate package locales".
-          sudo apt-get $APT_OPTS update -qq
+          sudo apt-get update -qq
           # DEBIAN_FRONTEND=noninteractive must be passed THROUGH sudo
           # via the leading env-prefix syntax — sudo's default env_reset
           # strips the env var set by ci/Dockerfile. The `locales`
@@ -62,7 +48,7 @@
           # hangs on a non-tty CI runner waiting for stdin that never
           # comes. The VPS doesn't hit this because Ubuntu Server ships
           # the package preinstalled.
-          sudo DEBIAN_FRONTEND=noninteractive apt-get $APT_OPTS install -y locales
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y locales
           sudo locale-gen en_US.UTF-8
           sudo update-locale LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
         fi

--- a/install-linux.conf.yaml
+++ b/install-linux.conf.yaml
@@ -31,8 +31,15 @@
       quiet: true
     - command: |
         if [ "${DOTFILES_DRY_RUN:-0}" = "1" ]; then
-          echo "[dry-run] would apt-get install locales + locale-gen en_US.UTF-8 + update-locale"
+          echo "[dry-run] would apt-get update + install locales + locale-gen en_US.UTF-8 + update-locale"
         else
+          # apt-get update is required: this command runs BEFORE
+          # install_packages.sh (which does its own update), and the
+          # ci/Dockerfile minimal base strips /var/lib/apt/lists/*.
+          # On the VPS Ubuntu Server has lists populated; in CI the
+          # cache is empty and `apt-get install locales` would fail
+          # with "Unable to locate package locales".
+          sudo apt-get update -qq
           sudo apt-get install -y locales
           sudo locale-gen en_US.UTF-8
           sudo update-locale LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8

--- a/install-linux.conf.yaml
+++ b/install-linux.conf.yaml
@@ -40,7 +40,15 @@
           # cache is empty and `apt-get install locales` would fail
           # with "Unable to locate package locales".
           sudo apt-get update -qq
-          sudo apt-get install -y locales
+          # DEBIAN_FRONTEND=noninteractive must be passed THROUGH sudo
+          # via the leading env-prefix syntax — sudo's default env_reset
+          # strips the env var set by ci/Dockerfile. The `locales`
+          # package's postinst is famously interactive (offers a
+          # locale-selection debconf menu); without noninteractive it
+          # hangs on a non-tty CI runner waiting for stdin that never
+          # comes. The VPS doesn't hit this because Ubuntu Server ships
+          # the package preinstalled.
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y locales
           sudo locale-gen en_US.UTF-8
           sudo update-locale LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
         fi


### PR DESCRIPTION
## Summary

Step 2/2 of #58, **scaled back** to digest-pin bump + locale-block correctness fixes. The original goal of also deleting the runtime apt-bootstrap step is **deferred** — see #65 — because empirically that step turned out to be load-bearing for apt warmth in the GH Actions container, in ways that no single network-config tweak resolved across 3 failed attempts.

## What this PR ships

- **Bump pin** \`sha256:8b0b7108…3865\` → \`sha256:758af964…a6d6\` (the digest published by \`publish-ci-image.yml\` after PR #62 merge).
- **Rename + simplify the runtime apt step** in \`install-matrix.yml\`: \"Install bootstrap deps (python3, sudo)\" → \"Warm up apt cache\". Body shrinks from \`apt-get update + apt-get install -y python3 sudo\` to just \`apt-get update -qq\` (python3 + sudo are now in the image). Comment documents that the step is kept as a network warm-up because removing it triggers a 60s/conn IPv6-timeout cascade in downstream apt invocations that compounds past the 20-min job cap.
- **Locale-block correctness fixes** in \`install-linux.conf.yaml\`:
  - Add \`sudo apt-get update -qq\` before \`sudo apt-get install -y locales\` (was always-needed; surfaces as \"Unable to locate package locales\" when run on a fresh apt cache).
  - Pass \`DEBIAN_FRONTEND=noninteractive\` through sudo on the locales install (sudo's env_reset strips the env var set by ci/Dockerfile, and the locales postinst is famously interactive — was hanging the job on a debconf menu).

## What this PR DOESN'T ship (deferred)

- **Removing the apt warm-up step entirely** — the original #58 acceptance criterion. Tracked as **#65**. Three different network-config approaches (conf-d IPv4 force, inline -o opts, http timeout cap) all failed to substitute for the warm-up's effect.

## CI evidence

| Run | Tree | Linux | macOS | Outcome |
|---|---|---|---|---|
| 25343189848 | step deleted, no apt-update fix | ❌ Apply failed (locale install: \"Unable to locate package locales\") | ✅ 8m23s | apt-update fix needed |
| 25344420787 | + apt-update fix, no DEBIAN_FRONTEND fix | ❌ 20m timeout (debconf hang) | ✅ 10m40s | DEBIAN_FRONTEND needed |
| 25346313051 | + DEBIAN_FRONTEND + IPv4 conf-d | ❌ 20m timeout (apt connections still slow) | ✅ 10m40s | conf-d not enough |
| 25347298749 | + inline -o opts | ❌ 20m timeout (apt-get update hung silently from start) | ✅ 7m59s | -o opts made it worse |
| **25348169302** | **+ restore warm-up step** | **✅ 12m10s** | **✅ 8m3s** | **green** |

## Test plan

- [x] Linux leg green (12m10s — slow but under cap; warm-up takes ~3 min, Apply takes ~9 min)
- [x] macOS leg green (unchanged path)
- [x] Locale step doesn't hang on debconf
- [x] apt-get install -y locales finds the package (no \"Unable to locate\" error)
- [x] Verified: image actually contains python3 + sudo (the \"Warm up apt cache\" step's apt-get update succeeds inside the container, and downstream pipeline runs Dotbot via baked-in python3, install_packages.sh via baked-in sudo)

## Closes

- Partially closes #58 — bake half is done; warm-up-removal half deferred to #65.

## Related

- #62 — step 1/2 (Dockerfile bake)
- #63 — publish-ci-image.yml smoke test (still useful; this PR proves contents indirectly via the green pipeline, but a direct test would catch image regressions earlier)
- #65 — investigate apt warmth so the warm-up step can truly be removed