### PR TITLE
ci(dockerfile): bake Acquire::ForceIPv4 to prevent IPv6 fallback (#65 step 1/2)

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -55,7 +55,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 # IPv4 forcing is wasted opinion. See
 # docs/solutions/cross-machine/install-matrix-ipv6-fallback-misattribution-2026-05-05.md
 # for the full investigation.
-RUN apt-get update \
+#
+# The printf MUST be the first link in the chain so the image build's
+# own apt-get update / apt-get install also benefit. Writing it after
+# the apt calls would protect runtime consumers but leave publish-ci-image.yml
+# itself exposed to the same IPv6 fallback this is meant to prevent.
+RUN printf 'Acquire::ForceIPv4 "true";\n' > /etc/apt/apt.conf.d/99-force-ipv4 \
+    && apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
@@ -64,8 +70,7 @@ RUN apt-get update \
         sudo \
         zsh \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && printf 'Acquire::ForceIPv4 "true";\n' > /etc/apt/apt.conf.d/99-force-ipv4
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /root
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -42,6 +42,19 @@ ENV DEBIAN_FRONTEND=noninteractive
 # `import json` raises ModuleNotFoundError. The full python3
 # metapackage pulls libpython3-stdlib (~45MB) and matches what
 # Ubuntu Server (the VPS production target) ships out of the box.
+#
+# Acquire::ForceIPv4: archive.ubuntu.com resolves to Cloudflare CDN
+# IPv6 (2606:4700:10::*). When the GH Actions Azure-eastus runner
+# network can't reach those endpoints, every fresh apt connection
+# waits ~60s for the IPv6 SYN to time out before falling back to IPv4
+# — that's the classic 60-69s gap signature observed on 2026-05-04
+# (#65). Forcing IPv4 at the image level skips the IPv6 attempt
+# entirely. Image-level (not workflow runtime, not install-pipeline
+# runtime) because (a) earlier apt invocations would miss runtime
+# injection, (b) the install pipeline also runs on the VPS where
+# IPv4 forcing is wasted opinion. See
+# docs/solutions/cross-machine/install-matrix-ipv6-fallback-misattribution-2026-05-05.md
+# for the full investigation.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -51,7 +64,8 @@ RUN apt-get update \
         sudo \
         zsh \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && printf 'Acquire::ForceIPv4 "true";\n' > /etc/apt/apt.conf.d/99-force-ipv4
 
 WORKDIR /root
 


### PR DESCRIPTION
## Summary

Step 1/2 of the actual #65 fix. Bakes `Acquire::ForceIPv4 "true";` into `ci/Dockerfile` so apt skips the IPv6 attempt preemptively. The 60-69s gaps between apt `Get:` lines that caused the 2026-05-04 install-matrix slowness were the IPv6 SYN-timeout fallback to IPv4 — not a missing apt-state dependency.

`archive.ubuntu.com` resolves to Cloudflare CDN IPv6 (`2606:4700:10::*`). When the GitHub Actions Azure-eastus runner network can't reach those endpoints, every fresh apt connection waits ~60s before falling back. The "warm-up step is load-bearing" finding from PR #64 was a misattribution — the warm-up coincidentally absorbed that timeout budget once.

## Investigation summary

Earlier commits on this branch had instrumented the workflow with a `skip_warmup` `workflow_dispatch` toggle and DNS/apt timing probes. Two paired runs against this branch:

- **Warm path** (`pull_request`, skip_warmup=false): Linux leg **52s**
- **Cold path** (`workflow_dispatch`, skip_warmup=true): Linux leg **51s**

Both showed sub-millisecond DNS resolution, sub-second `apt-get update` (37.9 MB in 2s @ 22 MB/s on cold path), and 15ms inter-`Get:` spacing — exactly the apt behavior expected when IPv6 works. The 60s gaps from yesterday simply weren't reproducible because IPv6 reachability had recovered overnight.

The diagnostic commits have been rebased away in favor of this clean single-commit fix; the methodology is captured in `docs/solutions/cross-machine/install-matrix-ipv6-fallback-misattribution-2026-05-05.md` (already landed on master).

## Why image-level (not runtime-injected)

PR #64 tried both runtime approaches and they failed:

- conf-d write at the start of the locale shell block — too late; earlier apt invocations had already paid the IPv6-fallback cost
- inline `-o Acquire::ForceIPv4=true -o Acquire::http::Timeout=20` — the timeout=20 caused infinite retries under `-qq`, producing a silent 20-min hang

Image-level state covers every apt invocation from the second one onward, in the workflow and inside `./install`. The VPS is not affected because it doesn't pull this image.

## What this PR does NOT do (deferred to step 2/2)

- Remove the "Warm up apt cache" step from `install-matrix.yml` (still pinned to the old digest, removing it before the new image republishes would break CI)
- Bump the `image:` digest pin
- Close #58 and #65

The chicken-and-egg from PR #62 + #64 applies again: ci/Dockerfile changes need to merge to master before publish-ci-image.yml republishes and the new digest is available. Step 2/2 PR will land that capture-and-bump cycle.

## Test plan

- [ ] Linux leg passes with the warm-up step still present (digest pin unchanged in this PR)
- [ ] No apt activity surprises in the Apply step
- [ ] After merge: confirm publish-ci-image.yml republishes successfully
- [ ] Capture new digest via `docker buildx imagetools inspect ghcr.io/villavicencio/dotfiles-ci-ubuntu:24.04`
- [ ] Open step 2/2 PR with the digest bump + warm-up step removal

## Related

- #65 — apt-warmth investigation (this PR + step 2/2 close it)
- #58 — bake python3 + sudo into ci/Dockerfile (this PR + step 2/2 truly close it)
- #62 — #58 step 1/2 (image bake)
- #64 — #58 step 2/2 (digest pin + locale-block fixes; scaled back)
- `docs/solutions/cross-machine/install-matrix-ipv6-fallback-misattribution-2026-05-05.md` — full investigation writeup

🤖 Generated with [Claude Code](https://claude.com/claude-code)