### PR TITLE
fix(tmux): polish config — XDG-independent sourcing, status-interval, dead-config sweep (P2-8)

### DIFF
--- a/install-linux.conf.yaml
+++ b/install-linux.conf.yaml
@@ -74,6 +74,8 @@
     ~/.config/btop/btop.conf: btop/btop.conf
     ~/.config/lazygit/config.yml: lazygit/config.yml
     ~/.config/tmux/tmux.conf: tmux/tmux.conf
+    ~/.config/tmux/tmux.general.conf: tmux/tmux.general.conf
+    ~/.config/tmux/tmux.display.conf: tmux/tmux.display.conf
     ~/.config/topgrade.toml: topgrade/topgrade.toml
 
 - shell:

--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -61,6 +61,8 @@
     ~/.config/btop/btop.conf: btop/btop.conf
     ~/.config/lazygit/config.yml: lazygit/config.yml
     ~/.config/tmux/tmux.conf: tmux/tmux.conf
+    ~/.config/tmux/tmux.general.conf: tmux/tmux.general.conf
+    ~/.config/tmux/tmux.display.conf: tmux/tmux.display.conf
     ~/.config/topgrade.toml: topgrade/topgrade.toml
 
 - shell:

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -1,9 +1,15 @@
-source-file $DOTFILES/tmux/tmux.general.conf
-source-file $DOTFILES/tmux/tmux.display.conf
+# Source from $HOME/.config/tmux (where Dotbot symlinks these), NOT $DOTFILES and
+# not $XDG_CONFIG_HOME: $DOTFILES is only set by the shell (zshenv), and even
+# $XDG_CONFIG_HOME may be unset for a server started without shell env (systemd, a
+# bare `tmux`). $HOME is essentially always present, and Dotbot always installs
+# under ~/.config regardless of a custom XDG value — so $HOME/.config is both the
+# correct location and shell-independent. tmux expands $HOME in source-file.
+source-file $HOME/.config/tmux/tmux.general.conf
+source-file $HOME/.config/tmux/tmux.display.conf
 
 # Machine-local overrides (e.g. VPS disables continuum-boot, sets save interval).
 # -q = silently skip if file doesn't exist.
-source-file -q $XDG_CONFIG_HOME/tmux/local.conf
+source-file -q $HOME/.config/tmux/local.conf
 
 # Initialize TMUX plugin manager (keep this line at the very bottom).
-run "$XDG_CONFIG_HOME/tmux/plugins/tpm/tpm"
+run "$HOME/.config/tmux/plugins/tpm/tpm"

--- a/tmux/tmux.display.conf
+++ b/tmux/tmux.display.conf
@@ -19,11 +19,12 @@ set -g display-panes-time 800
 # Slightly longer status messages display time
 set -g display-time 1000
 
-# Redraw status line every 10 seconds
-set -g status-interval 1
-
-# Clear both screen and history
-bind -n C-l send-keys C-l
+# Redraw the status line every 2s. The clock in status-right only shows minutes,
+# so 1s was needless churn; 2s still lets the Claude spinner glyph (written to
+# @claude_status every ~150ms by the attention hook, but only *visible* on a
+# status redraw) cycle at a legible rate. Don't push this to 5s+ without giving
+# the spinner its own refresh-client, or the animation stalls.
+set -g status-interval 2
 
 # Activity
 set -g monitor-activity on
@@ -63,7 +64,7 @@ set -g status-left "\
 # pill's blue (#2563EB bg, white bold fg). The middle dot · joins all three
 # segments into a single visual unit so they read as "where am I, what time"
 # instead of three fields. The location segment comes from
-# $XDG_CONFIG_HOME/tmux/scripts/location.sh (CoreLocationCLI on Mac, ipinfo.io
+# $HOME/.config/tmux/scripts/location.sh (CoreLocationCLI on Mac, ipinfo.io
 # IP geolocation on Linux/VPS) — emits "City, Region · " when populated, empty
 # when the cache is cold or the resolver is unavailable. Cache lives at
 # $XDG_CACHE_HOME/tmux-location/, never inside the dotfiles repo.
@@ -76,8 +77,8 @@ set -g status-left "\
 # so the glyph silhouette IS the pill's rounded end. Requires a Nerd Font
 # (installed via helpers/install_fonts.sh).
 set -g status-right "\
-#($XDG_CONFIG_HOME/tmux/plugins/tmux-continuum/scripts/continuum_save.sh)\
-#[fg=#{?#{==:#S,vps},##33843A,##2563EB}#,bg=default]#[fg=#FFFFFF,bg=#{?#{==:#S,vps},##33843A,##2563EB}#,bold] #($XDG_CONFIG_HOME/tmux/scripts/location.sh)%-I:%M %p · %b %d #[fg=#{?#{==:#S,vps},##33843A,##2563EB}#,bg=default]"
+#($HOME/.config/tmux/plugins/tmux-continuum/scripts/continuum_save.sh)\
+#[fg=#{?#{==:#S,vps},##33843A,##2563EB}#,bg=default]#[fg=#FFFFFF,bg=#{?#{==:#S,vps},##33843A,##2563EB}#,bold] #($HOME/.config/tmux/scripts/location.sh)%-I:%M %p · %b %d #[fg=#{?#{==:#S,vps},##33843A,##2563EB}#,bg=default]"
 
 set -g status-left-length 40
 set -g status-right-length 70

--- a/tmux/tmux.general.conf
+++ b/tmux/tmux.general.conf
@@ -29,10 +29,6 @@ set -sg repeat-time 600
 
 set -g focus-events on
 
-# expect UTF-8 (tmux < 2.2)
-set -q -g status-utf8 on
-setw -q -g utf8 on
-
 # Boost history (50k recommended for Claude Code sessions)
 set -g history-limit 50000
 
@@ -71,20 +67,27 @@ bind -r S-Right resize-pane -R 5
 bind c new-window -c "#{pane_current_path}"
 
 # Edit configuration quickly
-bind e new-window -n "$XDG_CONFIG_HOME/tmux/tmux.conf" "sh -c '\${EDITOR:-vim} $XDG_CONFIG_HOME/tmux/tmux.conf && tmux . $XDG_CONFIG_HOME/tmux/tmux.conf && tmux display \"$XDG_CONFIG_HOME/tmux/tmux.conf sourced\"'"
+bind e new-window -n "$HOME/.config/tmux/tmux.conf" "sh -c '\${EDITOR:-vim} $HOME/.config/tmux/tmux.conf && tmux . $HOME/.config/tmux/tmux.conf && tmux display \"$HOME/.config/tmux/tmux.conf sourced\"'"
 
 # Reload configuration quickly
-bind r source-file $XDG_CONFIG_HOME/tmux/tmux.conf \; display "$XDG_CONFIG_HOME/tmux/tmux.conf sourced"
+bind r source-file $HOME/.config/tmux/tmux.conf \; display "$HOME/.config/tmux/tmux.conf sourced"
 
 # Re-apply per-window glyph + color metadata (set by the tmux-window-namer
 # Claude skill) on every client attach. Idempotent, no-op if sidecar missing.
-set-hook -g client-attached 'run-shell "$XDG_CONFIG_HOME/tmux/scripts/restore-window-meta.sh"'
+set-hook -g client-attached 'run-shell "$HOME/.config/tmux/scripts/restore-window-meta.sh"'
 
-# Force a resurrect save on every attach — safety net in case continuum's
-# status-right auto-save hook gets dropped after a config reload.
-set-hook -ga client-attached 'run-shell "$XDG_CONFIG_HOME/tmux/plugins/tmux-resurrect/scripts/save.sh"'
+# Fallback save on attach — routed through continuum's OWN save script, not a
+# bare tmux-resurrect save.sh. continuum_save.sh is the interval + lock
+# coordinator (the same one status-right calls every refresh), so this is
+# race-safe: it only saves when a save is actually due and holds continuum's lock,
+# rather than forcing a second-granularity save.sh that could race the inlined
+# status-right save and corrupt `last`. Value: snapshots keep happening even if
+# status rendering (which normally drives continuum) is ever disabled or a
+# host/plugin overrides status-right. A just-started/fresh server hasn't hit the
+# save interval, so nothing is clobbered.
+set-hook -ga client-attached 'run-shell "$HOME/.config/tmux/plugins/tmux-continuum/scripts/continuum_save.sh"'
 
-set-environment -g TMUX_PLUGIN_MANAGER_PATH "$XDG_CONFIG_HOME/tmux/plugins/"
+set-environment -g TMUX_PLUGIN_MANAGER_PATH "$HOME/.config/tmux/plugins/"
 
 # List of plugins
 set -g @tpm_plugins '          \

--- a/tmux/window-meta.linux.json
+++ b/tmux/window-meta.linux.json
@@ -1,5 +1,1 @@
-{
-  "vps": {
-    "OpenClaw": { "glyph": "\uee0d\u2009", "glyph_color": "#FF4500" }
-  }
-}
+{}


### PR DESCRIPTION
tmux polish. **tmux.conf/general/display**: source + reference via `$HOME/.config/tmux` (shell-independent — verified loads under `env -i HOME PATH` with no XDG/DOTFILES); symlink general+display.conf into ~/.config/tmux in **both** install manifests. **display**: status-interval 1→2 (spinner still cycles), remove `C-l` identity bind. **general**: remove tmux<2.2 UTF-8 lines; route the attach-time fallback save through continuum's interval+lock-coordinated `continuum_save.sh` (not a bare `save.sh` that raced/corrupted the snapshot). **window-meta.linux.json**: empty the stale OpenClaw seed to `{}`.

Review (`gpt-5.6-sol`, 4 rounds): caught + fixed the real reachable bugs (Linux manifest, XDG dependency, save-race). Final finding is an unreachable multi-server ownership edge already shared by the pre-existing status-right inline. Verified: clean load with minimal env; correct hooks; `env -i` startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)