### PR TITLE
ci: SHA-pin tailscale/github-action to v4.1.2 (closes #77)

### DIFF
--- a/.github/workflows/sync-vps.yml
+++ b/.github/workflows/sync-vps.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Join tailnet
-        uses: tailscale/github-action@v4
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
         with:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}


### PR DESCRIPTION
## Summary

- Resolve `tailscale/github-action@v4` (mutable major-version tag) → `306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2`, matching the PR #57 SHA-pin convention applied to all other third-party actions in PR #76.
- Confirms Node 24 readiness: `action.yml` at v4.1.2 declares `runs.using: 'node24'`. The 2026-06-02 Node 20 force-flip does **not** apply to this action.
- Closes the last `@vN` pin in any workflow with production-tailnet secret access (`TS_OAUTH_CLIENT_ID` / `TS_OAUTH_SECRET`).

## Why

`sync-vps.yml:30` was the last violation of the SHA-pin convention in this repo. Same force-pushed-tag attack vector that PR #57 closed for `actions/*` and `docker/*` remained open here, and that workflow has the broadest blast radius (root SSH to prod VPS via Tailscale).

## Verification

| Check | Result |
| --- | --- |
| Latest stable release | `v4.1.2` (2026-03-11) |
| `action.yml` runtime | `runs.using: 'node24'` — already Node 24, no deadline urgency |
| SHA resolution method | `gh api repos/tailscale/github-action/commits/v4.1.2 --jq .sha` |
| Tag object type | `commit` (not annotated) — single hop, no dereference needed |
| YAML validity | passes `ruby -ryaml -e 'YAML.load_file(...)'` |
| Pre-commit | gitleaks pass |

## Test plan

- [ ] CI: any PR-triggered workflows pass (sync-vps.yml is `workflow_dispatch`-only, so the action itself only exercises post-merge)
- [ ] Post-merge: manually trigger `Sync VPS` workflow against `openclaw-prod` in **dry-run mode** to confirm the new pin resolves and the action joins the tailnet cleanly
- [ ] Confirm the post-merge run completes without "this action requires Node.js 20" annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)