### PR TITLE
fix(zsh): harden NVM default-node version selection

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -107,8 +107,13 @@ fi
 # Lazy load NVM
 export NVM_DIR="$HOME/.config/nvm"
 if [[ -s "$NVM_DIR/nvm.sh" ]]; then
-  # Add default node to PATH without sourcing nvm.sh (~0ms vs ~200-400ms)
-  DEFAULT_NODE_PATH="$(ls -d "$NVM_DIR/versions/node"/v* 2>/dev/null | tail -1)/bin"
+  # Add default node to PATH without sourcing nvm.sh (~0ms vs ~200-400ms).
+  # `command ls` bypasses the ls alias (alias.sh) so this never depends on what
+  # ls is aliased to; `sort -V` version-sorts so the highest semver wins even
+  # when majors mix single/double digits (plain lexicographic `tail -1` would
+  # pick v9 over v20). GNU sort is on PATH via zshenv's coreutils gnubin; on
+  # Linux `sort -V` is native.
+  DEFAULT_NODE_PATH="$(command ls -d "$NVM_DIR/versions/node"/v* 2>/dev/null | sort -V | tail -1)/bin"
   [[ -d "$DEFAULT_NODE_PATH" ]] && export PATH="$DEFAULT_NODE_PATH:$PATH"
   unset DEFAULT_NODE_PATH
 


### PR DESCRIPTION
## What

Changes the NVM lazy-loader's default-node probe in `zsh/zshrc`:

```diff
-  DEFAULT_NODE_PATH="$(ls -d "$NVM_DIR/versions/node"/v* 2>/dev/null | tail -1)/bin"
+  DEFAULT_NODE_PATH="$(command ls -d "$NVM_DIR/versions/node"/v* 2>/dev/null | sort -V | tail -1)/bin"
```

## Why

The bare `ls … | tail -1` had two latent fragilities (surfaced during the PR #84 review):

1. **Alias coupling** — bare `ls` resolved through whatever `ls` was aliased to (e.g. `eza` after #84). `command ls` decouples it from the interactive alias layer.
2. **Lexicographic sort** — `tail -1` after a string sort picks the wrong "latest" when node majors mix single/double digits: `{v9, v10, v20}` sorts with `v9` last, so the *older* v9 was chosen. `sort -V` (version sort) picks the true highest semver.

## Portability

`sort -V` is safe everywhere `zshrc` runs: GNU `sort` is on PATH via `zshenv`'s coreutils gnubin (coreutils is in the Brewfile) **before** the NVM block executes, on both Macs; Linux `sort -V` is native. (Not `gsort` — that's macOS-only and would break on Linux.)

## Verification

- Mixed-digit edge case `{v9,v10,v20}`: OLD → `v9.0.0`, NEW → `v20.0.0` ✔
- Real `$NVM_DIR` (v20/v22/v24 dirs): resolves `v24.13.0` ✔
- `zsh -i -c true` ~0.24s, under the 300ms budget ✔
- `zsh -n zsh/zshrc` clean ✔

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)