### PR TITLE
fix(tmux): theme window-status-bell-style (drop the default reverse pill)

### DIFF
--- a/tmux/tmux.display.conf
+++ b/tmux/tmux.display.conf
@@ -104,6 +104,12 @@ set -g status-right-length 70
 setw -g window-status-format "  #[fg=#4B5263#,nobold] #I:#{?#{==:#{@claude_status},asking},#[fg=#F5C300#,bold]  #[fg=#4B5263#,nobold],#{?#{==:#{@claude_status},waiting},#[fg=#E5C07B#,bold]  #[fg=#4B5263#,nobold],#{?#{!=:#{@claude_status},},#[fg=#D97757#,bold] #{@claude_status} #[fg=#4B5263#,nobold],#{?#{!=:#{@win_glyph},}, #{@win_glyph} , }}}}#W  "
 setw -g window-status-current-format "  #[fg=#7DACD3#,bold] #I:#{?#{==:#{@claude_status},asking},#[fg=#F5C300#,bold]  #[fg=#7DACD3#,bold],#{?#{==:#{@claude_status},waiting},#[fg=#E5C07B#,bold]  #[fg=#7DACD3#,bold],#{?#{!=:#{@claude_status},},#[fg=#D97757#,bold] #{@claude_status} #[fg=#7DACD3#,bold],#{?#{!=:#{@win_glyph},},#[fg=#{?#{!=:#{@win_glyph_color},},#{@win_glyph_color},#7DACD3}#,bold] #{@win_glyph} #[fg=#7DACD3#,bold], }}}}#W  "
 setw -g window-status-activity-style "fg=#E5C07B"
+# Bell: explicit override so a belled window (e.g. a \a from a remote SSH
+# session like Axiom) doesn't fall back to tmux's default `reverse`, which
+# inverts the whole entry into a jarring solid pill. Claude-orange bold matches
+# the attention palette (same hue as the @claude_status spinner) and reads as
+# "this window pinged" without the reverse box. Activity stays amber, above.
+setw -g window-status-bell-style "fg=#D97757,bold"
 
 # Pane borders — same color, nearly invisible
 set -g pane-border-style "fg=#21252B"


### PR DESCRIPTION
## What

Adds an explicit `window-status-bell-style`:

```tmux
setw -g window-status-bell-style "fg=#D97757,bold"
```

## Why

A belled window rendered as a solid inverted "pill" (spotted on window 7 *Axiom*):

The config themes `window-status-activity-style` (`fg=#E5C07B`, amber text) but never set `window-status-bell-style` — so a window with a bell flag (`!`) fell back to tmux's **built-in default `reverse`**, which inverts fg/bg into that pill. Window 7 had flags `# ! -` (activity, **bell**, last); the bell is what drew the box. Windows with activity-only (`#`) correctly showed amber text, no box — the inconsistency was bell-only.

The bell came from the **Axiom** SSH session (remote Claude Code): a `\a` propagates over SSH and tmux flags the window.

## Fix

Set bell-style to **claude-orange bold** (`#D97757`) — the same hue as the `@claude_status` spinner in the attention palette — so a belled window reads as "this window pinged" in-theme, without the jarring reverse box. Activity stays amber; the two states stay visually distinct (amber = output, orange = bell/attention).

## Verification

- Style applies cleanly live (valid syntax); `window-status-bell-style` resolves to `fg=#D97757,bold`.
- Window 7 (still belled) now renders claude-orange bold instead of `reverse`.
- `tmux source-file ~/.config/tmux/tmux.conf` reloads with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)