### PR TITLE
ci(publish-ci-image): add docker run smoke test for image contents (#63)

### DIFF
--- a/.github/workflows/publish-ci-image.yml
+++ b/.github/workflows/publish-ci-image.yml
@@ -121,7 +121,18 @@ jobs:
           # Linux CI goes from ~63s back toward ~12 minutes. Catching the
           # strip at publish time stops the broken image from getting pinned
           # downstream.
-          docker run --rm "$IMAGE" sh -c 'grep -q "Acquire::ForceIPv4" /etc/apt/apt.conf.d/99-force-ipv4'
+          #
+          # Assert the EFFECTIVE value via `apt-config dump` (which parses the
+          # full conf.d tree and emits one canonical line), not raw substring
+          # presence — a future change to "false", a commented-out directive,
+          # or a same-line comment would all pass a naive grep on the conf
+          # file but defeat the invariant.
+          actual="$(docker run --rm "$IMAGE" apt-config dump Acquire::ForceIPv4)"
+          expected='Acquire::ForceIPv4 "true";'
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::ForceIPv4 invariant broken. apt-config dump returned: ${actual:-<empty>}"
+            exit 1
+          fi
 
       - name: Ensure package is public
         env:

--- a/.github/workflows/publish-ci-image.yml
+++ b/.github/workflows/publish-ci-image.yml
@@ -92,6 +92,37 @@ jobs:
             exit 1
           fi
 
+      - name: Smoke-test image contents
+        # Pulls the just-pushed image by digest and runs each tool the install
+        # pipeline assumes is present in the base layer. A silent apt failure
+        # during build that Docker layer-caches past would otherwise produce a
+        # valid-shape digest pointing at a broken image; install-matrix.yml
+        # would only catch the regression after a consuming-side digest pin
+        # bump, by which time the broken artifact is already canonical on
+        # GHCR. Hard-failing here keeps the visibility flip below from
+        # promoting a broken image to public.
+        run: |
+          IMAGE="ghcr.io/${{ steps.owner.outputs.lc }}/dotfiles-ci-ubuntu@${{ steps.build.outputs.digest }}"
+          # `import json` covers the Dotbot trampoline (bin/dotbot exec's
+          # python3 with stdlib imports). `import yaml` is intentionally NOT
+          # tested here even though #63's spec listed it — Dotbot bundles its
+          # own PyYAML at lib/pyyaml/lib and inserts it into sys.path at
+          # runtime, so the image does not need a system-installed PyYAML.
+          # The Dockerfile uses --no-install-recommends and would have to add
+          # python3-yaml just for this assertion to pass; that would bloat the
+          # image for no real coverage gain.
+          docker run --rm "$IMAGE" python3 -c 'import json'        # Dotbot trampoline + stdlib
+          docker run --rm "$IMAGE" sh -c 'command -v sudo'         # install_packages.sh trampoline
+          docker run --rm "$IMAGE" sh -c 'command -v zsh'          # R4 assertion target
+          docker run --rm "$IMAGE" sh -c 'command -v git'          # checkout + dotbot submodules
+          # ForceIPv4 conf must stay first in the RUN chain (see comment in
+          # ci/Dockerfile). If a cleanup commit silently strips it, the apt
+          # IPv6 SYN-timeout regression on archive.ubuntu.com re-emerges and
+          # Linux CI goes from ~63s back toward ~12 minutes. Catching the
+          # strip at publish time stops the broken image from getting pinned
+          # downstream.
+          docker run --rm "$IMAGE" sh -c 'grep -q "Acquire::ForceIPv4" /etc/apt/apt.conf.d/99-force-ipv4'
+
       - name: Ensure package is public
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Closes the gap surfaced by ce-code-review on PR #62: `publish-ci-image.yml` validates only that a SHA256 digest was emitted and matches a regex — there is no verification that the image actually contains and can execute its baked-in tools. A silent apt failure during build that gets layer-cached would produce a valid-shape digest pointing at a broken image, and the only downstream catch today is `install-matrix.yml` failing after the consuming-side digest pin gets bumped — by which time the broken artifact is already canonical on GHCR.

This PR adds a **Smoke-test image contents** step between "Validate digest before emitting" and "Ensure package is public", so any failure hard-stops the pipeline before the broken image gets the visibility flip.

## What's checked

| Assertion | Verifies |
|---|---|
| `python3 -c 'import json'` | Dotbot trampoline + Python stdlib intact |
| `command -v sudo` | `install_packages.sh` apt trampoline |
| `command -v zsh` | install-matrix R4 assertion target |
| `command -v git` | `actions/checkout` + `git submodule update` |
| `grep -q "Acquire::ForceIPv4" /etc/apt/apt.conf.d/99-force-ipv4` | The conf that kept Linux CI at ~63s after #66/#67 landed; catches a "cleanup commit strips it" regression at publish time, before downstream consumers pin to it |

## Deviation from #63's spec

The issue listed `python3 -c 'import json, yaml'` framed as "Dotbot startup imports." After auditing Dotbot's source: Dotbot bundles its own PyYAML at `dotbot/lib/pyyaml/lib/` and inserts it into `sys.path` at runtime via `bin/dotbot`. The image does **not** need a system-installed PyYAML — including `import yaml` would force adding `python3-yaml` to the Dockerfile (which uses `--no-install-recommends`) just to make the assertion pass, with no real coverage gain. Smoke test runs `import json` only; trade-off is documented inline in the workflow comment.

## What this PR's CI will and won't do

- **`install-matrix.yml`** will run on the PR (pulls existing digest pin, exercises the install pipeline). Should pass — this PR doesn't change the consuming side.
- **`publish-ci-image.yml`** will **NOT** run on the PR. It only triggers on `push` to `master` with `paths:` matching `ci/Dockerfile` or the workflow file itself. The new smoke-test step gets exercised on the next master push that touches one of those paths (or via manual `workflow_dispatch` after merge).

I verified the current `ci/Dockerfile` already satisfies all 5 assertions, so the next publish run should pass without surprises. If you want belt-and-suspenders, after merge: `gh workflow run publish-ci-image.yml` triggers a fresh build + smoke against the same Dockerfile.

## Test plan

- [x] YAML parses (`ruby -ryaml -e ...`)
- [x] gitleaks pre-commit hook passed (no secrets in workflow)
- [x] Hand-checked each assertion against the published image's expected contents
- [ ] Post-merge: dispatch the workflow once to validate the smoke step end-to-end, OR wait for the next legitimate `ci/Dockerfile` change to do it implicitly

## Out of scope

- Server-side / Dependabot Dockerfile drift detection
- Full container `ENTRYPOINT` smoke (e.g., simulating Dotbot run inside the container)
- Removing the existing `install-matrix.yml` digest-pin assertion — they're complementary; this PR adds defense one layer earlier

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)