### PR TITLE
feat(herdr): adopt herdr agent multiplexer — config, Brewfile, install wiring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ docs/       Compound-engineering artifacts:
                                  frontmatter (module, tags, problem_type) + INDEX.md
 git/        gitconfig, gitignore, gitattributes
 helpers/    Bash scripts called by the install pipeline (each independently runnable)
+herdr/      Herdr agent-multiplexer config (config.toml symlinked into ~/.config/herdr/)
 iterm/      iTerm2 preferences
 lazygit/    lazygit config
 nvim/       Neovim config (custom/ is symlinked into ~/.config/nvim/)
@@ -225,6 +226,13 @@ install via Homebrew casks in `brew/Brewfile`, not a helper.)
   root). Note `topgrade --dry-run | grep sudo` does not predict which steps need root — a
   cask's own script can invoke sudo internally. Full write-up:
   `docs/solutions/security/sudo-in-no-tty-agent-shells-touch-id-2026-08-07.md`.
+- **`herdr/config.toml` IS symlinked — the opposite of Otty, deliberately.** Herdr
+  rewrites its config in place (inode-preserving, verified on 0.8.0), so the symlink
+  survives and live edits surface as `M herdr/config.toml`; diff and commit them. Link
+  only the file — `~/.config/herdr/` also holds the socket, logs, and session state.
+  `herdr server stop` / restart kills all pane processes (layout restores, supported
+  agent sessions resume); detach instead. `herdr integration install claude` writes
+  into `~/.claude/` and is a human step, not an agent one.
 - **`otty/` is copy-seeded, never symlinked — do not add a `link:` entry for it.**
   `otty config set` and the Settings UI write via temp-file + `rename(2)`, which replaces
   the path and destroys a symlink on the first settings change; the CLI still exits 0 and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,7 +263,7 @@ conversations across server restarts via `claude --resume <id>`.
   `~/.config/herdr/` also holds the socket, logs, `session.json`, and
   `config.toml.bak-*` backups.
 - **Server lifecycle:** `brew services start herdr` (launchd, keep_alive; log at
-  `$BREW_PREFIX/var/log/herdr.log`). Detach with `ctrl+b q` — panes keep
+  `$BREW_PREFIX/var/log/herdr.log`). Detach with `ctrl+space q` — panes keep
   running. `herdr server stop` (and any server restart, including
   `brew services restart` after an upgrade) **kills all pane processes**; layout
   is snapshot-restored and supported agent conversations resume

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ docs/           Compound-engineering pipeline artifacts:
 ci/             CI assets (Dockerfile for install-matrix workflow)
 git/            gitconfig, gitignore, gitattributes
 helpers/        Bash scripts called by the install pipeline
+herdr/          Herdr agent-multiplexer config (config.toml symlinked into ~/.config/herdr/)
 iterm/          iTerm2 preferences (exported plist, includes Shift+Enter key mapping)
 lazygit/        lazygit config
 npm/            npm global package list (npm-requirements.txt)
@@ -246,6 +247,42 @@ boundary to the whole directory.
 `otty config set --transient` is advertised in `--help` but errors out
 (`Transient config not yet implemented`) — every config experiment persists, so back up
 `~/.config/otty/config.toml` first.
+
+### Herdr — agent multiplexer (config symlinked; writes flow back)
+`herdr` (Brewfile) is a tmux-shaped client/server multiplexer with native agent
+awareness: it detects a Claude Code pane via screen manifests, tracks
+blocked/working/done/idle state (what `claude/hooks/tmux-attention.sh` hand-rolls
+for tmux), and — with the official integration installed — resumes Claude Code
+conversations across server restarts via `claude --resume <id>`.
+
+- **Config is symlinked, not copy-seeded.** Unlike Otty, herdr rewrites
+  `~/.config/herdr/config.toml` **in place** (verified on 0.8.0: `herdr config
+  reset-keys` preserves the inode), so the Dotbot `link:` entry is safe and live
+  changes surface as `M herdr/config.toml` — diff and commit them, same as
+  `claude/CLAUDE.md`. Link the **file only**, never the directory:
+  `~/.config/herdr/` also holds the socket, logs, `session.json`, and
+  `config.toml.bak-*` backups.
+- **Server lifecycle:** `brew services start herdr` (launchd, keep_alive; log at
+  `$BREW_PREFIX/var/log/herdr.log`). Detach with `ctrl+b q` — panes keep
+  running. `herdr server stop` (and any server restart, including
+  `brew services restart` after an upgrade) **kills all pane processes**; layout
+  is snapshot-restored and supported agent conversations resume
+  (`[session] resume_agents_on_restore`), but plain shells restart fresh.
+- **Updates ride `brew upgrade`** (topgrade covers it). `herdr update` and the
+  experimental `--handoff` live-update are disabled for Homebrew installs.
+- **`herdr integration install claude` is a human step** — it writes
+  `~/.claude/hooks/herdr-agent-state.sh` and registers hooks in
+  `~/.claude/settings.json`, which the auto-mode classifier blocks agents from
+  doing. Check `herdr integration status` after major Claude Code updates.
+- **Prefix is `ctrl+space`, deliberately matching tmux** — one muscle-memory
+  "multiplexer key" across both apps, which are not nested in normal use. If you
+  do nest, tmux's `send-prefix` binding passes it through on a double-tap. Herdr
+  can host tmux in a pane or run inside tmux, but agent detection does not see
+  through a nested tmux.
+- **Scripting:** NDJSON over `~/.config/herdr/herdr.sock`; `herdr api schema`
+  emits the full machine-readable surface. Gotcha: `herdr agent wait --until
+  done` never fires on a *focused* pane (done = finished-but-unseen) — wait on
+  `idle`/`blocked` or subscribe to `pane.agent_status_changed` events.
 
 ### No heredocs in `bin/dot`
 The Python that `dot doctor` and `dot bench` run lives in `bin/lib/*.py` as real files.

--- a/brew/Brewfile
+++ b/brew/Brewfile
@@ -91,8 +91,13 @@ brew "pam-reattach"         # Touch ID for sudo INSIDE tmux — reattaches PAM t
                             # session. Needs a one-time root step; see CLAUDE.md
                             # "Touch ID for sudo". Useless without /etc/pam.d/sudo_local.
 
-# --- Terminal multiplexer ---
+# --- Terminal multiplexers ---
 brew "tmux"
+brew "herdr"                # agent multiplexer — tracks Claude Code pane state, resumes
+                            # sessions across restarts. Server: brew services start herdr.
+                            # Config tracked at herdr/config.toml (symlinked); see CLAUDE.md "Herdr".
+brew "terminal-notifier"    # macOS notifications — herdr [ui.toast] delivery = "system"
+                            # prefers it over the osascript fallback
 
 # --- Docs, linting, prose ---
 brew "vale"                 # prose linter (vale/)

--- a/dotbot-conf/base.yaml
+++ b/dotbot-conf/base.yaml
@@ -28,6 +28,7 @@
     - ~/.config/zsh
     - ~/.config/btop
     - ~/.config/git
+    - ~/.config/herdr
     - ~/.config/lazygit
     - ~/.config/tmux
     - ~/.config/tmux/resurrect
@@ -80,6 +81,7 @@
     ~/.config/git/gitignore: git/gitignore
     ~/.config/git/gitattributes: git/gitattributes
     ~/.config/btop/btop.conf: btop/btop.conf
+    ~/.config/herdr/config.toml: herdr/config.toml
     ~/.config/lazygit/config.yml: lazygit/config.yml
     ~/.config/tmux/tmux.conf: tmux/tmux.conf
     ~/.config/tmux/tmux.general.conf: tmux/tmux.general.conf

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -1,0 +1,324 @@
+# herdr configuration
+# Place this file at ~/.config/herdr/config.toml
+
+# Show first-run notification setup on startup.
+# Missing also shows onboarding; set false after you've chosen.
+onboarding = false
+
+[theme]
+# Built-in themes: catppuccin, terminal, tokyo-night, dracula, nord,
+#                  gruvbox, one-dark, solarized, kanagawa, rose-pine,
+#                  vesper
+# name = "catppuccin"
+
+# Follow host terminal light/dark appearance and switch Herdr UI themes.
+# Existing manual behavior is unchanged unless this is true.
+# auto_switch = false
+# dark_name = "catppuccin"
+# light_name = "catppuccin-latte"
+
+# Override individual color tokens on top of the base theme.
+# Accepts: hex (#rrggbb), named colors, rgb(r,g,b), or panel_bg = "reset"
+# [theme.custom]
+# panel_bg = "reset"
+# accent = "#f5c2e7"
+# red = "#ff6188"
+# green = "#a6e3a1"
+
+[terminal]
+# Executable used for new interactive panes.
+# Empty means $SHELL, then /bin/sh.
+# default_shell = ""
+
+# Startup mode for new interactive pane shells: "auto", "login", or "non_login".
+# "auto" uses login shells on macOS and keeps the current behavior elsewhere.
+# shell_mode = "auto"
+
+# CWD policy for new panes, tabs, and workspaces when no explicit --cwd is provided.
+# Use "follow" to inherit the source pane/workspace, "home" for $HOME,
+# "current" for Herdr's process directory, or a fixed path such as "~/Projects".
+# new_cwd = "follow"
+
+[update]
+# Update channel used by background version checks and `herdr update`.
+# Defaults to "stable" on Linux/macOS and "preview" on Windows.
+# Set explicitly to choose stable releases or opt-in preview builds.
+# channel = "stable"
+
+# Check herdr.dev for new Herdr versions in the background.
+# version_check = true
+
+# Check herdr.dev for remote agent-detection manifest updates in the background.
+# manifest_check = true
+
+[keys]
+# Prefix key to enter prefix mode (default: "ctrl+b")
+# Examples: "ctrl+b", "f12", "esc", "-"
+# Action bindings use explicit syntax: "prefix+n" requires the prefix;
+# "ctrl+alt+n" is a direct terminal-mode shortcut.
+# Accepted key syntax: plain keys, ctrl/shift/alt/cmd/super modifiers, and special keys like enter/tab/esc/left/right/up/down.
+# Named punctuation such as minus, comma, ampersand, plus, and backtick is also accepted.
+# Most reliable direct bindings are ctrl+letter, function keys, and explicit modified chords.
+# alt+..., cmd/super, and punctuation-with-modifiers may depend on your terminal/tmux setup.
+prefix = "ctrl+space"
+
+# Prefix-mode actions
+# help = "prefix+?"
+# settings = "prefix+s"
+# detach = "prefix+q"
+# reload_config = "prefix+shift+r"
+# open_notification_target = "prefix+o"
+# workspace_picker = "prefix+w"
+# goto = "prefix+g"
+# new_workspace = "prefix+shift+n"
+# new_worktree = "prefix+shift+g"
+# open_worktree = ""    # optional, unset by default
+# remove_worktree = ""  # optional, unset by default; opens confirmation
+# rename_workspace = "prefix+shift+w"
+# close_workspace = "prefix+shift+d"
+# previous_workspace = "" # optional, unset by default
+# next_workspace = ""     # optional, unset by default
+# previous_agent = ""     # optional, unset by default
+# next_agent = ""         # optional, unset by default
+# focus_agent = ""        # optional indexed binding, e.g. "prefix+alt+1..9"
+# remote_image_paste = "ctrl+v" # only active in herdr --remote; empty disables raw-key image paste
+# new_tab = "prefix+c"
+# rename_tab = "prefix+shift+t"
+# previous_tab = "prefix+p"
+# next_tab = "prefix+n"
+# switch_tab = "prefix+1..9"
+# switch_workspace = ""   # optional indexed binding, e.g. "prefix+shift+1..9"
+# close_tab = "prefix+shift+x"
+# rename_pane = "prefix+shift+p"
+# edit_scrollback = "prefix+e"
+# focus_pane_left = "prefix+h"
+# focus_pane_down = "prefix+j"
+# focus_pane_up = "prefix+k"
+# focus_pane_right = "prefix+l"
+# cycle_pane_next = "prefix+tab"
+# cycle_pane_previous = "prefix+shift+tab"
+# last_pane = ""          # optional, unset by default; bind e.g. "prefix+tab" for global back-and-forth
+# split_vertical = "prefix+v"
+# split_horizontal = "prefix+minus"
+# close_pane = "prefix+x"
+# zoom = "prefix+z"       # legacy alias: fullscreen
+# resize_mode = "prefix+r"
+# toggle_sidebar = "prefix+b"
+
+# Navigate-mode movement. These local shortcuts win while navigate mode is open.
+# They are independent from focus_pane_*. Do not include prefix+, esc, enter, tab, or 1..9 here.
+# navigate_workspace_up = "up"
+# navigate_workspace_down = "down"
+# navigate_pane_left = "h"      # left arrow always focuses the pane to the left
+# navigate_pane_down = "j"
+# navigate_pane_up = "k"
+# navigate_pane_right = "l"     # right arrow always focuses the pane to the right
+
+# Custom commands use the same binding syntax.
+# type = "shell" runs detached in the background.
+# type = "pane" opens a temporary pane and closes it when the command exits.
+# type = "popup" opens a session-modal terminal without changing the tab layout.
+# Popup width and height accept terminal cells or percentages such as "80%".
+# On Windows, command strings run through cmd.exe /d /c.
+# [[keys.command]]
+# key = "prefix+alt+g"
+# type = "popup"
+# command = "lazygit"
+# width = "80%"
+# height = "80%"
+
+# Legacy indexed shortcut config is still parsed for compatibility.
+# Prefer switch_tab, switch_workspace, and focus_agent for new configs.
+# [keys.indexed]
+# tabs = ""       # e.g. "ctrl" makes ctrl+1..9 switch tabs directly
+# workspaces = "" # e.g. "ctrl+shift" makes ctrl+shift+1..9 switch workspaces directly
+# agents = ""     # e.g. "alt" makes alt+1..9 focus agent rows directly
+
+# [worktrees]
+# directory = "~/.herdr/worktrees"
+
+[ui]
+# Sidebar width (auto-scaled based on workspace names, this sets the default)
+# sidebar_width = 26
+
+# Minimum sidebar width when expanded (columns)
+# sidebar_min_width = 18
+
+# Maximum sidebar width when expanded (columns)
+# sidebar_max_width = 36
+
+# Start with the sidebar collapsed. Changes take effect on the next launch.
+# sidebar_start_collapsed = false
+
+# Collapsed sidebar presentation: "compact" keeps the narrow status rail, "hidden" uses zero width.
+# sidebar_collapsed_mode = "compact"
+
+# Terminal width at or below which Herdr uses the mobile single-column layout.
+# Increase this for foldables, tablets, or wide phone terminals.
+# mobile_width_threshold = 64
+
+# Capture mouse input for Herdr's mouse UI.
+# Set false to let the terminal handle normal clicks, such as Cmd-clicking URLs.
+# Pane apps like lazygit and btop can still receive mouse when they request it.
+# mouse_capture = true
+
+# Automatically copy text selected with the mouse.
+# Set false to retain drag or double-click word selection until Ctrl+C,
+# or Cmd+C when the host forwards it, copies and clears it.
+# copy_on_select = true
+
+# Host cursor policy: "auto", "native", or "drawn".
+# "auto" draws Herdr's own cursor on native Windows builds and WSL to avoid ConPTY cursor flicker, and uses the native terminal cursor elsewhere.
+# "native" always uses the outer terminal cursor. "drawn" always draws Herdr's cursor as terminal cell content.
+# host_cursor = "auto"
+
+# Optional modifier that forwards right-click hold/drag gestures to pane apps instead of opening Herdr's pane menu.
+# Empty/off disables this. Shift is intentionally unsupported because terminals commonly reserve Shift+mouse.
+# right_click_passthrough_modifier = ""
+
+# Force a full redraw when the outer terminal regains focus.
+# Set false to reduce visible flashing when switching back to Herdr.
+# Trade-off: rare host terminal surface corruption may persist until the next full redraw.
+# redraw_on_focus_gained = true
+
+# Pane scrollback lines to scroll per mouse wheel notch.
+# mouse_scroll_lines = 3
+
+# Ask for confirmation before closing a workspace
+# confirm_close = true
+
+# Ask for a tab name before creating a new tab.
+# Set false to create tabs immediately with generated names.
+# prompt_new_tab_name = true
+
+# Ask for a workspace name before interactive creation.
+# prompt_new_workspace_name = false
+
+# Draw borders around split panes.
+# pane_borders = true
+
+# Draw interactive scrollbars beside terminal panes.
+# Set false to reclaim the scrollbar column and keep it out of terminal-native selections.
+# pane_scrollbars = true
+
+# Keep split panes visually separated instead of sharing divider borders.
+# pane_gaps = true
+
+# Show detected/reported agent labels in split pane borders when no manual pane name is set.
+# show_agent_labels_on_pane_borders = false
+
+# Hide the tab row when a workspace has exactly one tab.
+# New tabs can still be created with the configured keybinding.
+# hide_tab_bar_when_single_tab = false
+
+# Desktop tab row placement: "top" or "bottom".
+# tab_bar_position = "top"
+
+# Agent panel ordering: "spaces" (grouped by space) or "priority" (attention queue).
+# "workspaces" is accepted as an alias for "spaces".
+# agent_panel_sort = "spaces"
+
+# Expanded agent rows. Built-ins are state_icon, state_text, workspace, tab, pane, agent,
+# terminal_title, and terminal_title_stripped.
+# Custom values reported through pane metadata use a $name token.
+# A token occurrence may be styled with { token = "workspace", fg = "#89b4fa", bold = true, dim = false }.
+# Omitted style fields preserve the contextual default.
+# [ui.sidebar.agents]
+# Blank rows between agent entries. Set to 1 to restore the previous spacing.
+# row_gap = 0
+# rows = [["state_icon", "workspace", "tab"], ["agent"]]
+# Optional canonical agent IDs replace the default rows for matching agents.
+# [ui.sidebar.agents.rows_by_agent]
+# claude = [["state_icon", "workspace", "tab"], ["terminal_title_stripped"], ["agent"]]
+
+# Expanded space rows. Built-ins are state_icon, state_text, workspace, branch, and git_status.
+# Custom values reported through workspace metadata use a $name token, for example $jj_status.
+# Inline token styles accept strict #RGB/#RRGGBB foregrounds plus bold and dim booleans.
+# [ui.sidebar.spaces]
+# Blank rows between space entries. Set to 1 to restore the previous spacing.
+# row_gap = 0
+# rows = [["state_icon", "workspace"], ["branch", "git_status"]]
+
+# Accent color for highlights, borders, and navigation UI.
+# Accepts: hex (#89b4fa), named colors (cyan, blue, magenta), or rgb(r,g,b)
+# accent = "cyan"
+
+# Background notification popup delivery
+[ui.toast]
+# off = disable pop-up notifications
+# herdr = show in-app toasts
+# terminal = ask the outer terminal to show a desktop notification
+# system = ask the OS notification service directly
+delivery = "system"
+# delay_seconds = 1
+
+[ui.toast.herdr]
+# position = "bottom-right"
+
+[ui.toast.clipboard]
+# enabled = true
+# position = "bottom-center"
+
+# Play sounds when agents change state in background workspaces
+[ui.sound]
+# enabled = true
+# Optional custom mp3 sound files. Relative paths are resolved from this config file's directory.
+# path = "sounds/notification.mp3"   # one mp3 file for all sound notifications
+# done_path = "sounds/done.mp3"      # overrides only finished notifications
+# request_path = "sounds/request.mp3" # overrides only needs-attention notifications
+
+# Per-agent overrides: default | on | off
+# By default, droid is muted.
+# [ui.sound.agents]
+# droid = "off"
+
+[session]
+# Resume supported AI-agent panes into their native conversation sessions after
+# a Herdr server restart. Requires official integrations that report session refs.
+# resume_agents_on_restore = true
+
+[remote]
+# Whether herdr manages the ssh config used for `herdr --remote`.
+# When true (default), herdr runs remote ssh through a generated config that
+# includes your ~/.ssh/config first and adds ServerAliveInterval/
+# ServerAliveCountMax as fallbacks (so any keepalive values you set yourself
+# still win) to survive idle network/NAT timeouts. Herdr also uses a private
+# per-attach OpenSSH control socket to reuse the first authenticated connection.
+# Set false to run plain ssh against your ssh config unchanged — this does not
+# force keepalive or multiplexing off, it only stops herdr from adding its own.
+# manage_ssh_config = true
+
+[experimental]
+# Allow launching herdr from inside a herdr-managed pane.
+# allow_nested = false
+# Experimental local Kitty graphics rendering for attached clients.
+# Requires a Kitty graphics-compatible outer terminal.
+# kitty_graphics = false
+# Save recent pane screen history across full server restarts.
+pane_history = false
+# While prefix mode is active, temporarily switch the host input source to
+# an ASCII-capable mode so prefix commands register even when an IME is
+# active, then restore the previous input source when prefix mode exits. On
+# macOS this selects the ASCII-capable keyboard layout; on Windows it toggles
+# a Korean IME between Hangul and English (other IME languages are left
+# unchanged). macOS and Windows only; best-effort. Default: false.
+# switch_ascii_input_source_in_prefix = false
+# Expose the focused pane's cursor to the outer terminal so macOS input
+# methods keep tracking the candidate window when TUIs paint their own
+# cursor (Claude Code, pi, codex). Trade-off: extra cursor visible for
+# apps that hide it without painting a replacement (vim normal mode, etc.).
+# reveal_hidden_cursor_for_cjk_ime = false
+# Optional allow-list: only reveal for focused panes whose detected agent
+# matches one of these names. Empty means apply to any focused pane.
+# If the list contains no valid names, the reveal does not apply.
+# Accepted: pi, claude, codex, gemini, cursor, devin, cline, opencode,
+# copilot, kimi, kiro, droid, amp, grok, hermes, kilo, qodercli, qoder.
+# cjk_ime_agents = []
+# Cursor shape rendered when reveal_hidden_cursor_for_cjk_ime is true.
+# Values: block, steady_block (default), underline, steady_underline, bar, steady_bar.
+# cjk_ime_cursor_shape = "steady_block"
+
+[advanced]
+# Maximum scrollback buffer size in bytes retained per pane terminal.
+# Matches Ghostty's default scrollback-limit behavior.
+# scrollback_limit_bytes = 10000000


### PR DESCRIPTION
## Summary

Adopts [herdr](https://herdr.dev) 0.8.0 — a client/server agent multiplexer that detects Claude Code panes, tracks working/blocked/done/idle state natively, and resumes agent conversations across server restarts.

- **herdr/config.toml** — full commented default config, explicit: `onboarding = false`, `[ui.toast] delivery = "system"`, `[keys] prefix = "ctrl+space"` (matches tmux deliberately; the two are not nested in normal use)
- **dotbot base.yaml** — `create` + `link` entries. Symlink is safe here: herdr rewrites config **in place** (inode-verified via `herdr config reset-keys`), the deliberate opposite of Otty's copy-seed. File-only link — the dir also holds socket/logs/session state
- **Brewfile** — `herdr` (server = brew services launchd job, keep_alive) + `terminal-notifier` (herdr's preferred system-toast path)
- **CLAUDE.md / AGENTS.md** — conventions: server-stop-kills-panes, updates ride `brew upgrade` (`herdr update --handoff` disabled on brew installs), `herdr integration install claude` is a human step (classifier blocks agent writes to `~/.claude/`), socket-API gotchas (`--until done` never fires on focused panes)

## Verification

- `dot check` green (incl. dotbot dry-run parse of all three layers)
- Live smoke test: workspace created via socket API, Claude Code pane detected (`idle → working → idle`), prompt injection + reply round-trip, system toast delivered
- Server reads config through the symlink; `reload-config` applies with zero diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQVqSScYPTLM7ZTz7aArja


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Herdr terminal multiplexer setup and configuration support.
  - Added configurable themes, terminal behavior, keybindings, notifications, sounds, sessions, remote SSH management, and scrollback options.
  - Added Claude integration guidance, including keybindings and scripting workflows.
  - Added system notifications through terminal-notifier.

- **Documentation**
  - Documented Herdr installation, configuration linking, session persistence, server lifecycle, updates, nesting behavior, and integration guidance.
  - Added a comprehensive configuration template with documented options and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->