### PR TITLE
chore: conform Otty shell-integration block to repo idiom

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -199,3 +199,6 @@ fi
 # Google Cloud SDK (optional)
 [[ -f "$HOME/.google-cloud-sdk/path.zsh.inc" ]] && source "$HOME/.google-cloud-sdk/path.zsh.inc"
 [[ -f "$HOME/.google-cloud-sdk/completion.zsh.inc" ]] && source "$HOME/.google-cloud-sdk/completion.zsh.inc"
+
+# Otty shell integration (optional; inert unless launched by Otty)
+[[ -n "$OTTY_SHELL_INTEGRATION" && -r "$OTTY_SHELL_INTEGRATION/otty-integration.zsh" ]] && source "$OTTY_SHELL_INTEGRATION/otty-integration.zsh"


### PR DESCRIPTION
## What

Rewrites the Otty terminal shell-integration block in `zsh/zshrc` from the installer's multi-line POSIX form to a single guarded `source` line matching the optional-integration idiom already used directly above it (gcloud, openclaw, antigravity).

```zsh
# Otty shell integration (optional; inert unless launched by Otty)
[[ -n "$OTTY_SHELL_INTEGRATION" && -r "$OTTY_SHELL_INTEGRATION/otty-integration.zsh" ]] && source "$OTTY_SHELL_INTEGRATION/otty-integration.zsh"
```

## Why

The Otty installer appended a multi-line `if [ -n … ]` block using POSIX `.` sourcing and `# >>>`/`# <<<` markers — exactly the installer-churn shape the repo's post-installer audit convention flags. Conforming keeps the section uniform.

## Notes

- **Guard semantics unchanged** — env var non-empty AND file readable; inert on any machine/terminal where Otty isn't the launcher, so it's safe on both Macs.
- **Trade-off (intentional):** dropping the installer markers means Otty's in-app toggle (Settings → Shell → Shell Integration) no longer manages this block — it's now owned manually in the repo, consistent with the source-of-truth model.
- **Verified:** parses (`zsh -n`) and sources cleanly under Otty (exit 0, emits the OSC 7 CWD sequence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)