### PR TITLE
chore(claude): allow `gh pr merge` in the baseline permission set

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,7 +1,10 @@
 {
   "//": "Tracked cross-machine baseline. Claude Code loads this as the user-scope ~/.claude/settings.json (lowest precedence). Keep machine-/session-specific values (model & effortLevel pins, host-specific allow rules, per-machine MCP servers) OUT of this shared file. Higher-precedence layers Claude Code loads: managed settings and CLI flags, plus per-project .claude/settings.local.json (gitignored) for project-scoped overrides. There is no user-level *.local override layer, so genuinely per-machine user settings must live on that machine's own ~/.claude/settings.json (not committed here).",
   "permissions": {
-    "defaultMode": "auto"
+    "defaultMode": "auto",
+    "allow": [
+      "Bash(gh pr merge:*)"
+    ]
   },
   "hooks": {
     "SessionStart": [


### PR DESCRIPTION
## Summary

Adds `Bash(gh pr merge:*)` to `permissions.allow` in the tracked `claude/settings.json` baseline, mirroring the rule already added to this machine's `~/.claude/settings.json`.

## Why

`gh pr merge` is a general capability, not host-specific, so it belongs in the shared baseline per this file's own header rule ("keep machine-/session-specific values ... OUT of this shared file"). Without this, the rule is local to one machine.

Two implementation notes:

- Goes in `permissions.allow`, not the legacy top-level `allowedTools` array — `permissions.allow` is the current schema and is what `/permissions` writes.
- `gh pr merge --delete-branch` is covered by this one rule, so no separate `git push --delete` grant is needed for branch cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LTQepKZXV8DuoHiGMTHaU