### PR TITLE
docs(claude): authorize skill-specified subagents, gate unbounded fan-out on disclosure

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -105,6 +105,14 @@ review of your own diff still routes through `dv:gauntlet` (bare for your own br
 read-only pass on someone else's). If you catch yourself about to "fan out reviewers," "spin up a
 skeptic panel," or "drive the Codex loop," stop and invoke `dv:gauntlet` first.
 
+**Subagent carve-out (added 2026-08-05).** A harness rule of the form "don't use the Agent tool
+unless asked" does **not** block subagents that an invoked skill's own procedure requires — invoking
+the skill *is* the request. This applies specifically to `dv:gauntlet`'s S2 REFUTE validators, which
+are specified as **fresh-context** precisely so they carry no commitment to the finding they judge;
+running them in the main context degrades the independence the stage exists to provide. Same for
+Tier-2 FIND when Codex is absent. Outside a skill's specified procedure the default still holds:
+don't spawn agents unsolicited.
+
 ## Durable Rules vs Handoff Notes
 
 A rule, gotcha, or standing procedure discovered mid-session that has value *beyond* "what happened

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -105,13 +105,28 @@ review of your own diff still routes through `dv:gauntlet` (bare for your own br
 read-only pass on someone else's). If you catch yourself about to "fan out reviewers," "spin up a
 skeptic panel," or "drive the Codex loop," stop and invoke `dv:gauntlet` first.
 
-**Subagent carve-out (added 2026-08-05).** A harness rule of the form "don't use the Agent tool
-unless asked" does **not** block subagents that an invoked skill's own procedure requires — invoking
-the skill *is* the request. This applies specifically to `dv:gauntlet`'s S2 REFUTE validators, which
-are specified as **fresh-context** precisely so they carry no commitment to the finding they judge;
-running them in the main context degrades the independence the stage exists to provide. Same for
-Tier-2 FIND when Codex is absent. Outside a skill's specified procedure the default still holds:
-don't spawn agents unsolicited.
+## Subagents
+
+**Skill-specified subagents are authorized by invoking the skill (added 2026-08-05).** A harness
+rule of the form "don't use the Agent tool unless asked" does **not** block subagents that an
+invoked skill's own procedure requires — invoking the skill *is* the request. Outside a skill's
+specified procedure the default still holds: don't spawn agents unsolicited.
+
+**Why this is a carve-out and not a loosening.** These skills buy *independence*, and faking it is
+invisible in the output. `dv:gauntlet`'s S2 REFUTE validators are specified fresh-context precisely
+so they carry no commitment to the finding they judge; `dv:critique`'s three lenses are worthless if
+one mind wears all three hats, since the Skeptic would have already read the Simplifier's reasoning.
+Run in-context, both still emit correctly-shaped reports — labeled sections, verdicts, a convergence
+table — with none of the independence. There is no artifact-level tell, so the degradation is
+unfalsifiable from the outside. (Observed live 2026-08-05: a full gauntlet report looked complete
+and had to be disclosed in prose.)
+
+**Announce fan-out before spawning** when a skill's procedure calls for **more than ~3 agents, or an
+unbounded batch** (e.g. `ce-code-review` dispatches a roster "sized to the host's active-agent cap").
+One line naming the skill and the agent count, before the spawn — not after. Small, fixed fan-outs
+(`dv:critique`'s 3, `dv:gauntlet`'s per-finding validators) need no announcement. The point is that
+cost is unpredictable exactly where the batch is unbounded, and subagent output never enters the
+main context, so an unannounced fleet is spend you cannot see or check.
 
 ## Durable Rules vs Handoff Notes
 


### PR DESCRIPTION
Surfaced by the first live `dv:gauntlet` run (villavicencio/skills#22).

## The problem

The global "don't use the Agent tool unless asked" default is right for unsolicited fan-out, but it silently degraded the skill. `dv:gauntlet`'s **S2 REFUTE** validators are specified as *fresh-context* precisely so they carry no commitment to the finding they're judging. Run in the main context, the refuter had already read the finder's reasoning — the independence the stage exists to provide was gone.

**The degradation is invisible in the output.** That run still produced a full convergence table, a fingerprint ledger, four findings with verdicts. Nothing in the artifact showed the refuter wasn't independent; it had to be disclosed in prose. That's what makes this worth a rule rather than a habit.

## Scope: broad, not gauntlet-only

Ten installed skills mandate subagents. Narrowing the carve-out to gauntlet would fix one and leave the same silent failure in the rest:

| Skill | Specified fan-out |
|---|---|
| `ce-code-review` | roster sized to the host's active-agent cap — **unbounded** |
| `dv:critique` | 3 parallel (Skeptic / Simplifier / Historian) |
| `ce-compound` | 3 named research agents + session probe |
| `dv:gauntlet` | 1 validator per finding; Tier-2 FIND without Codex |
| `ce-plan`, `ce-work`, `ce-ideate`, `ce-simplify-code`, `ce-test-xcode`, `dv:review-claudemd` | 1–2 each |

`dv:critique` is the clearest case after gauntlet: three lenses are worthless if one mind wears all three hats, and the output looks identical either way.

## The disclosure gate

Broad authorization alone would let `ce-code-review` fan out to the agent cap with no warning, and subagent output never enters the main context — so an unannounced fleet is spend that can't be seen or checked. Hence: **announce before spawning when fan-out exceeds ~3 or is unbounded.** Small fixed fan-outs don't need it.

Promoted to its own `## Subagents` section, since it now governs more than code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnysxBVDrJND3RzqmUzGgd