### PR TITLE
fix: force serial brew bundle in CI to stop Cellar lock-race

### DIFF
--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -148,6 +148,18 @@ jobs:
       # directive consults it.
       HOMEBREW_NO_AUTO_UPDATE: '1'
       HOMEBREW_NO_INSTALL_CLEANUP: '1'
+      # Force serial `brew bundle` install. The macos-15 runner image ships a
+      # default env that parallelizes bundle installs (upstream default is
+      # --jobs=1, so the runner is injecting a higher value). Parallel installs
+      # race on shared-dependency Cellar locks — e.g. `luajit` installing while
+      # `luarocks` (which depends on it) installs, or `go` being pulled by two
+      # formulae at once — producing intermittent "process has already locked
+      # /opt/homebrew/Cellar/<keg>" failures and a red macos leg on unchanged
+      # commits. Pinning to 1 here overrides the runner value regardless of its
+      # source. Upstream lock-fix tracked in Homebrew/brew#22293 / #22297; drop
+      # this once the runner image ships it. Real-machine `./install` is
+      # unaffected (it uses Homebrew's serial default).
+      HOMEBREW_BUNDLE_JOBS: '1'
       CI: 'true'
     steps:
       - name: Checkout


### PR DESCRIPTION
## What

Pins `HOMEBREW_BUNDLE_JOBS: '1'` in the macOS job's `env:` block so `brew bundle` installs serially.

## Why

The macOS leg intermittently fails with:

```
A `brew install --formula go` process has already locked /opt/homebrew/Cellar/go.
A `brew install --formula luarocks` process has already locked /opt/homebrew/Cellar/luajit.
`brew bundle` failed! N Brewfile dependencies failed to install
```

A "process has already locked" error requires **two concurrent `brew` processes**, so `brew bundle` is installing in parallel on the runner — even though our helper (`install_from_brewfile.sh`) passes no `--jobs` and Homebrew's upstream default is `--jobs=1`. The `macos-15` runner image ships an env that raises the bundle job count. Parallel installs race on shared-dependency Cellar locks (e.g. `luajit` installing while `luarocks`, which depends on it, installs concurrently; `go` pulled by two formulae at once), so the failures are intermittent and unrelated to the diff under test.

Pinning to `1` forces serial installs and overrides whatever the runner injects.

## Verification note

This branch is based on current `master`, which still contains the dead `adoptopenjdk/openjdk` tap (removed separately in #96). So this PR's macOS check will **still go red on the adoptopenjdk tap failure** — but the `go`/`luarocks` **lock-race lines should be absent**, which is the signal that this fix works. Master goes fully green once both this and #96 land.

## Scope

- Real-machine `./install` is unaffected (relies on Homebrew's serial default; doesn't set this var).
- Upstream lock-fix tracked in [Homebrew/brew#22293](https://github.com/Homebrew/brew/issues/22293) / #22297 — drop the pin once the runner image ships it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)