### PR TITLE
ci(install-matrix): remove warm-up step + bump digest (#65 step 2/2, closes #58 #65)

### DIFF
--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -102,30 +102,13 @@ jobs:
       # most recent ci/Dockerfile master push. Update this hash by hand
       # after each republish — fetch from `docker buildx imagetools
       # inspect ghcr.io/<owner>/dotfiles-ci-ubuntu:24.04`. The image
-      # bakes in python3 + sudo (per #58) so no runtime apt-bootstrap
-      # is needed. github.repository_owner is used so owner-rename /
-      # repo-transfer doesn't break CI; it's lowercase for this repo,
-      # which ghcr.io requires.
-      image: ghcr.io/${{ github.repository_owner }}/dotfiles-ci-ubuntu@sha256:758af964844df9c58c87669d31812cbda6655e78e8c94f66387bd0338651a6d6
+      # bakes in python3 + sudo (per #58) and Acquire::ForceIPv4 (per
+      # #65) so no runtime apt-bootstrap or network warm-up is needed.
+      # github.repository_owner is used so owner-rename / repo-transfer
+      # doesn't break CI; it's lowercase for this repo, which ghcr.io
+      # requires.
+      image: ghcr.io/${{ github.repository_owner }}/dotfiles-ci-ubuntu@sha256:8f6ad527bb8ee8d729f94c2e3c6f18f872a54b7a0f698d670ac4a8adc6a3f20e
     steps:
-      - name: Warm up apt cache
-        # Even though python3 + sudo are now baked into the image
-        # (per #58 / PR #62 / commit 6a8cd43), we still need an early
-        # apt-get update to populate /var/lib/apt/lists/* (which the
-        # ci/Dockerfile RUN block strips after image build) before
-        # downstream apt invocations run.
-        #
-        # Empirically this also serves as a network warm-up: without
-        # it, individual apt-get invocations later in the pipeline
-        # (locale install, helpers/install_packages.sh) hang ~60s per
-        # parallel connection on IPv6 timeout fallback, compounding
-        # past the 20-min job timeout. See run 25347298749 for the
-        # failure mode evidence. Once we have a clean fix for the apt
-        # warmth issue at the image level, this step can be removed.
-        # The empty `apt-get install` is intentional — populates apt
-        # state without installing anything (python3 + sudo are
-        # already present from the image bake).
-        run: apt-get update -qq
       - name: Checkout
         # SHA-pinned to close the supply-chain vector where a force-pushed
         # mutable tag could compromise this workflow at run time.


### PR DESCRIPTION
## Summary

Step 2/2 of the #65 fix. PR #66 baked `Acquire::ForceIPv4 "true";` into `ci/Dockerfile` at the image level, so apt skips the IPv6 SYN-timeout fallback that caused the 2026-05-04 slowness. With that protection in place, the runtime "Warm up apt cache" step is no longer needed — it was never structurally load-bearing, only coincidentally absorbing the IPv6-fallback timeout budget once.

## Changes

- **Bump `install-matrix.yml` image pin** to the new GHCR digest published after PR #66 merged:
  - Before: `sha256:758af964…a6d6`
  - After: `sha256:8f6ad527bb8ee8d729f94c2e3c6f18f872a54b7a0f698d670ac4a8adc6a3f20e`
  - Captured from `publish-ci-image.yml` run [25395181070](https://github.com/villavicencio/dotfiles/actions/runs/25395181070)'s `containerimage.digest` output (Docker daemon not available locally for the canonical `docker buildx imagetools inspect` capture).
- **Remove the "Warm up apt cache" step** and its 17-line comment block.
- **Update the image-pin comment** to mention #65's ForceIPv4 bake alongside #58's python3+sudo bake.

## Closes

- **#58** — the warm-up step is now removed, fulfilling its original acceptance criterion.
- **#65** — apt-warmth root cause documented, fix landed at the image level, observable failure mode neutralized.

## Investigation writeup

[`docs/solutions/cross-machine/install-matrix-ipv6-fallback-misattribution-2026-05-05.md`](docs/solutions/cross-machine/install-matrix-ipv6-fallback-misattribution-2026-05-05.md) (already on master) has the full timing data, hypothesis verdicts, and methodology.

## Test plan

- [ ] Linux leg passes against the new image (no warm-up step) in ~52s
- [ ] No apt errors during the locale block or `helpers/install_packages.sh`
- [ ] macOS leg unaffected
- [ ] After merge: `gh issue close 58 65`

🤖 Generated with [Claude Code](https://claude.com/claude-code)