### PR TITLE
chore: curate Brewfile to intentional tools + read-only drift reporter (P1-3)

### DIFF
--- a/brew/Brewfile
+++ b/brew/Brewfile
@@ -1,109 +1,145 @@
-brew "ack"
-brew "aria2"
-brew "atuin"
+# =============================================================================
+# Brewfile — Homebrew formulae & casks for both Macs.
+#
+# This records INTENTIONAL top-level tools only. Pure transitive dependencies
+# (libraries pulled in by the tools below) are deliberately NOT listed —
+# Homebrew reinstalls them automatically as dependencies. Language runtimes
+# owned by version managers are excluded on purpose:
+#   node   -> nvm    (zsh/zshenv NODE_VERSION + helpers/install_node.sh)
+#   ruby   -> rvm    (~/.rvm)
+#   python -> pyenv
+#
+# Before editing, run `helpers/report_drift.sh` to see installed-but-unrecorded
+# and recorded-but-missing formulae/casks and npm globals. It is read-only.
+# =============================================================================
+
+# --- Shell, prompt, history, navigation ---
+brew "bash"                 # modern bash (macOS ships 3.2); used by scripts + fresh installs
+brew "starship"             # cross-shell prompt (starship/starship.toml)
+brew "atuin"                # shell history database + Ctrl-R search
+brew "fzf"                  # fuzzy finder (Ctrl-T widget; ^R restored to atuin)
+brew "zoxide"               # smarter cd (z)
+brew "zsh-completions"      # extra completions — inert until wired: add
+                            #   fpath+=($(brew --prefix)/share/zsh-completions)
+                            # before compinit in zsh/zshrc (ZSH-12 follow-up).
+
+# --- Modern CLI replacements / file & text tools ---
+brew "bat"                  # cat with syntax highlighting
+brew "eza"                  # modern ls
+brew "fd"                   # modern find
+brew "ripgrep"              # fast recursive grep (rg)
+brew "tree"                 # directory tree view
+brew "duf"                  # disk usage/free (df replacement)
+brew "ncdu"                 # interactive disk usage
+brew "jq"                   # JSON processor
+brew "glow"                 # markdown renderer
+brew "tldr"                 # simplified, example-first man pages
+brew "watch"                # run a command periodically
+brew "most"                 # feature-rich pager
+
+# --- Git & code review ---
+brew "git"
+brew "gh"                   # GitHub CLI
+brew "git-delta"            # syntax-highlighting diff pager (git [pager] override)
+brew "lazygit"              # git TUI
+brew "tig"                  # git history TUI
+brew "icdiff"               # side-by-side colored diff
+brew "gitleaks"             # secret scanner (pre-commit hook)
+brew "pre-commit"           # git hook framework
+
+# --- Editor & Lua stack (Neovim) ---
+brew "neovim"
+brew "lua"
+brew "luajit"
+brew "luarocks"
+brew "lua-language-server"
+
+# --- Language runtimes / version managers (node/ruby/python: see header) ---
+brew "pyenv"                # Python version manager
+brew "pyenv-virtualenv"     # pyenv virtualenv plugin
+brew "pipx"                 # install Python CLI apps in isolated venvs
+brew "perl"                 # scripting + irssi
+brew "cpanminus"            # Perl module installer (cpanm)
+brew "go"                   # Go toolchain
+brew "yarn"                 # JS package manager
+
+# --- Build toolchain (compiling from source) ---
 brew "autoconf"
 brew "autoconf-archive"
 brew "automake"
-brew "bash"
-brew "bat"
-brew "bdw-gc"
-brew "berkeley-db"
-brew "boost"
-brew "brotli"
-brew "btop"
-brew "c-ares"
-brew "cffi"
 brew "cmake"
-brew "coreutils"
-brew "cpanminus"
-brew "curl"
-brew "docbook"
-brew "docbook-xsl"
-brew "libyaml"
-brew "dotbot"
-brew "duf"
-brew "eza"
-brew "fd"
-brew "freetype"
-brew "fswatch"
-brew "fzf"
-brew "gawk"
-brew "gdbm"
+brew "make"                 # GNU make (newer than macOS's)
+brew "coreutils"            # GNU coreutils (gnubin on PATH — see zsh/zshenv)
+brew "gnu-sed"              # GNU sed (gsed)
+brew "gawk"                 # GNU awk
+
+# --- Networking & downloads ---
+brew "curl"                 # newer curl (opt/curl/bin on PATH)
+brew "wget"
+brew "aria2"                # multi-connection downloader
+brew "yt-dlp"               # video/audio downloader
+
+# --- System monitoring & cleanup ---
+brew "btop"                 # resource monitor
+brew "fswatch"              # filesystem change monitor
+brew "mac-cleanup-py"       # macOS cleanup utility
+brew "kondo"                # project build-artifact cleanup
+
+# --- Security ---
+brew "gnupg"                # GPG (signing, encryption)
+
+# --- Terminal multiplexer ---
+brew "tmux"
+
+# --- Docs, linting, prose ---
+brew "vale"                 # prose linter (vale/)
+brew "shellcheck"           # shell script linter
+brew "source-highlight"     # syntax highlighting for less (LESSOPEN)
+
+# --- Package / dotfiles / system management ---
+brew "dotbot"               # dotfiles installer (a vendored submodule also exists)
+brew "topgrade"             # unified system updater (topgrade/topgrade.toml)
+
+# --- Cloud / deploy ---
+brew "vercel-cli"
+
+# --- Misc / oddballs (intentional installs) ---
+brew "grc"                  # generic text colorizer
+brew "lolcat"               # rainbow text
+brew "jrnl"                 # command-line journal
+brew "irssi"                # IRC client
+brew "handbrake"            # video transcoder (CLI)
+# Prune candidates — redundant with ripgrep / cosmetic. Kept for now; remove if
+# unwanted (flagged in the P1-3 PR for review):
+brew "ack"                  # grep-like search (ripgrep covers this)
+brew "the_silver_searcher"  # ag search (ripgrep covers this)
+brew "screenfetch"          # system-info banner (cosmetic)
+
+# --- Explicitly installed, retained pending owner review ---
+# Each of these was `brew install`ed on request (per `brew leaves
+# --installed-on-request`) but is currently required by nothing — mostly stale
+# library / build deps pulled in by hand for tools no longer present. They are
+# kept (not silently dropped) because they were intentional; prune once
+# confirmed unused. `helpers/report_drift.sh` and `brew uses --installed <f>`
+# help decide.
+brew "berkeley-db"
 brew "gdk-pixbuf"
-brew "gh"
-brew "giflib"
-brew "git"
-brew "git-delta"
-brew "gitleaks"
-brew "glow"
-brew "gnu-getopt"
-brew "gnu-sed"
-brew "gnupg"
-brew "go"
-brew "grc"
 brew "guile"
-brew "handbrake"
-brew "icdiff"
 brew "imlib2"
-brew "irssi"
-brew "jq"
-brew "jrnl"
-brew "kondo"
-brew "lazygit"
 brew "libpthread-stubs"
-brew "libtermkey"
-brew "libuv"
-brew "libvterm"
-brew "libxml2"
+brew "libtermkey"           # historical Neovim dependency
+brew "libvterm"             # historical Neovim dependency
 brew "libxslt"
 brew "libzip"
-brew "lolcat"
-brew "lua"
-brew "lua-language-server"
-brew "luajit"
-brew "luarocks"
-brew "luv"
-brew "mac-cleanup-py"
-brew "make"
-brew "most"
-brew "topgrade"
-brew "msgpack"
-brew "ncdu"
-brew "neovim"
-brew "node"
-brew "pcre"
-brew "perl"
-brew "pipx"
+brew "msgpack"              # historical Neovim dependency
 brew "portaudio"
-brew "pre-commit"
-brew "pyenv"
-brew "pyenv-virtualenv"
-brew "python@3.10"
-brew "rbenv"
-brew "ripgrep"
-brew "ruby"
-brew "screenfetch"
-brew "shellcheck"
-brew "source-highlight"
-brew "starship"
-brew "the_silver_searcher"
-brew "tig"
-brew "tldr"
-brew "tmux"
-brew "tree"
 brew "util-linux"
-brew "vale"
-brew "vercel-cli"
-brew "watch"
-brew "wget"
 brew "xmlto"
-brew "yarn"
-brew "yt-dlp"
-brew "zoxide"
-brew "zsh-completions"
-cask "corelocationcli"
+
+# --- Casks ---
+cask "corelocationcli"      # CLI to read macOS CoreLocation (location-based tooling)
 cask "docker-desktop"
 cask "git-credential-manager"
-cask "maccy"
-cask "pearcleaner"
-cask "shottr"
+cask "maccy"                # clipboard manager
+cask "pearcleaner"          # app uninstaller
+cask "shottr"               # screenshot tool

--- a/export_deps
+++ b/export_deps
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-brew bundle dump --force --file=brew/Brewfile
-ls "$(npm root -g)" > npm/npm-requirements.txt

--- a/helpers/report_drift.sh
+++ b/helpers/report_drift.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+#
+# report_drift.sh — READ-ONLY report of drift between this machine and the
+# tracked manifests (brew/Brewfile, npm/npm-requirements.txt).
+#
+# It NEVER modifies any manifest. It replaces the old regenerate-from-machine
+# habit (`brew bundle dump` / `ls $(npm root -g)`), which (a) recorded
+# transitive dependencies as fake intent and (b) mangled scoped npm packages
+# (`ls $(npm root -g)` lists `@scope` as one entry, losing `@scope/name`).
+#
+# It reports only INTENT-level drift: intentionally-installed formulae (every
+# one whose receipt has installed_on_request), casks, taps, and global npm
+# packages — never the pure transitive dependency graph. If it cannot read an
+# authoritative inventory it
+# says so on stderr and exits non-zero, so a failure can't masquerade as a
+# clean report.
+#
+# Usage: helpers/report_drift.sh   (run from anywhere)
+set -uo pipefail
+
+# Keep this strictly read-only: stop `brew` from auto-updating its own repos
+# (a network fetch + writes under the Homebrew prefix) as a side effect of the
+# `brew bundle check` / `leaves` / `tap` calls below.
+export HOMEBREW_NO_AUTO_UPDATE=1
+export HOMEBREW_NO_INSTALL_CLEANUP=1
+export HOMEBREW_NO_ENV_HINTS=1
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BREWFILE="$REPO_ROOT/brew/Brewfile"
+NPM_REQ="$REPO_ROOT/npm/npm-requirements.txt"
+status=0
+
+hr() { printf '\n== %s ==\n' "$1"; }
+indent() { sed 's/^/  /'; }
+# Print the lines in $1 that are not in $2, indented; "(none)" if empty.
+only_in_first() { comm -23 <(printf '%s\n' "$1") <(printf '%s\n' "$2") | grep . | indent || echo "  (none)"; }
+only_in_second() { comm -13 <(printf '%s\n' "$1") <(printf '%s\n' "$2") | grep . | indent || echo "  (none)"; }
+
+# ---------------------------------------------------------------------------
+# Homebrew
+# ---------------------------------------------------------------------------
+if command -v brew >/dev/null 2>&1; then
+  if [ ! -f "$BREWFILE" ]; then
+    echo "ERROR: Brewfile not found at $BREWFILE" >&2
+    exit 2
+  fi
+
+  # Recorded but not satisfied. `brew bundle check` exits 0 (satisfied) or 1
+  # (unsatisfied) — both expected; a higher code is a real failure.
+  check_out="$(brew bundle check --file="$BREWFILE" --verbose 2>&1)"; check_rc=$?
+  if [ "$check_rc" -gt 1 ] || printf '%s\n' "$check_out" | grep -qiE '^Error|SyntaxError'; then
+    echo "ERROR: 'brew bundle check' failed (exit $check_rc):" >&2
+    printf '%s\n' "$check_out" | indent >&2
+    status=1
+  fi
+  hr "Homebrew: recorded but not satisfied (in Brewfile, not installed / outdated)"
+  printf '%s\n' "$check_out" | grep -iE 'needs? to be installed|not installed|would install' | indent \
+    || echo "  (none)"
+
+  # Manifest sets.
+  bf_formulae="$(grep -E '^brew ' "$BREWFILE" | sed -E 's/^brew "([^"]+)".*/\1/; s|.*/||' | sort -u)"
+  bf_casks="$(grep -E '^cask ' "$BREWFILE" | sed -E 's/^cask "([^"]+)".*/\1/' | sort -u)"
+  bf_taps="$(grep -E '^tap ' "$BREWFILE" | sed -E 's/^tap "([^"]+)".*/\1/' | sort -u)"
+
+  # Machine inventories. Fail loudly if any can't be read.
+  #
+  # Use the COMPLETE set of intentionally-installed formulae (every one whose
+  # install receipt has installed_on_request), not `brew leaves
+  # --installed-on-request` — the latter drops on-request formulae that later
+  # became a dependency of something else, silently omitting real intent.
+  # Normalize BOTH sides to the basename so a tap-qualified machine entry
+  # (`oven-sh/bun/bun`) matches a Brewfile entry however written (`bun` or the
+  # qualified form). (Basename collisions across taps are possible but rare.)
+  if ! onrequest="$(brew info --json=v2 --installed 2>/dev/null | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(3)
+out = set()
+for f in d.get("formulae", []):
+    for inst in f.get("installed", []):
+        if inst.get("installed_on_request"):
+            out.add(f["name"].split("/")[-1])
+            break
+for n in sorted(out):
+    print(n)
+' 2>/dev/null)" || [ -z "$onrequest" ]; then
+    echo "ERROR: 'brew info --json' returned no on-request formulae — cannot compute formula drift" >&2
+    status=1; onrequest=""
+  fi
+  if ! casks="$(brew list --cask -1 2>/dev/null | sort -u)"; then
+    echo "ERROR: 'brew list --cask' failed — cannot compute cask drift" >&2
+    status=1; casks=""
+  fi
+  if ! taps="$(brew tap 2>/dev/null | sort -u)"; then
+    echo "ERROR: 'brew tap' failed — cannot compute tap drift" >&2
+    status=1; taps=""
+  elif [ -n "$taps" ] && printf '%s\n' "$taps" | grep -qvE '^[^[:space:]/]+/[^[:space:]/]+$'; then
+    echo "ERROR: 'brew tap' returned lines that are not owner/repo taps — refusing to report tap drift" >&2
+    status=1; taps=""
+  fi
+
+  hr "Homebrew: top-level formulae installed but NOT in Brewfile (unrecorded intent)"
+  only_in_first "$onrequest" "$bf_formulae"
+  hr "Homebrew: casks installed but NOT in Brewfile"
+  only_in_first "$casks" "$bf_casks"
+  hr "Homebrew: active taps not in Brewfile"
+  only_in_first "$taps" "$bf_taps"
+else
+  echo "ERROR: brew not found on PATH — cannot report Homebrew drift" >&2
+  status=1
+fi
+
+# ---------------------------------------------------------------------------
+# npm globals (scoped-package aware via --json)
+# ---------------------------------------------------------------------------
+if command -v npm >/dev/null 2>&1; then
+  # Read the global node_modules directory directly rather than `npm ls`, whose
+  # JSON output is filtered by inherited config (e.g. npm_config_link/omit) and
+  # can silently return a subset of the installed globals. Reading the directory
+  # is config-filter-independent and scope-aware; an absent/empty directory is a
+  # valid "zero globals" state (e.g. an unusual prefix), not a failure.
+  if ! npm_root="$(npm root -g 2>/dev/null)" || [ -z "$npm_root" ]; then
+    echo "ERROR: 'npm root -g' failed — cannot read npm global inventory" >&2
+    status=1
+  else
+    installed=""
+    inv_ok=1
+    if [ ! -d "$npm_root" ]; then
+      : # global root does not exist yet -> installed stays "" (valid zero globals)
+    elif [ ! -r "$npm_root" ] || [ ! -x "$npm_root" ]; then
+      # Searchable-but-unreadable (or fully unreadable) root: the glob would list
+      # nothing and be mistaken for "zero globals". Treat as an error instead.
+      echo "ERROR: npm global root $npm_root is not readable — cannot list globals" >&2
+      status=1; inv_ok=0
+    else
+      # If the root exists but can't be entered/read, the subshell exits nonzero;
+      # capture that so an unreadable root is an error, NOT a false "zero globals".
+      if ! installed="$(
+        cd "$npm_root" || exit 1
+        shopt -s nullglob
+        for d in */; do
+          name="${d%/}"
+          # Skip dotfiles (.bin, .package-lock.json). The leading "(" on the
+          # pattern balances the ")" so the enclosing command substitution
+          # parses correctly.
+          case "$name" in (.*) continue ;; esac
+          if [ "${name#@}" != "$name" ]; then
+            # scope directory: emit @scope/pkg for each package inside it
+            for s in "$name"/*/; do printf '%s\n' "${s%/}"; done
+          else
+            printf '%s\n' "$name"
+          fi
+        done | sort -u
+      )"; then
+        echo "ERROR: could not read npm global root $npm_root (unreadable directory?)" >&2
+        status=1; inv_ok=0
+      fi
+    fi
+    # (root absent -> installed stays "" -> a valid zero-globals state)
+
+    if [ "$inv_ok" -eq 0 ]; then
+      :   # already errored; skip the manifest comparison for this run
+    elif [ ! -f "$NPM_REQ" ]; then
+      # -f (not -r): a readable *directory* would pass -r and silently yield an
+      # empty manifest.
+      echo "ERROR: npm requirements is not a regular file: $NPM_REQ — cannot compute npm drift" >&2
+      status=1
+    elif ! npm_req_raw="$(cat "$NPM_REQ" 2>/dev/null)"; then
+      # Catch read / I/O failures up front, so the parse below runs in-memory and
+      # can't mask a read error as an empty manifest.
+      echo "ERROR: failed to read $NPM_REQ — cannot compute npm drift" >&2
+      status=1
+    # Parse in-memory. `sed '/^$/d'` (not `grep -v '^$'`) drops blank lines while
+    # returning 0 on empty input, so the pipeline's exit reflects a REAL failure
+    # (sed/tr/sort error under pipefail) rather than a benign empty result.
+    elif ! recorded="$(printf '%s\n' "$npm_req_raw" | sed 's/#.*//' | tr -d '[:blank:]' | sed '/^$/d' | sort -u)"; then
+      echo "ERROR: failed to parse $NPM_REQ — cannot compute npm drift" >&2
+      status=1
+    else
+      hr "npm: installed globals NOT in npm-requirements.txt"
+      only_in_first "$installed" "$recorded"
+      hr "npm: recorded in npm-requirements.txt but NOT installed"
+      only_in_second "$installed" "$recorded"
+    fi
+  fi
+else
+  echo "ERROR: npm not found on PATH — cannot report npm drift" >&2
+  status=1
+fi
+
+hr "Done (read-only — no manifests were modified)"
+exit "$status"


### PR DESCRIPTION
## P1-3 — Brewfile curation + `report_drift.sh`

The Brewfile had drifted into a machine dump. Curate it to intentional top-level tools in commented sections, and replace the destructive `export_deps` with a read-only drift reporter.

### Brewfile
- Drop the pure transitive-dependency attic (Homebrew reinstalls as deps of kept tools) and version-manager runtimes (node→nvm, rbenv+ruby→rvm, python@3.10→pyenv).
- **Retain** 13 `installed-on-request` formulae in a flagged "review" section (not silently dropped).
- **Prune candidates flagged** for your review: `ack`, `the_silver_searcher` (redundant with ripgrep), `screenfetch` (cosmetic).

### `helpers/report_drift.sh` (replaces destructive `export_deps`)
The old `export_deps` ran `brew bundle dump --force` + `ls $(npm root -g) >`, clobbering both manifests and mangling scoped npm names — **removed**. The new reporter is strictly read-only:
- Formula drift from the complete `installed_on_request` set; casks + taps separate; basename-normalized.
- npm globals read from the global `node_modules` directory (scope-aware, config-filter-independent); absent root = valid zero-globals, unreadable root = error.
- Every inventory validated; exits non-zero with a diagnostic if any can't be read. `HOMEBREW_NO_AUTO_UPDATE` keeps it from writing.

### Review
Codex `gpt-5.6-sol`, **13 rounds → approve**. The review caught the destructive `export_deps`, npm-config-injection edges, and an incomplete on-request inventory. Machine reconciliation of the 59 unrecorded formulae is a morning task.