### PR TITLE
chore: prune machine/session-specific bits from claude/settings.json (D5)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -66,8 +66,21 @@ artifact for the overnight execution loop (Opus 4.8 + Codex adversarial review).
 - **Do NOT conform/edit the Otty `# >>>`…`# <<<` block in `zsh/zshrc`** (see #97→#99 lesson).
 - **No machine-side uninstalls overnight** — repo-side changes only; machine reconciliation is
   a morning-checklist activity (plan doc §Safety-rails).
-- **P2-7 (settings hygiene) runs last** — it removes allow-rules the running loop may rely on.
 - **iTerm defaults flip is manual** — iTerm rewrites the prefs folder on quit; don't fight it
   from a background agent.
-- `claude/settings.json` `/model`-churn rule stays in force until P2-7 lands (then pins are
-  gone by design, D5).
+- **`claude/settings.json` is now the shared cross-machine baseline** (P2-7 landed, D5): the
+  `model`/`effortLevel` pins, the two dead marketplaces (`claude-code-plugins`,
+  `villavicencio-skills-private`), and the host-specific `curl`/`ssh root@openclaw-prod`
+  auto-allow rules were removed. Claude Code has **no user-level `*.local` override layer**
+  (`settings.local.json` is project-scoped only), so genuinely per-machine user settings must
+  live on that machine's own `~/.claude/settings.json`, not be committed here.
+- **The P2-7 change is currently INERT on the personal Mac** and applying it is a manual step.
+  The live `~/.claude/settings.json` is a **regular file** (decoupled from the repo — it still
+  carries the old pins + `curl`/`ssh` allow rules). Dotbot's `link` defaults are `relink: true`
+  with **no `force`**, so `./install` will *not* overwrite a regular file — it reports a link
+  failure and leaves the old settings active. To actually apply the hygiene change on a machine
+  (morning-checklist, **do not auto-delete — it's live user data**): (1) back up the live file
+  (`cp ~/.claude/settings.json ~/.claude/settings.json.bak`); (2) remove it; (3) run `./install`
+  so Dotbot creates the symlink; (4) verify `~/.claude/settings.json` is now the symlink and the
+  removed rules are absent (`readlink ~/.claude/settings.json`; `jq '.model // "gone"'`). A fresh
+  session will then see more permission prompts — by design.

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,8 +1,8 @@
 {
+  "//": "Tracked cross-machine baseline. Claude Code loads this as the user-scope ~/.claude/settings.json (lowest precedence). Keep machine-/session-specific values (model & effortLevel pins, host-specific allow rules, per-machine MCP servers) OUT of this shared file. Higher-precedence layers Claude Code loads: managed settings and CLI flags, plus per-project .claude/settings.local.json (gitignored) for project-scoped overrides. There is no user-level *.local override layer, so genuinely per-machine user settings must live on that machine's own ~/.claude/settings.json (not committed here).",
   "permissions": {
     "defaultMode": "auto"
   },
-  "model": "opus[1m]",
   "hooks": {
     "SessionStart": [
       {
@@ -90,12 +90,6 @@
     "codex@openai-codex": true
   },
   "extraKnownMarketplaces": {
-    "claude-code-plugins": {
-      "source": {
-        "source": "github",
-        "repo": "anthropics/claude-code"
-      }
-    },
     "compound-engineering-plugin": {
       "source": {
         "source": "github",
@@ -115,12 +109,6 @@
         "repo": "villavicencio/skills"
       }
     },
-    "villavicencio-skills-private": {
-      "source": {
-        "source": "github",
-        "repo": "villavicencio/skills-private"
-      }
-    },
     "openai-codex": {
       "source": {
         "source": "github",
@@ -128,7 +116,6 @@
       }
     }
   },
-  "effortLevel": "xhigh",
   "tui": "fullscreen",
   "showThinkingSummaries": true,
   "skipDangerousModePermissionPrompt": true,
@@ -155,10 +142,7 @@
     "Bash(npm view*)",
     "Bash(npm uninstall*)",
     "Bash(claude *)",
-    "Bash(curl -fsSL*)",
-    "Bash(curl -s*)",
-    "Bash(tmux -V*)",
-    "Bash(ssh root@openclaw-prod*)"
+    "Bash(tmux -V*)"
   ],
   "mcpServers": {
     "eagle": {


### PR DESCRIPTION
## What

Make `claude/settings.json` a clean shared cross-machine baseline (D5). **Removed:**

- the `model` (`opus[1m]`) and `effortLevel` (`xhigh`) pins
- two dead, unreferenced marketplaces — `claude-code-plugins`, `villavicencio-skills-private`
  (no `enabledPlugin` is sourced from either)
- three host/network auto-allow rules — `Bash(curl -fsSL*)`, `Bash(curl -s*)`,
  `Bash(ssh root@openclaw-prod*)`

**Kept:** the read-only git/gh/brew/npm allow rules plus `Bash(claude *)` and
`Bash(tmux -V*)`, all hooks, `statusLine`, `mcpServers`, and the six `enabledPlugins`
(each still maps to an existing marketplace — verified no orphans). Added a `//` note
documenting where machine/session-specific values belong and the real Claude Code
settings layers.

`HANDOFF.md`: the live `~/.claude/settings.json` is a regular file (decoupled), and
Dotbot links with `relink: true` / **no `force`**, so `./install` won't overwrite it —
documented a safe manual back-up → remove → relink → verify migration (do not
auto-delete live user settings).

## Adversarial review (gpt-5.6-sol, 3 rounds → approve)

- **r1** — the note pointed overrides at `~/.claude/settings.local.json`, which Claude
  Code does not load at user scope (verified against the settings docs: no user-level
  `*.local` layer). Fixed.
- **r2** — the "`./install` re-links it" claim was wrong (Dotbot won't clobber a regular
  file without `force`). Fixed with a safe manual migration.
- **r3** — clean.

## Acceptance

- `jq empty claude/settings.json` valid; the removed keys/rules are gone.
- Every `enabledPlugin` (incl. `dv`, `codex`) still maps to an existing marketplace.
- gitleaks pre-commit passes; CI green.

> Note: after this is applied to a machine, a fresh Claude Code session will see more
> permission prompts — by design (this packet is sequenced last for that reason).

🤖 Generated with [Claude Code](https://claude.com/claude-code)