### PR TITLE
chore(zsh,git): curate legacy aliases/functions + dead git config (P2-4)

### DIFF
--- a/git/gitattributes
+++ b/git/gitattributes
@@ -1,3 +1,2 @@
-*.png diff=exif
-*.jpg diff=exif
-*.gif diff=exif
+# Global git attributes. (The image `diff=exif` textconv entries were removed —
+# exiftool isn't installed, so they only made `git diff` on images error.)

--- a/git/gitconfig
+++ b/git/gitconfig
@@ -20,17 +20,6 @@
     pager = vim -
 [help]
     autocorrect = 1
-[gitflow "branch"]
-    master = master
-    develop = develop
-[gitflow "prefix"]
-    feature = feature/
-    release = release/
-    hotfix = hotfix/
-    support = support/
-    versiontag =
-[diff "exif"]
-    textconv = exiftool
 [diff]
 	submodule = log
 [status]
@@ -54,7 +43,6 @@
     line-numbers = true
 [alias]
 	# Basic aliases
-	push = push -u
 	stat = status
     co = checkout
     ci = commit
@@ -78,6 +66,12 @@
 	provider = generic
 [credential "https://github.com"]
 	helper = 
+	# Absolute path (not bare `gh`): git credential helpers are invoked by GUI/IDE
+	# git clients with a minimal PATH that never sourced the shell, where bare `gh`
+	# fails with "command not found" and the scoped block has no fallback. Both
+	# machines are Apple Silicon, so /opt/homebrew/bin/gh is correct on both; git
+	# config has no $BREW_PREFIX expansion, so an absolute literal is the only
+	# PATH-independent option.
 	helper = !/opt/homebrew/bin/gh auth git-credential
 [credential "https://gist.github.com"]
 	helper =

--- a/zsh/alias.sh
+++ b/zsh/alias.sh
@@ -18,7 +18,7 @@ alias la="ls -laF ${colorflag}"
 alias ll="la"
 
 # List only directories
-alias lsd="ls -lF ${colorflag}"
+alias lsd="ls -lF ${colorflag} | grep --color=never '^d'"
 
 # Always use color output for 'ls'
 alias ls="command ls ${colorflag}"
@@ -52,21 +52,11 @@ alias timer='echo "Timer started. Stop with Ctrl-D." && date && time cat && date
 # Update everything via topgrade
 alias update='topgrade'
 
-# IP addresses
-alias ip="echo 'IPv4: ' \$(dig -4 +short myip.opendns.com @resolver1.opendns.com); echo 'IPv6: ' \$(dig -6 +short myip.opendns.com @resolver1.opendns.com)"
+# Local IP address
 alias localip="ipconfig getifaddr en0"
-alias ips="ifconfig -a | grep -o 'inet6\? \(addr:\)\?\s\?\(\(\([0-9]\+\.\)\{3\}[0-9]\+\)\|[a-fA-F0-9:]\+\)' | awk '{ sub(/inet6? (addr:)? ?/, \"\"); print }'"
 
 # Flush Directory Service cache
 alias flush="dscacheutil -flushcache && killall -HUP mDNSResponder"
-
-# Clean up LaunchServices to remove duplicates in the “Open With” menu
-alias lscleanup="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister\
- -kill -r -domain local -domain system -domain user && killall Finder"
-
-# View HTTP traffic
-alias sniff="sudo ngrep -d 'en1' -t '^(GET|POST) ' 'tcp and port 80'"
-alias httpdump="sudo tcpdump -i en1 -n -s 0 -w - | grep -a -o -E \"Host\: .*|GET \/.*\""
 
 # Canonical hex dump; some systems have this symlinked
 command -v hd >/dev/null || alias hd="hexdump -C"
@@ -83,10 +73,6 @@ alias c="tr -d '\n' | pbcopy"
 # Recursively delete `.DS_Store` files
 alias cleanup="find . -type f -name '*.DS_Store' -ls -delete"
 
-# Empty the Trash on all mounted volumes and the main HDD
-# Also, clear Apple’s System Logs to improve shell startup speed
-alias emptytrash="sudo rm -rfv /Volumes/*/.Trashes; sudo rm -rfv ~/.Trash; sudo rm -rfv /private/var/log/asl/*.asl"
-
 # Show/hide hidden files in Finder
 alias show="defaults write com.apple.finder AppleShowAllFiles -bool true && killall Finder"
 alias hide="defaults write com.apple.finder AppleShowAllFiles -bool false && killall Finder"
@@ -98,35 +84,11 @@ alias showdesktop="defaults write com.apple.finder CreateDesktop -bool true && k
 # URL-encode strings
 alias urlencode='python3 -c "import sys, urllib.parse as ul; print(ul.quote_plus(sys.argv[1]));"'
 
-# Disable Spotlight
-alias spotoff="sudo mdutil -a -i off"
-# Enable Spotlight
-alias spoton="sudo mdutil -a -i on"
-
 # PlistBuddy alias, because sometimes `defaults` just doesn’t cut it
 alias plistbuddy="/usr/libexec/PlistBuddy"
 
-# Ring the terminal bell, and put a badge on Terminal.app’s Dock icon
-# (useful when executing time-consuming commands)
-alias badge="tput bel"
-
-# Intuitive map function
-# For example, to list all directories that contain a certain file:
-# find . -name .gitattributes | map dirname
-alias map="xargs -n1"
-
-# Kill all the tabs in Chrome to free up memory
-# [C] explained: http://www.commandlinefu.com/commands/view/402/exclude-grep-from-your-grepped-output-of-ps-alias-included-in-description
-alias chromekill="ps ux | grep '[C]hrome Helper --type=renderer' | grep -v extension-process | tr -s ' ' | cut -d ' ' -f2 | xargs kill"
-
-# Lock the screen (when going AFK)
-alias afk="/System/Library/CoreServices/Menu\ Extras/User.menu/Contents/Resources/CGSession -suspend"
-
 # Reload the shell (i.e. invoke as a login shell)
 alias reload="exec $SHELL -l"
-
-# Open tmux with custom config location
-alias tmux='tmux -f "$XDG_CONFIG_HOME"/tmux/tmux.conf'
 
 # `hh` (history search) now lives in zsh/functions/hh.sh — atuin-backed, mirrors ^R.
 

--- a/zsh/functions.sh
+++ b/zsh/functions.sh
@@ -1,45 +1,8 @@
 #!/usr/bin/env sh
 
-# Syntax-highlight JSON strings or files
-# Usage: `json '{"foo":42}'` or `echo '{"foo":42}' | json`
-function json() {
-	if [ -t 0 ]; then # argument
-		echo "$@" | jq . | pygmentize -l javascript;
-	else # pipe
-		jq . | pygmentize -l javascript;
-	fi;
-}
-
 # Run `dig` and display the most useful info
 function digga() {
 	dig +nocmd "$1" any +multiline +noall +answer;
-}
-
-# UTF-8-encode a string of Unicode symbols
-function escape() {
-	printf "\\\x%s" "$(printf "%s" "$@" | xxd -p -c1 -u)";
-	# print a newline unless we’re piping the output to another program
-	if [ -t 1 ]; then
-		echo ""; # newline
-	fi;
-}
-
-# Decode \x{ABCD}-style Unicode escape sequences
-function unidecode() {
-	perl -e "binmode(STDOUT, ':utf8'); print \"$*\"";
-	# print a newline unless we’re piping the output to another program
-	if [ -t 1 ]; then
-		echo ""; # newline
-	fi;
-}
-
-# Get a character’s Unicode code point
-function codepoint() {
-	perl -e "use utf8; print sprintf('U+%04X', ord(\"$*\"))";
-	# print a newline unless we’re piping the output to another program
-	if [ -t 1 ]; then
-		echo ""; # newline
-	fi;
 }
 
 # `tre` is a shorthand for `tree` with hidden files and color enabled, ignoring
@@ -51,3 +14,4 @@ function tre() {
 }
 
 for function in "$DOTFILES/zsh/functions"/*.sh; do . "${function}"; done
+unset function


### PR DESCRIPTION
Curation/deletion sweep (all deletions listed for veto).

**zsh/alias.sh**: fix `lsd` (restore dirs-only filter); delete `ip`/`ips` (keep `localip`), `lscleanup`, `sniff`/`httpdump`, `emptytrash`, `spotoff`/`spoton`, `badge`, `map`, `chromekill`, `afk`, obsolete `tmux -f` alias.
**zsh/functions.sh**: delete `json` (pygmentize), `escape`/`unidecode`/`codepoint` (perl); keep `digga`/`tre`; unset the loop var.
**git/gitconfig**: delete dead `push = push -u`, `[gitflow]` blocks, `[diff "exif"]` textconv; **kept** the gh credential helper as an absolute `/opt/homebrew/bin/gh` path (review r1 caught that bare `gh` breaks GUI/minimal-PATH clients).
**git/gitattributes**: remove image `diff=exif` lines.

Review (`gpt-5.6-sol`): 2 rounds → **approve**. Acceptance: `zsh -n`; startup stderr-empty; git config parses (no push/gitflow/exif); every surviving alias resolves; image `git diff` no longer errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)