### PR TITLE
chore: record plugin marketplace autoUpdate flags

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,8 @@
       "source": {
         "source": "github",
         "repo": "villavicencio/skills"
-      }
+      },
+      "autoUpdate": true
     }
   }
 }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -97,7 +97,8 @@
       "source": {
         "source": "github",
         "repo": "EveryInc/compound-engineering-plugin"
-      }
+      },
+      "autoUpdate": true
     },
     "claude-plugins-official": {
       "source": {


### PR DESCRIPTION
## What

Claude Code's plugin rebuild after the post-Pearcleaner restart wrote `"autoUpdate": true` onto two marketplace declarations. This syncs the repo to match the live local state.

- `claude/settings.json` (symlinked → `~/.claude/settings.json`): `compound-engineering-plugin` marketplace
- `.claude/settings.json` (project-local): `villavicencio/skills` marketplace

## Why

Machine-generated additive flags — no behavior change to the dotfiles themselves. Keeps `master` clean so a future `git status` doesn't show perpetual drift on these files. Same sync pattern as #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)