### PR TITLE
ci(install-matrix): tighten Dotbot link emitter regex to catch partial-match drift (#61)

### DIFF
--- a/.github/actions/install-matrix-pre-apply/action.yml
+++ b/.github/actions/install-matrix-pre-apply/action.yml
@@ -49,18 +49,32 @@ runs:
         fi
 
         # R3 assertion 2: every "Would create symlink/hardlink X -> Y"
-        # target Y must exist in the repo. Strict prefix match against
+        # target Y must exist in the repo. Strict full-line match against
         # Dotbot's link-plugin emitter (see
         # dotbot/src/dotbot/plugins/link.py:350 — format is
         # "Would create {symlink|hardlink} {link_name} -> {target_path}").
         # Color is auto-disabled when stdout is piped (use_color falls
         # back to sys.stdout.isatty()), so no ANSI stripping needed.
         #
+        # Defined once and reused so the count check and the extraction
+        # loop can't drift apart. The regex pins all four structural
+        # pieces — keyword prefix, sym|hard variant, the literal " -> "
+        # separator, and end-of-line — so a Dotbot submodule bump that
+        # changes ANY of them (e.g., emits "Would create link" without
+        # the variant, or replaces "->" with "=>") will fail to match
+        # and trip the fresh-runner sanity check below. A wider regex
+        # could let a partial-match regression through silently.
+        # [^[:space:]]+ on each side because Dotbot's emitter never
+        # produces whitespace-bearing link-names or targets — repo paths
+        # in install.conf.yaml don't allow them.
+        LINK_RE='^Would create (sym|hard)link [^[:space:]]+ -> [^[:space:]]+$'
+
         # Fresh-runner sanity check: on a CI runner with empty $HOME,
         # every link directive must produce a "Would create" line. Zero
-        # lines means either Dotbot's output format changed or $HOME is
-        # pre-populated — both should fail loudly, not silently pass.
-        created=$(grep -cE '^Would create (sym|hard)link ' "$DRY_LOG" || true)
+        # lines means either Dotbot's output format changed (the strict
+        # regex above stopped matching) or $HOME is pre-populated —
+        # both should fail loudly, not silently pass.
+        created=$(grep -cE "$LINK_RE" "$DRY_LOG" || true)
         if [ "${created:-0}" -eq 0 ]; then
           echo "::error::expected ≥1 'Would create symlink' line in dry-run output (fresh CI runner). Output format change or pre-populated \$HOME?"
           exit 1
@@ -74,7 +88,7 @@ runs:
             echo "::error::Dotbot symlink target missing: $target  (from: $line)"
             missing=$((missing + 1))
           fi
-        done < <(grep -E '^Would create (sym|hard)link ' "$DRY_LOG" || true)
+        done < <(grep -E "$LINK_RE" "$DRY_LOG" || true)
         if [ "$missing" -gt 0 ]; then
           echo "::error::$missing symlink target(s) missing from repo"
           exit 1


### PR DESCRIPTION
## Summary

The current parser regex `^Would create (sym|hard)link ` matches the prefix only — a Dotbot submodule bump that keeps the prefix but changes the separator (`->` → `=>`) or rearranges structure could still emit lines that satisfy the prefix and silently slip past with garbage `${line##*-> }` extractions.

This PR replaces the loose regex with a full-line structural match:

```
^Would create (sym|hard)link [^[:space:]]+ -> [^[:space:]]+$
```

Pins all four structural pieces:
1. **Keyword prefix** (`Would create`)
2. **Variant** (`sym|hard`)
3. **Separator** (literal ` -> `)
4. **End-of-line** (no trailing extras)

If any of these change in a future Dotbot version, the regex stops matching → `created` falls to 0 → the existing fresh-runner sanity check fires loudly. This implements **Option 2** from #61 ("Tighten the parser regex"), preferred over Option 1 (hard version assert) and Option 3 (snapshot-based pre-commit) because it self-corrects rather than requiring a workflow edit on every Dotbot bump.

Bonus: extracts the regex into a single `LINK_RE` variable so the count check and the extraction loop can no longer drift apart silently.

## Validation

Tested against synthetic fixtures matching the [documented Dotbot v1.24.1 emitter format](https://github.com/anishathalye/dotbot/blob/v1.24.1/src/dotbot/plugins/link.py#L350):

| Input line | Loose regex (old) | Strict regex (new) |
|---|---|---|
| `Would create symlink ~/.config/zsh/.zshenv -> zsh/zshenv` | ✅ match | ✅ match |
| `Would create symlink ~/.gitconfig -> git/gitconfig` | ✅ match | ✅ match |
| `Would create hardlink ~/foo -> bar/baz` | ✅ match | ✅ match |
| `Would create symlink ~/foo => bar` (separator drift) | ❌ false match (let through) | ✅ correctly rejected |
| `Would create symlink ~/foo  bar` (no-arrow drift) | ❌ false match (let through) | ✅ correctly rejected |
| `Would create link ~/x -> y` (variant drop) | ✅ correctly rejected | ✅ correctly rejected |

3 documented-format lines match cleanly under both regexes. 2 partial-match regression shapes that the loose regex let through are now caught.

## Acceptance criteria from #61

- [x] A submodule bump to a hypothetical Dotbot version with a different emitter wording is detected by CI on the bump PR — regex stops matching → `created` count falls to 0 → fresh-runner sanity check fires
- [x] The `created≥1` and missing-target assertions remain the primary gates — both still in place, now reading from a single shared `LINK_RE`

## Out of scope

- Hardcoded version assertion (Option 1) — every Dotbot bump becomes a workflow edit
- Snapshot-based pre-commit (Option 3) — adds tooling surface for marginal value over Option 2

## Test plan

- [x] YAML parses
- [x] Synthetic regex test (table above)
- [x] Pre-commit gitleaks hook passes
- [ ] Linux + macOS CI legs go green on this PR (validates the strict regex still matches Dotbot v1.24.1's actual fresh-runner output)

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)