### PR TITLE
ci(install-matrix): extract duplicated assertion bodies into composite actions (#59)

### DIFF
--- a/.github/actions/install-matrix-post-apply/action.yml
+++ b/.github/actions/install-matrix-post-apply/action.yml
@@ -1,0 +1,47 @@
+name: install-matrix post-apply
+description: >
+  R3 assertion 1 (no hardcoded user paths in install-pipeline files) + R4
+  (zsh -i -c true exits cleanly). Runs after `./install`. Body is
+  identical across the linux and macos legs by construction.
+
+runs:
+  using: composite
+  steps:
+    - name: R3 assertion 1 (no hardcoded user paths)
+      shell: bash
+      run: |
+        set -eo pipefail
+        # Fail-closed scope check: a refactor that drops a pathspec
+        # would otherwise let the assertion silently no-op. claude/**
+        # is included because Dotbot symlinks claude/settings.json,
+        # claude/commands/*.md, and claude/hooks/*.sh into ~/.claude/
+        # — they're install-pipeline content for cross-platform
+        # purposes even though they live outside the helpers/zsh tree.
+        files=$(git ls-files -- 'zsh/**' 'helpers/**' 'brew/**' 'git/**' 'claude/**')
+        if [ -z "$files" ]; then
+          echo "::error::scoping returned no files — file-list bug"
+          exit 1
+        fi
+        # Match macOS-style hardcoded /Users/<user>/ paths. We do NOT
+        # include /home/<user>/ — that prefix matches legitimate
+        # upstream paths (Linuxbrew at /home/linuxbrew/.linuxbrew, the
+        # OpenClaw container's /home/node user) where the path is the
+        # actual install location, not a hardcoded user path.
+        # `git grep` (vs `xargs grep`) handles filenames with embedded
+        # whitespace and avoids the xargs no-input edge case.
+        if git grep -l --extended-regexp '/Users/[^/]+/' -- \
+            'zsh/**' 'helpers/**' 'brew/**' 'git/**' 'claude/**'; then
+          echo "::error::found hardcoded user path(s) in install-pipeline files"
+          exit 1
+        fi
+
+    - name: R4 assertion (zsh -i -c true exits cleanly)
+      # Per docs/solutions/code-quality/zsh-dash-i-c-exit-false-positive-health-check.md:
+      # use `true` not `exit` — `zsh -i -c exit` returns the exit
+      # status of the last statement in .zshrc (because `exit` with no
+      # arg inherits $?), so a trailing `[[ -f /missing ]]` silently
+      # propagates 1 from a clean shell. `-c true` always exits 0
+      # unless init itself errored, making this a real "did init
+      # complete cleanly?" probe.
+      shell: bash
+      run: zsh -i -c true

--- a/.github/actions/install-matrix-pre-apply/action.yml
+++ b/.github/actions/install-matrix-pre-apply/action.yml
@@ -1,0 +1,92 @@
+name: install-matrix pre-apply
+description: >
+  R2 (mutation-free dry-run) + R3 assertion 2 (Dotbot symlink-target
+  resolution) + clean actions/checkout side effects. Runs before
+  `./install`. Body is identical across the linux and macos legs by
+  construction — extracting it here closes the silent-divergence gap
+  flagged on PR #57 (the `created≥1` fresh-runner check originally
+  shipped on linux only).
+
+# Composite actions don't inherit the workflow's `defaults.run.shell`,
+# so each step declares `shell: bash` explicitly.
+runs:
+  using: composite
+  steps:
+    - name: R2 + R3 (mutation-free dry-run + symlink-resolution)
+      shell: bash
+      run: |
+        set -eo pipefail
+        DRY_LOG=$(mktemp)
+
+        # Pre-snapshot of $HOME for delta semantics. Works on a non-empty
+        # $HOME (the macOS leg's runner $HOME has setup state); the diff
+        # is what matters, not the absolute count.
+        # Prune runner-noise subtrees from the snapshot:
+        # - $HOME/actions-runner: the GH Actions agent rotates its
+        #   own _diag log files during the step, generating false-
+        #   positive deltas.
+        # - $HOME/work: GitHub workspace (on macOS, $GITHUB_WORKSPACE
+        #   is inside $HOME); checkout/runtime state isn't an
+        #   "install mutation."
+        # - $HOME/Library: macOS background services rotate caches/
+        #   logs continuously.
+        # On Linux containers ($HOME=/github/home or /root), none of
+        # these paths exist as $HOME children — the prune is a no-op.
+        snapshot_home() {
+          find "$HOME" -mindepth 1 \
+            \( -path "$HOME/actions-runner" -o -path "$HOME/work" -o -path "$HOME/Library" \) -prune \
+            -o -print 2>/dev/null \
+            | sort
+        }
+        pre=$(snapshot_home)
+        ./install --dry-run | tee "$DRY_LOG"
+        post=$(snapshot_home)
+
+        # R2: zero-mutation delta assertion.
+        if ! diff <(echo "$pre") <(echo "$post"); then
+          echo "::error::dry-run mutated \$HOME"
+          exit 1
+        fi
+
+        # R3 assertion 2: every "Would create symlink/hardlink X -> Y"
+        # target Y must exist in the repo. Strict prefix match against
+        # Dotbot's link-plugin emitter (see
+        # dotbot/src/dotbot/plugins/link.py:350 — format is
+        # "Would create {symlink|hardlink} {link_name} -> {target_path}").
+        # Color is auto-disabled when stdout is piped (use_color falls
+        # back to sys.stdout.isatty()), so no ANSI stripping needed.
+        #
+        # Fresh-runner sanity check: on a CI runner with empty $HOME,
+        # every link directive must produce a "Would create" line. Zero
+        # lines means either Dotbot's output format changed or $HOME is
+        # pre-populated — both should fail loudly, not silently pass.
+        created=$(grep -cE '^Would create (sym|hard)link ' "$DRY_LOG" || true)
+        if [ "${created:-0}" -eq 0 ]; then
+          echo "::error::expected ≥1 'Would create symlink' line in dry-run output (fresh CI runner). Output format change or pre-populated \$HOME?"
+          exit 1
+        fi
+
+        missing=0
+        while IFS= read -r line; do
+          target="${line##*-> }"
+          if [ -z "$target" ]; then continue; fi
+          if [ ! -e "$target" ]; then
+            echo "::error::Dotbot symlink target missing: $target  (from: $line)"
+            missing=$((missing + 1))
+          fi
+        done < <(grep -E '^Would create (sym|hard)link ' "$DRY_LOG" || true)
+        if [ "$missing" -gt 0 ]; then
+          echo "::error::$missing symlink target(s) missing from repo"
+          exit 1
+        fi
+
+    - name: Clean actions/checkout side effects in $HOME
+      # actions/checkout configures git in $HOME during its own setup
+      # phase, leaving a regular `$HOME/.gitconfig` behind. Dotbot's
+      # `~/.gitconfig: git/gitconfig` link entry then fails the real
+      # install with "already exists but is a regular file or
+      # directory" — even with `relink: true`, Dotbot refuses to
+      # delete a regular file (only existing symlinks). Remove it
+      # explicitly so Dotbot can symlink cleanly.
+      shell: bash
+      run: rm -f "$HOME/.gitconfig"

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -78,9 +78,11 @@ concurrency:
 
 defaults:
   run:
-    # Container jobs default to `sh` unless overridden — bash is needed
-    # for `<(...)` process substitution in the assertion steps. Both
-    # legs share the same shell so step bodies stay portable.
+    # Container jobs default to `sh` unless overridden. Most assertion
+    # bodies live in the composite actions under .github/actions/ (each
+    # step there declares `shell: bash` explicitly), but inline run
+    # steps in this workflow still rely on this default — keep it pinned
+    # so future inline additions don't silently get sh on Linux.
     shell: bash
 
 # PYTHONDONTWRITEBYTECODE: dotbot is a Python tool that imports pyyaml at
@@ -127,122 +129,14 @@ jobs:
         # $HOME/.gitconfig — system-level config survives that.
         run: git config --system --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: R2 + R3 (mutation-free dry-run + symlink-resolution)
-        run: |
-          set -eo pipefail
-          DRY_LOG=$(mktemp)
-
-          # Pre-snapshot of $HOME for delta semantics. Works on a non-empty
-          # $HOME (the macOS leg's runner $HOME has setup state); the diff
-          # is what matters, not the absolute count.
-          # Prune runner-noise subtrees from the snapshot:
-          # - $HOME/actions-runner: the GH Actions agent rotates its
-          #   own _diag log files during the step, generating false-
-          #   positive deltas.
-          # - $HOME/work: GitHub workspace (on macOS, $GITHUB_WORKSPACE
-          #   is inside $HOME); checkout/runtime state isn't an
-          #   "install mutation."
-          # - $HOME/Library: macOS background services rotate caches/
-          #   logs continuously.
-          # On Linux containers ($HOME=/github/home or /root), none of
-          # these paths exist as $HOME children — the prune is a no-op.
-          snapshot_home() {
-            find "$HOME" -mindepth 1 \
-              \( -path "$HOME/actions-runner" -o -path "$HOME/work" -o -path "$HOME/Library" \) -prune \
-              -o -print 2>/dev/null \
-              | sort
-          }
-          pre=$(snapshot_home)
-          ./install --dry-run | tee "$DRY_LOG"
-          post=$(snapshot_home)
-
-          # R2: zero-mutation delta assertion.
-          if ! diff <(echo "$pre") <(echo "$post"); then
-            echo "::error::dry-run mutated \$HOME"
-            exit 1
-          fi
-
-          # R3 assertion 2: every "Would create symlink/hardlink X -> Y"
-          # target Y must exist in the repo. Strict prefix match against
-          # Dotbot's link-plugin emitter (see
-          # dotbot/src/dotbot/plugins/link.py:350 — format is
-          # "Would create {symlink|hardlink} {link_name} -> {target_path}").
-          # Color is auto-disabled when stdout is piped (use_color falls
-          # back to sys.stdout.isatty()), so no ANSI stripping needed.
-          #
-          # Fresh-runner sanity check: on a CI runner with empty $HOME,
-          # every link directive must produce a "Would create" line. Zero
-          # lines means either Dotbot's output format changed or $HOME is
-          # pre-populated — both should fail loudly, not silently pass.
-          created=$(grep -cE '^Would create (sym|hard)link ' "$DRY_LOG" || true)
-          if [ "${created:-0}" -eq 0 ]; then
-            echo "::error::expected ≥1 'Would create symlink' line in dry-run output (fresh CI runner). Output format change or pre-populated \$HOME?"
-            exit 1
-          fi
-
-          missing=0
-          while IFS= read -r line; do
-            target="${line##*-> }"
-            if [ -z "$target" ]; then continue; fi
-            if [ ! -e "$target" ]; then
-              echo "::error::Dotbot symlink target missing: $target  (from: $line)"
-              missing=$((missing + 1))
-            fi
-          done < <(grep -E '^Would create (sym|hard)link ' "$DRY_LOG" || true)
-          if [ "$missing" -gt 0 ]; then
-            echo "::error::$missing symlink target(s) missing from repo"
-            exit 1
-          fi
-
-      - name: Clean actions/checkout side effects in $HOME
-        # actions/checkout configures git in $HOME during its own setup
-        # phase, leaving a regular `$HOME/.gitconfig` behind. Dotbot's
-        # `~/.gitconfig: git/gitconfig` link entry then fails the real
-        # install with "already exists but is a regular file or
-        # directory" — even with `relink: true`, Dotbot refuses to
-        # delete a regular file (only existing symlinks). Remove it
-        # explicitly so Dotbot can symlink cleanly.
-        run: rm -f "$HOME/.gitconfig"
+      - name: Pre-apply assertions (R2 + R3 symlink-resolution + checkout cleanup)
+        uses: ./.github/actions/install-matrix-pre-apply
 
       - name: Apply (./install)
         run: ./install
 
-      - name: R3 assertion 1 (no hardcoded user paths)
-        run: |
-          set -eo pipefail
-          # Fail-closed scope check: a refactor that drops a pathspec
-          # would otherwise let the assertion silently no-op. claude/**
-          # is included because Dotbot symlinks claude/settings.json,
-          # claude/commands/*.md, and claude/hooks/*.sh into ~/.claude/
-          # — they're install-pipeline content for cross-platform
-          # purposes even though they live outside the helpers/zsh tree.
-          files=$(git ls-files -- 'zsh/**' 'helpers/**' 'brew/**' 'git/**' 'claude/**')
-          if [ -z "$files" ]; then
-            echo "::error::scoping returned no files — file-list bug"
-            exit 1
-          fi
-          # Match macOS-style hardcoded /Users/<user>/ paths. We do NOT
-          # include /home/<user>/ — that prefix matches legitimate
-          # upstream paths (Linuxbrew at /home/linuxbrew/.linuxbrew, the
-          # OpenClaw container's /home/node user) where the path is the
-          # actual install location, not a hardcoded user path.
-          # `git grep` (vs `xargs grep`) handles filenames with embedded
-          # whitespace and avoids the xargs no-input edge case.
-          if git grep -l --extended-regexp '/Users/[^/]+/' -- \
-              'zsh/**' 'helpers/**' 'brew/**' 'git/**' 'claude/**'; then
-            echo "::error::found hardcoded user path(s) in install-pipeline files"
-            exit 1
-          fi
-
-      - name: R4 assertion (zsh -i -c true exits cleanly)
-        # Per docs/solutions/code-quality/zsh-dash-i-c-exit-false-positive-health-check.md:
-        # use `true` not `exit` — `zsh -i -c exit` returns the exit
-        # status of the last statement in .zshrc (because `exit` with no
-        # arg inherits $?), so a trailing `[[ -f /missing ]]` silently
-        # propagates 1 from a clean shell. `-c true` always exits 0
-        # unless init itself errored, making this a real "did init
-        # complete cleanly?" probe.
-        run: zsh -i -c true
+      - name: Post-apply assertions (R3 user-paths + R4 zsh init)
+        uses: ./.github/actions/install-matrix-post-apply
 
   macos:
     runs-on: macos-15
@@ -273,101 +167,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-brew-
 
-      - name: R2 + R3 (mutation-free dry-run + symlink-resolution)
-        run: |
-          set -eo pipefail
-          DRY_LOG=$(mktemp)
-
-          # Prune runner-noise subtrees from the snapshot:
-          # - $HOME/actions-runner: the GH Actions agent rotates its
-          #   own _diag log files during the step, generating false-
-          #   positive deltas.
-          # - $HOME/work: GitHub workspace (on macOS, $GITHUB_WORKSPACE
-          #   is inside $HOME); checkout/runtime state isn't an
-          #   "install mutation."
-          # - $HOME/Library: macOS background services rotate caches/
-          #   logs continuously.
-          # On Linux containers ($HOME=/github/home or /root), none of
-          # these paths exist as $HOME children — the prune is a no-op.
-          snapshot_home() {
-            find "$HOME" -mindepth 1 \
-              \( -path "$HOME/actions-runner" -o -path "$HOME/work" -o -path "$HOME/Library" \) -prune \
-              -o -print 2>/dev/null \
-              | sort
-          }
-          pre=$(snapshot_home)
-          ./install --dry-run | tee "$DRY_LOG"
-          post=$(snapshot_home)
-
-          if ! diff <(echo "$pre") <(echo "$post"); then
-            echo "::error::dry-run mutated \$HOME"
-            exit 1
-          fi
-
-          # Fresh-runner sanity check (mirrors the Linux leg): on a CI
-          # runner with empty $HOME, every link directive must produce a
-          # "Would create" line. Zero lines means either Dotbot's output
-          # format changed or $HOME is pre-populated — both should fail
-          # loudly, not silently pass.
-          created=$(grep -cE '^Would create (sym|hard)link ' "$DRY_LOG" || true)
-          if [ "${created:-0}" -eq 0 ]; then
-            echo "::error::expected ≥1 'Would create symlink' line in dry-run output (fresh CI runner). Output format change or pre-populated \$HOME?"
-            exit 1
-          fi
-
-          missing=0
-          while IFS= read -r line; do
-            target="${line##*-> }"
-            if [ -z "$target" ]; then continue; fi
-            if [ ! -e "$target" ]; then
-              echo "::error::Dotbot symlink target missing: $target  (from: $line)"
-              missing=$((missing + 1))
-            fi
-          done < <(grep -E '^Would create (sym|hard)link ' "$DRY_LOG" || true)
-          if [ "$missing" -gt 0 ]; then
-            echo "::error::$missing symlink target(s) missing from repo"
-            exit 1
-          fi
-
-      - name: Clean actions/checkout side effects in $HOME
-        # actions/checkout configures git in $HOME during its own setup
-        # phase, leaving a regular `$HOME/.gitconfig` behind. Dotbot's
-        # `~/.gitconfig: git/gitconfig` link entry then fails the real
-        # install with "already exists but is a regular file or
-        # directory" — even with `relink: true`, Dotbot refuses to
-        # delete a regular file (only existing symlinks). Remove it
-        # explicitly so Dotbot can symlink cleanly.
-        run: rm -f "$HOME/.gitconfig"
+      - name: Pre-apply assertions (R2 + R3 symlink-resolution + checkout cleanup)
+        uses: ./.github/actions/install-matrix-pre-apply
 
       - name: Apply (./install)
         run: ./install
 
-      - name: R3 assertion 1 (no hardcoded user paths)
-        run: |
-          set -eo pipefail
-          # Fail-closed scope check: a refactor that drops a pathspec
-          # would otherwise let the assertion silently no-op. claude/**
-          # is included because Dotbot symlinks claude/settings.json,
-          # claude/commands/*.md, and claude/hooks/*.sh into ~/.claude/
-          # — they're install-pipeline content for cross-platform
-          # purposes even though they live outside the helpers/zsh tree.
-          files=$(git ls-files -- 'zsh/**' 'helpers/**' 'brew/**' 'git/**' 'claude/**')
-          if [ -z "$files" ]; then
-            echo "::error::scoping returned no files — file-list bug"
-            exit 1
-          fi
-          # Match macOS-style hardcoded /Users/<user>/ paths. We do NOT
-          # include /home/<user>/ — that prefix matches legitimate
-          # upstream paths (Linuxbrew at /home/linuxbrew/.linuxbrew, the
-          # OpenClaw container's /home/node user) where the path is the
-          # actual install location, not a hardcoded user path.
-          # `git grep` (vs `xargs grep`) handles filenames with embedded
-          # whitespace and avoids the xargs no-input edge case.
-          if git grep -l --extended-regexp '/Users/[^/]+/' -- \
-              'zsh/**' 'helpers/**' 'brew/**' 'git/**' 'claude/**'; then
-            echo "::error::found hardcoded user path(s) in install-pipeline files"
-            exit 1
-          fi
-
-      - name: R4 assertion (zsh -i -c true exits cleanly)
-        run: zsh -i -c true
+      - name: Post-apply assertions (R3 user-paths + R4 zsh init)
+        uses: ./.github/actions/install-matrix-post-apply


### PR DESCRIPTION
## Summary

Closes the ~80-line step-body duplication between the linux and macos jobs in `install-matrix.yml`. The duplication had already produced one silent divergence (PR #57's `created≥1` fresh-runner sanity check originally shipped on linux only — caught by code review). Extracting both shared blocks into composite actions makes drift impossible by construction.

## Structure

Two composite actions under `.github/actions/`:

| Action | Wraps |
|---|---|
| `install-matrix-pre-apply/action.yml` | R2 mutation-free dry-run + R3 assertion 2 (Dotbot symlink-target resolution) + clean actions/checkout side effects |
| `install-matrix-post-apply/action.yml` | R3 assertion 1 (no hardcoded `/Users/<user>/` paths) + R4 (`zsh -i -c true`) |

Each leg's job now reduces to:

```yaml
steps:
  - checkout
  - <leg-specific setup>          # container safe.directory OR Homebrew cache
  - uses: ./.github/actions/install-matrix-pre-apply
  - run: ./install
  - uses: ./.github/actions/install-matrix-post-apply
```

## Behavior-preserving

Assertion logic is byte-equivalent to the original inline steps:

- `snapshot_home` function (same `find` + prune list)
- `diff <(echo "$pre") <(echo "$post")` for R2
- `created≥1` fresh-runner sanity check (now identical across legs by construction)
- `while IFS= read -r line; ... target="${line##*-> }"` missing-target loop
- R3-a `git grep --extended-regexp '/Users/[^/]+/'` against the same pathspecs (`zsh/** helpers/** brew/** git/** claude/**`)
- R4 `zsh -i -c true`

## Acceptance criteria from #59

- [x] One canonical implementation of each assertion body, invoked by both legs
- [x] `created≥1` sanity check identical across legs by construction (single-source)
- [x] Existing seeded-failure validation still applies — parsing logic is unchanged, evidence doc at `docs/solutions/cross-machine/install-matrix-seeded-failure-evidence-2026-05-03.md` references behavior that is preserved
- [x] Both legs continue to fail loudly with actionable messages — composite action steps emit `::error::` annotations the same as inline steps

## Implementation notes

- Composite actions don't inherit workflow `defaults.run.shell`, so each step declares `shell: bash` explicitly.
- The `defaults.run.shell: bash` block in the workflow is retained for future inline `run:` additions; comment updated to reflect that the assertion bodies have moved.
- `install-matrix.yml` drops from 373 → 175 lines.
- Local composite path uses `./` prefix per GH Actions docs.

## Test plan

- [x] Both `action.yml` files parse as valid YAML
- [x] Workflow file parses as valid YAML
- [x] Pre-commit gitleaks hook passes
- [ ] Linux + macOS CI legs go green on this PR (validates the composite invocation end-to-end)

## Out of scope

- Rewriting the `git grep` regex or pathspec for R3-a (#61 covers parser tightening)
- Empirically validating R3 assertion 2 with a seeded missing-target failure (#60 covers that, easier to do after this lands so the seeded change is against the post-refactor structure)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)