### PR TITLE
fix: remove dead adoptopenjdk/openjdk tap from Brewfile

### DIFF
--- a/brew/Brewfile
+++ b/brew/Brewfile
@@ -1,4 +1,3 @@
-tap "adoptopenjdk/openjdk"
 tap "rigellute/tap"
 brew "ack"
 brew "aria2"


### PR DESCRIPTION
## What

Removes the orphaned `tap "adoptopenjdk/openjdk"` line from `brew/Brewfile`.

## Why

The macOS CI job (and any fresh-machine `brew bundle`) fails on this tap. On modern Homebrew, `brew tap` audits the tap's cask definitions, and one of them — `adoptopenjdk-jre` — still uses the removed `appcast` stanza:

```
Cask 'adoptopenjdk-jre' definition is invalid: undefined method 'appcast' for Cask 'adoptopenjdk-jre'
Tapping adoptopenjdk/openjdk has failed!
`brew bundle` failed! 3 Brewfile dependencies failed to install
```

(The other two failures in that run — `gitleaks` and `luarocks` — are transient `Cellar` lock-races from parallel installs, not config bugs; they clear on re-run.)

The tap is **orphaned**: no cask in the Brewfile installs from it, it's the only `adoptopenjdk` reference in the repo, and it's been there since the original Dotbot conversion. AdoptOpenJDK was retired in favor of Eclipse Temurin years ago.

## Behavior impact

None. No Java was being installed from this tap, so removing it changes nothing about what lands on a machine — it only stops the failed `brew tap` attempt. If a JDK/JRE is ever wanted, add `cask "temurin"` deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)