### PR TITLE
fix: let Otty manage its own shell-integration block

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -200,5 +200,10 @@ fi
 [[ -f "$HOME/.google-cloud-sdk/path.zsh.inc" ]] && source "$HOME/.google-cloud-sdk/path.zsh.inc"
 [[ -f "$HOME/.google-cloud-sdk/completion.zsh.inc" ]] && source "$HOME/.google-cloud-sdk/completion.zsh.inc"
 
-# Otty shell integration (optional; inert unless launched by Otty)
-[[ -n "$OTTY_SHELL_INTEGRATION" && -r "$OTTY_SHELL_INTEGRATION/otty-integration.zsh" ]] && source "$OTTY_SHELL_INTEGRATION/otty-integration.zsh"
+# >>> otty shell integration >>>
+# Added by Otty — toggle in Settings > Shell > Shell Integration.
+# Inert unless launched by Otty (it sets $OTTY_SHELL_INTEGRATION).
+if [ -n "$OTTY_SHELL_INTEGRATION" ] && [ -r "$OTTY_SHELL_INTEGRATION/otty-integration.zsh" ]; then
+  . "$OTTY_SHELL_INTEGRATION/otty-integration.zsh"
+fi
+# <<< otty shell integration <<<


### PR DESCRIPTION
## What

Reverts #97's idiomatic one-liner in `zsh/zshrc` back to Otty's verbatim `# >>>`/`# <<<` markered block.

## Why

Within one session of #97 merging, Otty **re-added its installer block**, leaving a duplicate in the Dotbot-symlinked live `zshrc`:

```zsh
# Otty shell integration (optional; inert unless launched by Otty)   ← #97's one-liner
[[ -n "$OTTY_SHELL_INTEGRATION" && -r … ]] && source …

# >>> otty shell integration >>>                                     ← Otty re-added this
if [ -n "$OTTY_SHELL_INTEGRATION" ] && [ -r … ]; then
  . …
fi
# <<< otty shell integration <<<
```

Otty uses its `# >>>`/`# <<<` markers to detect whether its integration is installed. #97 removed them, so Otty concluded it wasn't and re-appended a fresh block on shell launch — and it'll keep doing that on every new Otty shell.

**The general pattern:** tool-managed markered blocks (conda, nvm, Otty) are conventionally left *verbatim* precisely because the tool rewrites them. The repo's one-line `[[ … ]] && source` idiom is for **hand-managed** integrations (gcloud, openclaw) that nothing re-adds. #97 treated Otty as the latter; it's the former.

Keeping Otty's block exactly as it writes it means Otty matches its own markers and stops duplicating.

## Verification

- `zsh -n zsh/zshrc` parses.
- Block is guarded (`[ -n "$OTTY_SHELL_INTEGRATION" ]`) → inert in CI where the var is unset, so R4 (`zsh -i -c true`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)