### PR TITLE
feat(herdr): Atlas surface — Hermes TUI as a detected agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,6 +279,17 @@ conversations across server restarts via `claude --resume <id>`.
   do nest, tmux's `send-prefix` binding passes it through on a double-tap. Herdr
   can host tmux in a pane or run inside tmux, but agent detection does not see
   through a nested tmux.
+- **Atlas surface:** workspace `atlas ⚓` hosts the Hermes TUI (Atlas, on the
+  VPS) via `~/.local/bin/hermes-agent` — a **symlink to `/usr/bin/ssh`**. Herdr
+  identifies agents by *process name*, and `hermes-agent` is an alias in its
+  hermes manifest, so the ssh attach is detected as a hermes agent; the
+  `HERDR_AGENT` env pin does not work for spawned panes on 0.8.0. Recreate with
+  `ln -sf /usr/bin/ssh ~/.local/bin/hermes-agent` (machine-local, not
+  Dotbot-managed). The remote hermes tmux session has `set-titles on` +
+  `set-titles-string "#{pane_title}"` so the TUI's ✓/⏳/⚠ OSC titles drive
+  herdr's idle/working/blocked states through the nested tmux. `ctrl+space a`
+  jumps to the atlas agent. Never restart `hermes-tmux.service` casually — it
+  drops Atlas's in-memory history (see ~/Projects/agents docs for Hermes rules).
 - **Scripting:** NDJSON over `~/.config/herdr/herdr.sock`; `herdr api schema`
   emits the full machine-readable surface. Gotcha: `herdr agent wait --until
   done` never fires on a *focused* pane (done = finished-but-unseen) — wait on

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -127,6 +127,12 @@ prefix = "ctrl+space"
 # width = "80%"
 # height = "80%"
 
+[[keys.command]]
+key = "prefix+a"
+type = "shell"
+command = "herdr agent focus atlas"
+description = "jump to Atlas"
+
 # Legacy indexed shortcut config is still parsed for compatibility.
 # Prefer switch_tab, switch_workspace, and focus_agent for new configs.
 # [keys.indexed]
@@ -230,6 +236,8 @@ prefix = "ctrl+space"
 # Optional canonical agent IDs replace the default rows for matching agents.
 # [ui.sidebar.agents.rows_by_agent]
 # claude = [["state_icon", "workspace", "tab"], ["terminal_title_stripped"], ["agent"]]
+[ui.sidebar.agents.rows_by_agent]
+hermes = [["state_icon", "workspace"], ["terminal_title_stripped"]]
 
 # Expanded space rows. Built-ins are state_icon, state_text, workspace, branch, and git_status.
 # Custom values reported through workspace metadata use a $name token, for example $jj_status.


### PR DESCRIPTION
## Summary

Follow-up to #135: surfaces **Atlas** (the Hermes TUI on the VPS, GPT-5.6 Sol) as a first-class detected agent in herdr — workspace `atlas ⚓`, real idle/working/blocked states, toasts, and a one-chord jump.

- **Detection mechanism**: herdr identifies agents by *process name*; `~/.local/bin/hermes-agent` (symlink → `/usr/bin/ssh`, machine-local) matches the hermes manifest alias, so the ssh attach to the VPS tmux session is detected natively. The documented `HERDR_AGENT` env pin does not work for spawned panes on 0.8.0 (verified: env absent from pane process via both layout `env` and `env(1)` wrapping).
- **State pipeline**: remote hermes tmux session now has `set-titles on` + `set-titles-string "#{pane_title}"` (two idempotent, reversible options; Hermes itself untouched) — the TUI's ✓/⏳/⚠ OSC title prefixes match herdr's highest-priority manifest rules through the nested tmux.
- **Config**: `[ui.sidebar.agents.rows_by_agent]` hermes rows (state icon + workspace / stripped title); `[[keys.command]]` `prefix+a` → `herdr agent focus atlas`.

## Verification

- Live: `herdr agent list` shows `w4:p4 | hermes | idle`, named `atlas`, title `✓ Obscura Task 2 · gpt-5.6-sol · ~`
- Offline manifest test (`herdr agent explain --file`) on a captured TUI screen: rules evaluate, no false positives from the tmux status bar
- `herdr server reload-config`: applied, zero diagnostics; `herdr agent focus atlas` verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQVqSScYPTLM7ZTz7aArja


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a quick navigation shortcut to jump directly to the Atlas workspace.
  * Added a Hermes sidebar entry displaying the active workspace and terminal title.

* **Documentation**
  * Documented the Atlas workspace connection, navigation, state handling, and remote service restart guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->