### PR TITLE
fix: drop orphan rigellute/tap from Brewfile (P0-5)

### DIFF
--- a/brew/Brewfile
+++ b/brew/Brewfile
@@ -1,4 +1,3 @@
-tap "rigellute/tap"
 brew "ack"
 brew "aria2"
 brew "atuin"


### PR DESCRIPTION
## P0-5 — orphan tap

`tap "rigellute/tap"` (Brewfile line 1) is declared but unused — no `brew "rigellute/tap/<formula>"` entries depend on it (the tap only provides `spotify-tui`). Same dead-tap class as adoptopenjdk (#96): needless tapping step + a 404 failure surface.

**Verification:** `rigellute` appears only on line 1; `brew bundle check --verbose` unmet-dependency output is identical before/after. Codex review: 1 round → approve.