### PR TITLE
fix(zsh): sweep dead config; capability-aware fzf init (P2-3)

### DIFF
--- a/.github/actions/install-matrix-post-apply/action.yml
+++ b/.github/actions/install-matrix-post-apply/action.yml
@@ -69,7 +69,7 @@ runs:
       shell: bash
       run: |
         set -eo pipefail
-        plugins="zsh-256color zsh-autosuggestions zsh-history-substring-search zsh-syntax-highlighting"
+        plugins="zsh-autosuggestions zsh-history-substring-search zsh-syntax-highlighting"
         missing=0
         for p in $plugins; do
           d="$HOME/.oh-my-zsh/custom/plugins/$p"

--- a/helpers/install_omz.sh
+++ b/helpers/install_omz.sh
@@ -131,7 +131,6 @@ fi
 # associative arrays, so a plain indexed array of delimited strings is used —
 # the previous `declare -A` silently failed under bash 3.2 and installed 0 plugins.
 PLUGINS=(
-  "zsh-256color|https://github.com/chrissicool/zsh-256color"
   "zsh-autosuggestions|https://github.com/zsh-users/zsh-autosuggestions"
   "zsh-history-substring-search|https://github.com/zsh-users/zsh-history-substring-search"
   "zsh-syntax-highlighting|https://github.com/zsh-users/zsh-syntax-highlighting"

--- a/zsh/iterm2.zsh
+++ b/zsh/iterm2.zsh
@@ -145,4 +145,9 @@ if [[ -o interactive ]]; then
   fi
 fi
 fi
-alias imgcat=~/.iterm2/imgcat;alias imgls=~/.iterm2/imgls;alias it2api=~/.iterm2/it2api;alias it2attention=~/.iterm2/it2attention;alias it2check=~/.iterm2/it2check;alias it2copy=~/.iterm2/it2copy;alias it2dl=~/.iterm2/it2dl;alias it2getvar=~/.iterm2/it2getvar;alias it2git=~/.iterm2/it2git;alias it2setcolor=~/.iterm2/it2setcolor;alias it2setkeylabel=~/.iterm2/it2setkeylabel;alias it2ul=~/.iterm2/it2ul;alias it2universion=~/.iterm2/it2universion
+# iTerm2 utility aliases target ~/.iterm2/* scripts (installed by iTerm2's shell
+# integration). Only define them when that directory exists, so they aren't dead
+# aliases on machines/terminals without iTerm2 integration.
+if [[ -d "$HOME/.iterm2" ]]; then
+  alias imgcat=~/.iterm2/imgcat;alias imgls=~/.iterm2/imgls;alias it2api=~/.iterm2/it2api;alias it2attention=~/.iterm2/it2attention;alias it2check=~/.iterm2/it2check;alias it2copy=~/.iterm2/it2copy;alias it2dl=~/.iterm2/it2dl;alias it2getvar=~/.iterm2/it2getvar;alias it2git=~/.iterm2/it2git;alias it2setcolor=~/.iterm2/it2setcolor;alias it2setkeylabel=~/.iterm2/it2setkeylabel;alias it2ul=~/.iterm2/it2ul;alias it2universion=~/.iterm2/it2universion
+fi

--- a/zsh/zshenv
+++ b/zsh/zshenv
@@ -50,7 +50,13 @@ export EDITOR='nvim'
 if [ -n "$ZSH_VERSION" ]; then
   eval 'export DOTFILES=${${:-$ZDOTDIR/.zshrc}:A:h:h}'
 else
-  export DOTFILES="$(CDPATH= cd -- "$(dirname -- "$(readlink "$ZDOTDIR/.zshrc")")/.." && pwd -P)"
+  # Non-zsh (the install pipeline `.`-sources this under sh/bash, sometimes with
+  # ZDOTDIR unset — e.g. helpers/install_tmux.sh). Use the git derivation, which
+  # resolves the repo whether or not ZDOTDIR is set: with it, from the symlinked
+  # .zshrc's dir; without it, readlink yields "" so `git -C .` runs from the repo
+  # cwd the install helpers already sit in. A subprocess here is fine — never hit
+  # on the subprocess-free zsh startup path above.
+  export DOTFILES="$(git -C "$(dirname "$(readlink "$ZDOTDIR/.zshrc" 2>/dev/null)" 2>/dev/null)" rev-parse --show-toplevel 2>/dev/null)"
 fi
 
 # ======================================

--- a/zsh/zshenv
+++ b/zsh/zshenv
@@ -42,9 +42,16 @@ export EDITOR='nvim'
 # Prioritize using GNU commands over BSD commands (macOS only)
 [[ -d "$BREW_PREFIX/opt/coreutils/libexec/gnubin" ]] && export PATH="$BREW_PREFIX/opt/coreutils/libexec/gnubin:$PATH"
 
-# Save reference to dotfiles directory. Subprocess-free: resolve the symlinked
-# .zshrc to its real path in the repo, then take its grandparent (repo root).
-export DOTFILES=${${:-$ZDOTDIR/.zshrc}:A:h:h}
+# Save reference to the dotfiles directory: resolve the symlinked .zshrc to its
+# real path in the repo, then take its grandparent (repo root). In zsh this is
+# subprocess-free via modifiers. This file is ALSO `.`-sourced by /bin/sh during
+# `./install`, where the zsh `${…:A:h:h}` form is a fatal "bad substitution" — so
+# guard on $ZSH_VERSION and give POSIX sh a readlink/dirname fallback.
+if [ -n "$ZSH_VERSION" ]; then
+  eval 'export DOTFILES=${${:-$ZDOTDIR/.zshrc}:A:h:h}'
+else
+  export DOTFILES="$(CDPATH= cd -- "$(dirname -- "$(readlink "$ZDOTDIR/.zshrc")")/.." && pwd -P)"
+fi
 
 # ======================================
 #             PATH CONFIG

--- a/zsh/zshenv
+++ b/zsh/zshenv
@@ -42,9 +42,9 @@ export EDITOR='nvim'
 # Prioritize using GNU commands over BSD commands (macOS only)
 [[ -d "$BREW_PREFIX/opt/coreutils/libexec/gnubin" ]] && export PATH="$BREW_PREFIX/opt/coreutils/libexec/gnubin:$PATH"
 
-# Save reference to dotfiles directory.
-export DOTFILES=$(git -C "$(dirname "$(readlink "$ZDOTDIR/.zshrc")")" \
-    rev-parse --show-toplevel)
+# Save reference to dotfiles directory. Subprocess-free: resolve the symlinked
+# .zshrc to its real path in the repo, then take its grandparent (repo root).
+export DOTFILES=${${:-$ZDOTDIR/.zshrc}:A:h:h}
 
 # ======================================
 #             PATH CONFIG
@@ -110,26 +110,13 @@ export HISTFILE="$ZDOTDIR/.zsh_history"
 # Change the time stamp shown in the history command output.
 export HIST_STAMPS="mm/dd/yyyy"
 
-# Allow 32³ entries; the default is 500.
+# Allow up to 1,000,000 entries; the default is 500.
 export HISTSIZE=1000000
 export SAVEHIST=$HISTSIZE
 
 # ======================================
-#             HOMEBREW CONFIG
-# ======================================
-
-# Enables automatic cleanup of installed Homebrew packages.
-export HOMEBREW_INSTALL_CLEANUP=1
-
-# ======================================
 #             NVM CONFIG
 # ======================================
-
-# Defer NVM initialization until it's actually needed.
-export NVM_LAZY=true
-
-# Enable NVM command-line completion.
-export NVM_COMPLETION=true
 
 # Node Version Manager path.
 export NVM_DIR=$XDG_CONFIG_HOME/nvm
@@ -174,22 +161,8 @@ export AWS_ASSUME_ROLE_TTL=12h
 export STARSHIP_CONFIG=$DOTFILES/starship/starship.toml
 
 # ======================================
-#          NVIM CONFIG
-# ======================================
-
-# Set the path to the Neovim configuration file
-export MYVIMRC=$XDG_CONFIG_HOME/nvim/init.vim
-
-# ======================================
 #           TMUX CONFIG
 # ======================================
 
 # Set the path for the Tmux plugin manager to store installed plugins
 export TMUX_PLUGIN_MANAGER_PATH=$XDG_CONFIG_HOME/tmux/plugins/
-
-# ======================================
-#           LUA CONFIG
-# ======================================
-
-# Set the path used by require to search for a Lua loader
-export LUA_PATH="$DOTFILES/?.lua;./?.lua"

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -6,7 +6,9 @@ zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=*' 'l:
 zstyle ':completion:*' menu select
 zstyle ':completion:*' list-colors ''
 zstyle ':completion:*' use-cache on
-zstyle ':completion:*' cache-path $ZSH_CACHE_DIR
+# Hardcode the cache dir: $ZSH_CACHE_DIR isn't set until OMZ sources (below), so
+# referencing it here would leave the cache path empty.
+zstyle ':completion:*' cache-path "${XDG_CACHE_HOME:-$HOME/.cache}/zsh"
 zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#)*=0=01;31'
 zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
 
@@ -44,17 +46,17 @@ setopt HIST_IGNORE_SPACE      # Do not record an event starting with a space.
 setopt HIST_SAVE_NO_DUPS      # Do not write a duplicate event to the history file.
 setopt HIST_VERIFY            # Do not execute immediately upon history expansion.
 
-# Load plugins in optimal order
-# Plugin order matters! Add plugins wisely as they impact shell startup time.
+# Load plugins in optimal order. Order matters — it affects both correctness and
+# startup time.
 # 1. Core plugins first (git)
-# 2. UI/UX enhancements (256color, autosuggestions)
-# 3. zsh-syntax-highlighting must be last
+# 2. UI/UX enhancements (autosuggestions)
+# 3. zsh-syntax-highlighting, THEN zsh-history-substring-search — the latter must
+#    be sourced AFTER syntax-highlighting per its README, so it loads last.
 plugins=(
   git                          # Load git first as other plugins might depend on it
-  zsh-256color                 # Terminal color support
   zsh-autosuggestions          # Suggestions based on history
-  zsh-history-substring-search # Better history search (depends on syntax-highlighting)
-  zsh-syntax-highlighting      # Must be last for proper highlighting
+  zsh-syntax-highlighting      # Before history-substring-search (per its README)
+  zsh-history-substring-search # Must load AFTER zsh-syntax-highlighting
 )
 
 source "$ZSH/oh-my-zsh.sh"
@@ -77,22 +79,35 @@ source "$DOTFILES/zsh/iterm2.zsh"   # iTerm2 integration after functions
 source "$DOTFILES/zsh/alias.sh"     # Aliases last as they might use functions
 source "$HOME/env.sh" 2>/dev/null   # Optional overrides at the very end
 
-# Lazy load fzf
-if [[ -f "$HOME/.fzf.zsh" ]]; then
-  _load_fzf() {
-    unset -f _load_fzf fzf fzf-cd-widget fzf-file-widget
-    source "$HOME/.fzf.zsh"
-    # fzf's key-bindings re-bind ^R on load; atuin owns ^R, so restore it.
-    if command -v atuin >/dev/null 2>&1; then
-      bindkey -M emacs '^r' atuin-search 2>/dev/null
-      bindkey -M viins '^r' atuin-search-viins 2>/dev/null
-    fi
-  }
-  fzf()             { _load_fzf; fzf "$@"; }
-  fzf-cd-widget()   { _load_fzf; fzf-cd-widget "$@"; }
-  fzf-file-widget() { _load_fzf; fzf-file-widget "$@"; }
-  bindkey '^T' fzf-file-widget
-  bindkey '\ec' fzf-cd-widget
+# fzf key-bindings + completion. Modern fzf (>= 0.48) ships `fzf --zsh`, which
+# defines the real zle widgets and binds ^T (file), \ec (cd), and ^R (history).
+# atuin's init below runs AFTER this and re-claims ^R for atuin-search, so ^R
+# stays atuin. (The old lazy block sourced a non-existent ~/.fzf.zsh and bound
+# ^T to a plain function that was never a zle widget.)
+if command -v fzf >/dev/null 2>&1; then
+  if fzf --zsh >/dev/null 2>&1; then
+    # fzf >= 0.48 ships `fzf --zsh` (real zle widgets + completion). Capability-
+    # checked just above, so the ONLY thing this 2>/dev/null hides is fzf's
+    # benign option-restore "can't change option: zle", which fires solely under
+    # the tty-less `zsh -i -c` health check (a real interactive session is clean)
+    # — not a genuine init error. Keeps `zsh -i -c true` a true breakage signal.
+    source <(fzf --zsh) 2>/dev/null
+  else
+    # Older fzf (e.g. Ubuntu 24.04 ships 0.44, which predates `--zsh`): source the
+    # distro/Homebrew integration scripts instead. Same narrow rationale for the
+    # 2>/dev/null: we only source files we've confirmed exist (-f), so the only
+    # possible stderr is fzf's benign tty-less init noise under `zsh -i -c`, never
+    # a missing-file or version error.
+    for _fzf_dir in /usr/share/doc/fzf/examples /usr/share/fzf \
+                    "$BREW_PREFIX/opt/fzf/shell"; do
+      if [[ -f "$_fzf_dir/key-bindings.zsh" ]]; then
+        source "$_fzf_dir/key-bindings.zsh" 2>/dev/null
+        [[ -f "$_fzf_dir/completion.zsh" ]] && source "$_fzf_dir/completion.zsh" 2>/dev/null
+        break
+      fi
+    done
+    unset _fzf_dir
+  fi
 fi
 
 # Lazy load pyenv
@@ -107,8 +122,7 @@ if command -v pyenv 1>/dev/null 2>&1; then
   pip()    { _load_pyenv; pip "$@"; }
 fi
 
-# Lazy load NVM
-export NVM_DIR="$HOME/.config/nvm"
+# Lazy load NVM. NVM_DIR is exported once in zshenv ($XDG_CONFIG_HOME/nvm).
 if [[ -s "$NVM_DIR/nvm.sh" ]]; then
   # Add default node to PATH without sourcing nvm.sh (~0ms vs ~200-400ms).
   # `command ls` bypasses the ls alias (alias.sh) so this never depends on what
@@ -169,6 +183,10 @@ fi
 # without atuin just skips it.
 if command -v atuin >/dev/null 2>&1; then
   eval "$(atuin init zsh --disable-up-arrow --disable-ai)"
+  # fzf's `--zsh` bindings (sourced earlier) also grab ^R; re-assert atuin's ^R
+  # now that atuin-search is defined, so ^R is unambiguously atuin.
+  bindkey -M emacs '^r' atuin-search 2>/dev/null
+  bindkey -M viins '^r' atuin-search-viins 2>/dev/null
 fi
 
 # Perl local lib configuration
@@ -179,7 +197,7 @@ export PERL_MM_OPT="INSTALL_BASE=${HOME}/perl5"
 
 # Tmux session restoration (only outside tmux, only in iTerm2)
 if [[ -z "$TMUX" && "$TERM_PROGRAM" == "iTerm.app" ]]; then
-  tmux ls >/dev/null 2>&1 || (tmux start-server && tmux new -s dummy -d && sleep 1s && tmux kill-session -t dummy)
+  tmux ls >/dev/null 2>&1 || (tmux start-server && tmux new -s dummy -d && sleep 1 && tmux kill-session -t dummy)
 fi
 
 # Rustup env (optional)


### PR DESCRIPTION
Dead-config sweep across zshenv/zshrc + a capability-aware fzf init.

**zshenv**: subprocess-free `DOTFILES`; remove dead `NVM_LAZY`/`NVM_COMPLETION`/`MYVIMRC`/`LUA_PATH`/`HOMEBREW_INSTALL_CLEANUP`; fix the wrong `32³` HISTSIZE comment.

**zshrc**: replace the dead lazy fzf block (non-existent `~/.fzf.zsh`, non-widget `^T`) with a **capability-aware** init — `fzf --zsh` on fzf ≥ 0.48, else the distro/Homebrew integration scripts (so Ubuntu 24.04's fzf 0.44 still gets ^T/Alt-C). `^T`=fzf-file-widget, `Alt-C`=fzf-cd-widget, `^R`=atuin-search (atuin re-claims ^R after its init). Hardcode completion cache-path; load history-substring-search after syntax-highlighting; drop `zsh-256color` (plugins + install_omz + R5); `sleep 1s`→`sleep 1`; drop duplicate `NVM_DIR`.

**iterm2.zsh**: gate the `~/.iterm2/*` aliases on dir existence.

Review (`gpt-5.6-sol`): 2 rounds → **approve**. Round 1 caught the real Ubuntu-0.44 `fzf --zsh` version-skew (Linux R4) — fixed via the fallback. Acceptance: `zsh -n`; startup stderr-empty; DOTFILES resolves; ^T widget (pty); 195ms ≤ 240ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)