### PR TITLE
chore(claude): consolidate into one allowlist, document the precedence trap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,32 @@ this repo, not just ticket work. Avoid committing directly to `master`.
 Picking up a board ticket always gets its own branch (never work a ticket on
 `master`).
 
+### Claude Code permissions: one allowlist, not two
+
+**`permissions.allow` is the allowlist. There is no `allowedTools` key** — do not
+reintroduce one (discovered 2026-08-07).
+
+`allowedTools` is a legacy top-level key. When both exist, **the legacy key wins
+and `permissions.allow` is silently inert.** Nothing warns you: rules in
+`permissions.allow` simply never take effect, and the failure looks like "the
+rule doesn't work" rather than "the rule isn't being read."
+
+This cost a real debugging session. `Bash(gh pr merge:*)` sat in
+`permissions.allow` (added by PR #121) while every merge still prompted, because
+the live `allowedTools` list — which had 17 read-only-ish rules and no merge
+entry — was the one actually consulted. Adding the same rule to `allowedTools`
+fixed it instantly, which is what proved the precedence.
+
+Both lists are now consolidated into `permissions.allow` in
+`claude/settings.json`. If a permission rule ever appears to be ignored, check
+for a resurrected `allowedTools` **before** assuming the auto-mode classifier is
+gating the command.
+
+Related but distinct: the auto-mode classifier **does** independently block
+agent edits to `~/.claude/settings.json` itself, regardless of allow rules. That
+is intended — it stops an agent widening its own permissions — and is not the
+same mechanism. Permission-file edits are a human job.
+
 ---
 
 ## Install pipeline

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -3,7 +3,24 @@
   "permissions": {
     "defaultMode": "auto",
     "allow": [
-      "Bash(gh pr merge:*)"
+      "Bash(git branch*)",
+      "Bash(git log*)",
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(gh pr list*)",
+      "Bash(gh pr view*)",
+      "Bash(gh pr merge:*)",
+      "Bash(ls*)",
+      "Bash(cat*)",
+      "Bash(which*)",
+      "Bash(brew info*)",
+      "Bash(brew list*)",
+      "Bash(brew uninstall*)",
+      "Bash(npm list*)",
+      "Bash(npm view*)",
+      "Bash(npm uninstall*)",
+      "Bash(claude *)",
+      "Bash(tmux -V*)"
     ]
   },
   "hooks": {
@@ -128,25 +145,6 @@
   "inputNeededNotifEnabled": true,
   "agentPushNotifEnabled": true,
   "skipAutoPermissionPrompt": true,
-  "allowedTools": [
-    "Bash(git branch*)",
-    "Bash(git log*)",
-    "Bash(git status*)",
-    "Bash(git diff*)",
-    "Bash(gh pr list*)",
-    "Bash(gh pr view*)",
-    "Bash(ls*)",
-    "Bash(cat*)",
-    "Bash(which*)",
-    "Bash(brew info*)",
-    "Bash(brew list*)",
-    "Bash(brew uninstall*)",
-    "Bash(npm list*)",
-    "Bash(npm view*)",
-    "Bash(npm uninstall*)",
-    "Bash(claude *)",
-    "Bash(tmux -V*)"
-  ],
   "mcpServers": {
     "eagle": {
       "type": "streamable-http",


### PR DESCRIPTION
## The trap

`allowedTools` is a **legacy** top-level key. When it coexists with `permissions.allow`, **the legacy key wins and `permissions.allow` is silently inert.** Nothing warns you — rules simply never take effect, and it presents as "the rule doesn't work" rather than "the rule isn't being read."

## How it surfaced

`Bash(gh pr merge:*)` was added to `permissions.allow` by #121, yet every `gh pr merge` still prompted — noted across three separate handoffs in the skills repo as an unexplained annoyance.

Config inspection found two competing lists: `permissions.allow` with exactly one rule (the merge rule), and `allowedTools` with 17 read-only-ish rules and **no** merge entry. Adding the same rule to `allowedTools` made merges work immediately — which is what proved the precedence rather than merely suggesting it.

## What changed

- All 17 `allowedTools` rules merged into `permissions.allow` (18 with the merge rule), verified none dropped in the move
- `allowedTools` key removed
- CLAUDE.md documents the trap under Key conventions, at the point of discovery

## Also recorded: the mechanism this was confused with

Mid-investigation the classifier blocked an agent edit to `~/.claude/settings.json`, which briefly looked like the same cause. It isn't. The auto-mode classifier independently gates agent writes to the permission file regardless of allow rules — that's intended, it stops an agent widening its own permissions, and permission-file edits stay a human job. Both facts are now in CLAUDE.md so the next investigation doesn't conflate them.

## Follow-up needed per machine

This tracked baseline seeds the user-scope file, but each machine's live `~/.claude/settings.json` needs the same consolidation applied **by hand** — an agent cannot edit it, by design. Until then, the live file keeps whichever split it currently has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PwFZYmhEhduNYPSQTnAs7