### PR TITLE
ci: keep brew-bundle serial pin; correct the droppable premise (P0-4, reversed)

### DIFF
--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -148,17 +148,29 @@ jobs:
       # directive consults it.
       HOMEBREW_NO_AUTO_UPDATE: '1'
       HOMEBREW_NO_INSTALL_CLEANUP: '1'
-      # Force serial `brew bundle` install. The macos-15 runner image ships a
-      # default env that parallelizes bundle installs (upstream default is
-      # --jobs=1, so the runner is injecting a higher value). Parallel installs
-      # race on shared-dependency Cellar locks — e.g. `luajit` installing while
-      # `luarocks` (which depends on it) installs, or `go` being pulled by two
-      # formulae at once — producing intermittent "process has already locked
-      # /opt/homebrew/Cellar/<keg>" failures and a red macos leg on unchanged
-      # commits. Pinning to 1 here overrides the runner value regardless of its
-      # source. Upstream lock-fix tracked in Homebrew/brew#22293 / #22297; drop
-      # this once the runner image ships it. Real-machine `./install` is
-      # unaffected (it uses Homebrew's serial default).
+      # Force serial `brew bundle`. Parallel installs race on shared-dependency
+      # Cellar locks — e.g. `gitleaks` pulling `go` while another formula does,
+      # or `luarocks` pulling `luajit` — producing intermittent
+      # "process has already locked /opt/homebrew/Cellar/<keg>" failures and a
+      # red macos leg on commits that don't touch the Brewfile.
+      #
+      # DO NOT remove this expecting the upstream lock-fix to cover it. The
+      # Homebrew/brew#22293 issue / #22297 fix shipped in Homebrew 5.1.12
+      # (2026-05-16), yet the race STILL occurred on 2026-07-14 (run
+      # 29301199411, macos-15 image 20260706.0213.1, which carries
+      # Homebrew >= 6.0.5 — well above 5.1.12). #22297 does not eliminate this
+      # Brewfile's specific contention. Keep the pin until the race is
+      # root-caused (Brewfile shared-dep fan-out; the P1-3 curation may reduce
+      # but is not expected to eliminate it).
+      #
+      # This pin is workflow-scoped and does not change real-machine `./install`.
+      # Current Homebrew (6.x) defaults HOMEBREW_BUNDLE_JOBS to `auto` (parallel,
+      # up to 4 jobs), so real machines can hit the same contention. The helper
+      # deliberately does not pin it — an explicit speed-vs-reliability tradeoff:
+      # a failed local `brew bundle` MAY succeed on re-run, but the race is
+      # nondeterministic (the colliding pair changes run-to-run), so re-running is
+      # not a guaranteed fix. Pin it in helpers/install_from_brewfile.sh if
+      # deterministic local installs are needed.
       HOMEBREW_BUNDLE_JOBS: '1'
       CI: 'true'
     steps:

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -23,8 +23,12 @@ artifact for the overnight execution loop (Opus 4.8 + Codex adversarial review).
 - **BOOT-02/NVIM (high):** `nvim/custom` targets removed NvChad v1.0 APIs while
   `install_nvim.sh` clones unpinned HEAD (v2.x, `custom/` mechanism deleted upstream);
   live `~/.config/nvim` is a non-git 2022 fossil. Fresh machine = broken editor.
-- **CI-01 (actionable now):** the `HOMEBREW_BUNDLE_JOBS: '1'` pin is droppable — upstream fix
-  shipped in Homebrew 5.1.12; macos-15 runner image carries 6.0.5 (verified).
+- **CI-01 (REVERSED 2026-07-14):** the `HOMEBREW_BUNDLE_JOBS: '1'` pin is NOT droppable. The
+  upstream #22297 fix shipped in Homebrew 5.1.12 and reached the runner (6.0.5+), but run
+  `29301199411` (image `20260706.0213.1`, Homebrew ≥6.0.5) still hit the Cellar-lock race — so
+  #22297 doesn't cover this Brewfile's contention. Keep the pin (P0-4 repurposed to a comment/doc
+  correction). Current Homebrew defaults bundle jobs to parallel `auto`, so real machines are
+  exposed too.
 - **BOOT-05:** Brewfile is a stale dump — 99 installed-but-unrecorded, 7 recorded-but-missing,
   ~30 transitive deps as fake intent; `export_deps` regeneration would corrupt scoped npm names.
 - **TMUX-01:** `tmux-attention.sh` spinner cleanup `pkill` prefix-collides (pane `%2` kills

--- a/docs/plans/2026-07-14-001-chore-10x-roadmap-execution-plan.md
+++ b/docs/plans/2026-07-14-001-chore-10x-roadmap-execution-plan.md
@@ -117,11 +117,19 @@ Acceptance: with two panes whose ids are prefix-related (spawn stub loops), clea
 the other's loop alive; `zsh -n`/`bash -n` clean; hook still sets/clears `@claude_status`.
 
 ### 4. P0-4 `ci/drop-brew-bundle-jobs-pin`
-Scope: `.github/workflows/install-matrix.yml:145-162`. Delete `HOMEBREW_BUNDLE_JOBS: '1'`; fix
-the comment (#22293 is the issue, #22297 the fix PR).
-Evidence: fix merged 2026-05-16 → Homebrew 5.1.12; macos-15 image `20260629.0276.1` ships 6.0.5.
-Acceptance: macOS leg green with zero `already locked` lines (check run log); record wall-clock
-delta in run log. Rollback: re-add the env line.
+**REVERSED during execution (2026-07-14) — DO NOT delete the pin.** The premise below was
+falsified: run `29301199411` (2026-07-14, macos-15 image `20260706.0213.1`, Homebrew ≥6.0.5 —
+above the 5.1.12 fix) still hit `already locked /opt/homebrew/Cellar/{go,luajit}`. #22297 does
+not cover this Brewfile's contention, so removing the pin would reintroduce flaky macOS reds.
+P0-4 was repurposed to a **comment + solution-doc + HANDOFF correction** that keeps the pin and
+records why it can't be dropped. See
+`docs/solutions/cross-machine/brew-bundle-parallel-cellar-lock-race-macos-runner-2026-07-13.md`
+("When to remove the pin" update).
+
+~~Scope: `.github/workflows/install-matrix.yml:145-162`. Delete `HOMEBREW_BUNDLE_JOBS: '1'`; fix
+the comment (#22293 is the issue, #22297 the fix PR). Evidence: fix merged 2026-05-16 → Homebrew
+5.1.12; macos-15 image `20260629.0276.1` ships 6.0.5. Acceptance: macOS leg green with zero
+`already locked` lines; record wall-clock delta. Rollback: re-add the env line.~~
 
 ### 5. P0-5 `fix/remove-orphan-rigellute-tap`
 Scope: `brew/Brewfile:1`. Nothing is installed from `rigellute/tap` (verified); same dead-tap

--- a/docs/solutions/cross-machine/brew-bundle-parallel-cellar-lock-race-macos-runner-2026-07-13.md
+++ b/docs/solutions/cross-machine/brew-bundle-parallel-cellar-lock-race-macos-runner-2026-07-13.md
@@ -1,5 +1,5 @@
 ---
-title: "`brew bundle` races on shared-dependency Cellar locks when the macos-15 runner parallelizes it"
+title: "`brew bundle` races on shared-dependency Cellar locks under Homebrew's parallel `auto` default (observed on the macOS CI leg)"
 date: 2026-07-13
 category: cross-machine
 tags:
@@ -27,7 +27,7 @@ related_solutions:
 
 ## TL;DR
 
-The macOS leg intermittently fails with `... process has already locked /opt/homebrew/Cellar/<keg>`. That error requires **two concurrent `brew` processes** — so `brew bundle` was installing in **parallel** on the runner, even though our helper passes no `--jobs` and Homebrew's upstream default is `--jobs=1` (serial). The `macos-15` runner image injects a higher bundle job count. Parallel installs of formulae that share a dependency keg (e.g. `luarocks` needs `luajit`, which is also a top-level Brewfile entry; `go` is pulled by `gitleaks`) collide on the Cellar lock. It's **nondeterministic** — the racing pair changes run-to-run and a plain re-run doesn't reliably clear it. Fix: pin `HOMEBREW_BUNDLE_JOBS: '1'` in the macOS job `env:` to force serial installs, overriding whatever the runner injects. (PR #98, commit `ab3c347`.) Drop the pin once Homebrew ships its upstream lock-fix ([Homebrew/brew#22293](https://github.com/Homebrew/brew/issues/22293) / #22297) to the runner image.
+The macOS leg intermittently fails with `... process has already locked /opt/homebrew/Cellar/<keg>`. That error requires **two concurrent `brew` processes** — so `brew bundle` was installing in **parallel**, because our helper passes no `--jobs` and current Homebrew (6.x) defaults `HOMEBREW_BUNDLE_JOBS` to `auto` (parallel, up to 4 jobs). (An earlier version of this doc mis-attributed the parallelism to a runner-injected job count and claimed Homebrew defaults to serial — see the 2026-07-14 update below; the default is `auto`, which also exposes real machines.) Parallel installs of formulae that share a dependency keg (e.g. `luarocks` needs `luajit`, which is also a top-level Brewfile entry; `go` is pulled by `gitleaks`) collide on the Cellar lock. It's **nondeterministic** — the racing pair changes run-to-run and a plain re-run doesn't reliably clear it. Fix: pin `HOMEBREW_BUNDLE_JOBS: '1'` in the macOS job `env:` to force serial installs, overriding Homebrew's parallel `auto` default. (PR #98, commit `ab3c347`.) ~~Drop the pin once Homebrew ships its upstream lock-fix ([Homebrew/brew#22293](https://github.com/Homebrew/brew/issues/22293) / #22297) to the runner image.~~ **Superseded — see "When to remove the pin" below: the fix shipped and reached the runner, but the race persists, so the pin stays.**
 
 ## Symptom
 
@@ -48,19 +48,19 @@ Two properties made it clearly a race, not a config bug:
 
 **An "already locked" error requires ≥2 concurrent `brew` processes.** `brew install` acquires a lock on the target formula's `Cellar/<keg>` path; a second `brew` touching the same keg reports "already locked." A single serial installer can never collide with itself.
 
-So `brew bundle` was running **parallel installs** on the runner. But:
+So `brew bundle` was running **parallel installs**. The source:
 
-- Our helper (`helpers/install_from_brewfile.sh`) runs plain `brew bundle --file=./brew/Brewfile` — **no `--jobs` flag**.
-- Homebrew's upstream default is **`--jobs=1` (serial)** — parallel bundle install is opt-in via `--jobs=N` / `--jobs=auto` / the `HOMEBREW_BUNDLE_JOBS` env var (added in [Homebrew/brew#21891](https://github.com/Homebrew/brew/pull/21891)).
+- Our helper (`helpers/install_from_brewfile.sh`) runs plain `brew bundle --file=./brew/Brewfile` — **no `--jobs` flag** — so it inherits Homebrew's default.
+- Current Homebrew (6.x) defaults `HOMEBREW_BUNDLE_JOBS` to **`auto`** (parallel, up to 4 jobs). The `HOMEBREW_BUNDLE_JOBS` env var was added in [Homebrew/brew#21891](https://github.com/Homebrew/brew/pull/21891). (The original investigation believed the default was serial and the runner was "injecting" parallelism — that was wrong; parallelism is Homebrew's own default, which is why it also affects real machines.)
 
-Therefore the parallelism is **injected by the `macos-15` runner image**, which ships a default environment raising the bundle job count. Under parallelism, two formulae that need the same keg get installed concurrently and race on its lock:
+Under that parallel default, two formulae that need the same keg get installed concurrently and race on its lock:
 
 | Racing formula | Shared keg | Why they collide |
 |---|---|---|
 | `luarocks` (top-level) | `luajit` | `luarocks` depends on `luajit`, which is *also* a top-level Brewfile entry — both install paths touch the same keg |
 | `gitleaks` / other | `go` | `go` is pulled as a dependency by a Go-based formula while another install also wants it |
 
-The upstream lock-handling bug is acknowledged and being fixed in Homebrew ([#22293](https://github.com/Homebrew/brew/issues/22293) / #22297) — until that reaches the runner image, parallel bundle installs remain racy.
+The upstream lock-handling bug ([#22293](https://github.com/Homebrew/brew/issues/22293) / #22297, fixed in Homebrew 5.1.12) was expected to make parallel bundle installs safe. **It did not** for this Brewfile — the race persisted on Homebrew ≥6.0.5; see the 2026-07-14 update in "When to remove the pin".
 
 ## Fix
 
@@ -72,24 +72,24 @@ Pin the job count to 1 in the macOS job `env:` block, next to the existing `HOME
     env:
       HOMEBREW_NO_AUTO_UPDATE: '1'
       HOMEBREW_NO_INSTALL_CLEANUP: '1'
-      HOMEBREW_BUNDLE_JOBS: '1'   # force serial; overrides runner-injected parallelism
+      HOMEBREW_BUNDLE_JOBS: '1'   # force serial; overrides Homebrew's parallel `auto` default
       CI: 'true'
 ```
 
-Setting `HOMEBREW_BUNDLE_JOBS: '1'` at job scope overrides whatever the runner injects, regardless of its source (runner env or a future Homebrew default flip).
+Setting `HOMEBREW_BUNDLE_JOBS: '1'` at job scope forces serial installs, overriding Homebrew's `auto` default.
 
 ### Why in the workflow, not the helper
 
 The pin lives in CI config, **not** `install_from_brewfile.sh`, on purpose:
 
-- **Real-machine `./install` is unaffected** — it relies on Homebrew's serial default and doesn't set this var. Forcing `--jobs=1` in the helper would permanently forgo the parallel-install speedup on real bootstraps, even after Homebrew fixes the bug.
-- **Trade-off accepted:** serial install makes the macOS leg somewhat slower but **deterministic** — no more flaky reds.
-- **Escape hatch:** if a *real* fresh-machine install ever races (i.e., Homebrew flips the default to parallel for everyone), export the same var in the helper.
+- **CI must be deterministic.** A flaky red on an unrelated commit is expensive and misleading, so the leg is pinned serial.
+- **Real-machine `./install` is deliberately left unpinned** — it inherits Homebrew's parallel `auto` default and gets the speedup. This is an explicit speed-vs-reliability tradeoff: a real bootstrap **can** hit the same race, but a failed `brew bundle` can be re-run (nondeterministically — the colliding pair changes, so it's not a guaranteed fix) and it's not blocking a merge.
+- **Escape hatch:** pin the same var in `install_from_brewfile.sh` if deterministic local installs are ever required (at the cost of the parallel speedup).
 
 ## The general lesson
 
 - **"already locked" ⇒ concurrency.** If you see a Cellar lock error, something is running two `brew` processes at once. Find the parallelism source before assuming a package is broken.
-- **The parallelism may not be in your code.** Our invocation was serial-by-default; the runner image supplied the parallelism. When CI behaves differently from a local run with identical commands, suspect the runner environment (see workflow header caveat #8 on runner-image rotation).
+- **Check the tool's *current* default, not what you remember.** The parallelism here came from Homebrew's own `HOMEBREW_BUNDLE_JOBS=auto` default (6.x), not from a runner injection as first assumed. A wrong root-cause ("the runner defaults differ") sends you looking in the wrong place and misleads the next reader — verify the default in the installed version.
 - **A re-run is not a fix for a race.** It just re-rolls the dice. Only removing the concurrency (serial install) fixes it deterministically.
 
 ## Sites
@@ -103,4 +103,14 @@ PR #98's macOS log had **zero `already locked` lines** after the pin (the fix's 
 
 ## When to remove the pin
 
-Drop `HOMEBREW_BUNDLE_JOBS: '1'` once the upstream lock-fix ([Homebrew/brew#22293](https://github.com/Homebrew/brew/issues/22293) / #22297) lands in the `macos-15` runner image. At that point parallel bundle installs become safe again and the serial pin is just leaving CI speed on the table. The pin's inline comment flags this.
+**Do not remove it based on the upstream fix.** The original guidance here — "drop the pin once [Homebrew/brew#22293](https://github.com/Homebrew/brew/issues/22293) / #22297 lands in the runner image" — was **wrong**, and this section supersedes it.
+
+### Update 2026-07-14 — the upstream fix does NOT cover this race
+
+The #22297 fix shipped in Homebrew 5.1.12 (2026-05-16) and the `macos-15` runner already carries it: the failing run [`29301199411`](https://github.com/villavicencio/dotfiles/actions/runs/29301199411) (2026-07-14) used image `20260706.0213.1`, which ships **Homebrew ≥ 6.0.5** — well above 5.1.12 — and it *still* logged `A `brew install --formula gitleaks` process has already locked /opt/homebrew/Cellar/go.` and the same for `luarocks`/`luajit`. So #22297 does not eliminate **this Brewfile's** shared-dependency contention.
+
+Two corrections to the analysis above:
+- The claim that "Homebrew's upstream default is `--jobs=1` (serial)" is **outdated**. Current Homebrew (6.x) defaults `HOMEBREW_BUNDLE_JOBS` to `auto` (parallel, up to 4). The runner isn't "injecting" parallelism so much as running Homebrew's own default — and so do **real machines**, which are exposed to the same race (the helper doesn't pin jobs).
+- Removal is therefore **unsafe** and would reintroduce intermittent red macOS legs. Keep `HOMEBREW_BUNDLE_JOBS: '1'` in CI until the race is root-caused at the Brewfile level (shared-dep fan-out; the P1-3 curation may reduce but is not expected to eliminate it). Only then, verify removal with **repeated** parallel runs, not a single green leg.
+
+(Verified while executing roadmap packet P0-4, which had proposed removing the pin; the proposal was reversed on this evidence.)


### PR DESCRIPTION
## P0-4 — REVERSED by the adversarial-review gate

The roadmap proposed **deleting** the macOS `HOMEBREW_BUNDLE_JOBS: '1'` pin because #22297 (Homebrew 5.1.12) "fixed" the Cellar-lock race. Verification proved the premise false, so the pin **stays** and the misleading guidance is corrected instead.

### Evidence
The pin was added 2026-07-13 (`ab3c347`) after failures. The motivating failure — run [`29301199411`](https://github.com/villavicencio/dotfiles/actions/runs/29301199411) (2026-07-14) — ran on macos-15 image `20260706.0213.1` carrying **Homebrew ≥ 6.0.5** (above the 5.1.12 fix) and still logged `already locked /opt/homebrew/Cellar/go` + `luajit`. So #22297 does not cover this Brewfile's contention; removal would reintroduce flaky macOS reds.

### Changes (no behavior change — pin retained)
- Workflow comment rewritten: keep the pin, document the persisting race, and fix the false "real-machine uses serial default" claim (Homebrew 6.x defaults bundle jobs to parallel `auto`; real machines are exposed; helper unpinned as a speed-vs-reliability tradeoff).
- Lock-race **solution doc**: "When to remove" superseded (2026-07-14 update); TL;DR / root-cause / title corrected to consistently attribute parallelism to Homebrew's `auto` default.
- **HANDOFF.md** CI-01 and the **execution plan** P0-4 entry marked REVERSED.

### Review
Codex `gpt-5.6-sol`, **5 rounds → approve** — the reviewer *raised* the false premise, then confirmed the fix against the repo's failure history and Homebrew 6.0.11 source.