### PR TITLE
ci: bump SHA-pinned actions to Node 24 releases

### DIFF
--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Checkout
         # SHA-pinned to close the supply-chain vector where a force-pushed
         # mutable tag could compromise this workflow at run time.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: recursive
 
@@ -150,7 +150,7 @@ jobs:
       CI: 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: recursive
 
@@ -158,7 +158,7 @@ jobs:
         # Restore-keys deliberately omits a Brewfile-hash subset — that
         # would let a stale cache survive a Brewfile change. Helper
         # changes also bust the cache via hashFiles('helpers/**').
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: |
             ~/Library/Caches/Homebrew/downloads

--- a/.github/workflows/publish-ci-image.yml
+++ b/.github/workflows/publish-ci-image.yml
@@ -49,7 +49,7 @@ jobs:
         # vector where a force-pushed mutable tag could compromise this
         # workflow's secrets.GITHUB_TOKEN (packages: write). Version
         # comments preserve the human-readable pin.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Lowercase repository owner
         id: owner
@@ -59,18 +59,18 @@ jobs:
           echo "lc=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to ghcr.io
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
         with:
           context: ./ci
           push: true


### PR DESCRIPTION
Closes #75.

## Summary

GitHub Actions force-flips JS actions to Node 24 on **2026-06-02** (24 days from this PR) and removes Node 20 on **2026-09-16**. All 5 SHA-pinned third-party actions in this repo were on Node-20 releases and emit the deprecation annotation on every CI run. Bumping each to the matching latest stable release; every new pin declares `using: node24` in its `action.yml` at the resolved SHA.

## Changes

| Action | From | To | Major |
|---|---|---|---|
| `actions/checkout` | `34e1148` `# v4.3.1` | `de0fac2` `# v6.0.2` | v4 → v6 |
| `actions/cache` | `0057852` `# v4.3.0` | `27d5ce7` `# v5.0.5` | v4 → v5 |
| `docker/login-action` | `c94ce9f` `# v3` | `4907a6d` `# v4.1.0` | v3 → v4 |
| `docker/setup-buildx-action` | `8d2750c` `# v3` | `4d04d5d` `# v4.0.0` | v3 → v4 |
| `docker/build-push-action` | `10e90e3` `# v6` | `bcafcac` `# v7.1.0` | v6 → v7 |

Each SHA resolved from the release tag via `gh api repos/<owner>/<repo>/commits/<tag> --jq .sha` (canonical commit SHA, not lightweight tag SHA). SHA-pinning convention from PR #57 preserved; the trailing `# vX.Y.Z` comments are normalized to the explicit version on each pin (the previous mix of `# v4.3.1` vs `# v4` is unified to explicit semver).

## Breaking-change risk

Each action's invocation in this repo is intentionally minimal:

- **checkout**: `submodules: recursive` only — unchanged across v4→v6
- **cache**: `path` / `key` / `restore-keys` — core inputs, unchanged across v4→v5 (v5 bumped the internal cache-service protocol but the public input shape is stable)
- **login**: `registry` / `username` / `password` inputs — unchanged across v3→v4
- **setup-buildx**: no inputs (default) — v4 bumped the runtime but defaults are conservative
- **build-push**: `context` / `push` / `tags` / `provenance: false` — `provenance` semantics unchanged; v7 affects attestation defaults which we explicitly opt out of

None of our usage sits on a documented breaking-change surface. PR-side CI will validate.

## Verification

- [x] All 5 third-party actions reference SHAs from releases that declare `using: node24`
- [x] Trailing `# vX.Y.Z` comment beside each pin updated to reflect the new version
- [x] YAML parse-check passes on both workflow files
- [ ] Both `install-matrix.yml` legs (linux + macos) pass — **awaiting CI on this PR**
- [ ] `publish-ci-image.yml` passes and the Node 20 deprecation annotation is gone — **fires automatically on merge to master because this PR touches its watched path (`.github/workflows/publish-ci-image.yml`); no manual dispatch needed**
- [ ] Post-#71 5-assertion smoke-test gate still passes on the new CI image

## Out of scope (follow-up)

`tailscale/github-action@v4` in `sync-vps.yml` is a mutable tag (not SHA-pinned) and was never in #75's enumerated list. Worth a separate ticket on (a) bringing it under the PR #57 SHA-pinning convention and (b) confirming Node 24 readiness if it's a JS action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)