### PR TITLE
chore: register openai-codex plugin in Claude settings

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -86,7 +86,8 @@
     "compound-engineering@compound-engineering-plugin": true,
     "vercel@claude-plugins-official": true,
     "dv@villavicencio-skills": true,
-    "skill-creator@claude-plugins-official": true
+    "skill-creator@claude-plugins-official": true,
+    "codex@openai-codex": true
   },
   "extraKnownMarketplaces": {
     "claude-code-plugins": {
@@ -118,6 +119,12 @@
       "source": {
         "source": "github",
         "repo": "villavicencio/skills-private"
+      }
+    },
+    "openai-codex": {
+      "source": {
+        "source": "github",
+        "repo": "openai/codex-plugin-cc"
       }
     }
   },


### PR DESCRIPTION
Records the `codex@openai-codex` plugin (installed today via slash command) in the tracked `claude/settings.json` baseline, along with its `openai/codex-plugin-cc` marketplace under `extraKnownMarketplaces`.

Also restores the `"model": "opus[1m]"` pin that `/model` had stripped at runtime — so the only net change vs. the recorded baseline is the codex addition.

Follows the precedent set by #94 (settings baseline changes go through a PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)