### PR TITLE
chore: record Claude settings baseline

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -2,6 +2,7 @@
   "permissions": {
     "defaultMode": "auto"
   },
+  "model": "opus[1m]",
   "hooks": {
     "SessionStart": [
       {
@@ -83,8 +84,9 @@
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
     "compound-engineering@compound-engineering-plugin": true,
-    "vercel@claude-plugins-official": false,
-    "dv@villavicencio-skills": true
+    "vercel@claude-plugins-official": true,
+    "dv@villavicencio-skills": true,
+    "skill-creator@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "claude-code-plugins": {
@@ -123,6 +125,7 @@
   "tui": "fullscreen",
   "showThinkingSummaries": true,
   "skipDangerousModePermissionPrompt": true,
+  "skipWorkflowUsageWarning": true,
   "preferredNotifChannel": "iterm2",
   "remoteControlAtStartup": true,
   "inputNeededNotifEnabled": true,


### PR DESCRIPTION
Records current `claude/settings.json`: model pin `opus[1m]`, enable vercel + skill-creator plugins, `skipWorkflowUsageWarning`. Axiom's overlay strips the model pin. Note: this file is rewritten by /model and /effort at runtime, so it will go dirty again after use.