### PR TITLE
docs(claude): route adversarial code review to dv:gauntlet

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -84,6 +84,15 @@ merge (PR where the repo has a remote review flow; local merge where it doesn't)
 to every repo, including data vaults and doc-only commits (handoff commits ride a branch
 too). Repos with their own stricter rules (e.g. skills-private's PR-only flow) keep them.
 
+## Code Review
+
+**Adversarial code review → invoke `dv:gauntlet`** (dv suite ≥ 0.2.0, installed user-scope, so it
+resolves in every project); do **not** hand-roll `codex exec review` or Claude↔Codex review loops.
+Bare `dv:gauntlet` is the full autonomous find→refute→fix→commit loop (staged, cost-tiered,
+budgeted); `dv:gauntlet report` is a single report-only round. The skill owns the procedure —
+rounds, budgets, the fingerprint ledger, stop rules, read-only peer runs — so don't re-derive it
+per project.
+
 ## Research
 
 When you hit a wall — unfamiliar tool, unknown API, missing docs — always perform a web search


### PR DESCRIPTION
## Summary

Adds a global **Code Review** rule to `claude/CLAUDE.md`: adversarial code review invokes **`dv:gauntlet`** (dv suite ≥ 0.2.0, installed user-scope) rather than a hand-rolled `codex exec review` / Claude↔Codex review loop.

## Why

The adversarial-review loop practice previously lived only as per-project harness memory (browse-gateway, ibmcconstruction had near-identical `codex-review-loop-sop.md` files) — which is exactly why it never traveled to new projects. `dv:gauntlet` now packages it (staged, cost-tiered, budgeted, with a fingerprint ledger and standoff terminal); this one line makes every current and future project route to it. The per-project SOPs have been superseded in place to point at the same skill.

One line plus the skill pointer — the skill owns the procedure (rounds, budgets, ledger, stop rules, read-only peer runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCpfu6qaGR7CpSZeMFFRNz