### PR TITLE
chore: record herdr fleet + review-tool drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,8 +231,12 @@ install via Homebrew casks in `brew/Brewfile`, not a helper.)
   survives and live edits surface as `M herdr/config.toml`; diff and commit them. Link
   only the file — `~/.config/herdr/` also holds the socket, logs, and session state.
   `herdr server stop` / restart kills all pane processes (layout restores, supported
-  agent sessions resume); detach instead. `herdr integration install claude` writes
-  into `~/.claude/` and is a human step, not an agent one.
+  agent sessions resume); detach instead. `herdr integration install <agent>` writes
+  into the agent's own config dir and is a human step, not an agent one (claude and
+  codex installed, both v7). Custom `[[keys.command]]` bindings load only at server
+  startup — `reload-config` reports "applied" without activating them. The ssh shims
+  herdr's remote-agent detection keys on (`~/.local/bin/{hermes-agent,claude-code}`
+  → `/usr/bin/ssh`) are seeded by `helpers/install_herdr_agents.sh` (darwin.yaml).
 - **`otty/` is copy-seeded, never symlinked — do not add a `link:` entry for it.**
   `otty config set` and the Settings UI write via temp-file + `rename(2)`, which replaces
   the path and destroys a symlink on the first settings change; the CLI still exits 0 and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,7 +235,7 @@ install via Homebrew casks in `brew/Brewfile`, not a helper.)
   into the agent's own config dir and is a human step, not an agent one (claude and
   codex installed, both v7). Custom `[[keys.command]]` bindings load only at server
   startup — `reload-config` reports "applied" without activating them. The ssh shims
-  herdr's remote-agent detection keys on (`~/.local/bin/{hermes-agent,claude-code}`
+  herdr's remote-agent detection depends on (`~/.local/bin/{hermes-agent,claude-code}`
   → `/usr/bin/ssh`) are seeded by `helpers/install_herdr_agents.sh` (darwin.yaml).
 - **`otty/` is copy-seeded, never symlinked — do not add a `link:` entry for it.**
   `otty config set` and the Settings UI write via temp-file + `rename(2)`, which replaces

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,26 +270,40 @@ conversations across server restarts via `claude --resume <id>`.
   (`[session] resume_agents_on_restore`), but plain shells restart fresh.
 - **Updates ride `brew upgrade`** (topgrade covers it). `herdr update` and the
   experimental `--handoff` live-update are disabled for Homebrew installs.
-- **`herdr integration install claude` is a human step** — it writes
-  `~/.claude/hooks/herdr-agent-state.sh` and registers hooks in
+- **`herdr integration install <agent>` is a human step** — it writes hooks into
+  the agent's own config (for claude: `~/.claude/hooks/herdr-agent-state.sh` +
   `~/.claude/settings.json`, which the auto-mode classifier blocks agents from
-  doing. Check `herdr integration status` after major Claude Code updates.
+  editing). Installed: claude and codex, both v7; codex's hook lives in
+  `~/.codex/` and was merged alongside the pre-existing Otty hooks in
+  `hooks.json`. Check `herdr integration status` after major agent-CLI updates.
 - **Prefix is `ctrl+space`, deliberately matching tmux** — one muscle-memory
   "multiplexer key" across both apps, which are not nested in normal use. If you
   do nest, tmux's `send-prefix` binding passes it through on a double-tap. Herdr
   can host tmux in a pane or run inside tmux, but agent detection does not see
   through a nested tmux.
-- **Atlas surface:** workspace `atlas ⚓` hosts the Hermes TUI (Atlas, on the
-  VPS) via `~/.local/bin/hermes-agent` — a **symlink to `/usr/bin/ssh`**. Herdr
-  identifies agents by *process name*, and `hermes-agent` is an alias in its
-  hermes manifest, so the ssh attach is detected as a hermes agent; the
-  `HERDR_AGENT` env pin does not work for spawned panes on 0.8.0. Recreate with
-  `ln -sf /usr/bin/ssh ~/.local/bin/hermes-agent` (machine-local, not
-  Dotbot-managed). The remote hermes tmux session has `set-titles on` +
-  `set-titles-string "#{pane_title}"` so the TUI's ✓/⏳/⚠ OSC titles drive
-  herdr's idle/working/blocked states through the nested tmux. `ctrl+space a`
-  jumps to the atlas agent. Never restart `hermes-tmux.service` casually — it
-  drops Atlas's in-memory history (see ~/Projects/agents docs for Hermes rules).
+- **Remote agent surfaces (`atlas ⚓` / `axiom ∴`):** each workspace hosts a VPS
+  TUI through an ssh shim whose *name* matches a detection-manifest alias —
+  herdr identifies agents by process name, and the `HERDR_AGENT` env pin does
+  not work for spawned panes on 0.8.0. `~/.local/bin/hermes-agent → /usr/bin/ssh`
+  attaches the Hermes TUI (Atlas, detected as hermes);
+  `~/.local/bin/claude-code → /usr/bin/ssh` attaches AXIOM's Claude Code
+  (detected as claude, renamed `axiom`) via
+  `sudo -u node tmux -L axiom attach -t AXIOM` — since the 2026-07-14 vault
+  fold AXIOM runs as **node** on the dedicated socket `-L axiom`. Both shims
+  are Dotbot-managed (`helpers/install_herdr_agents.sh`, darwin.yaml). Each
+  remote tmux carries `set-titles on` + `set-titles-string "#{pane_title}"` so
+  the TUIs' OSC titles drive herdr states through the nested tmux. Never
+  restart `hermes-tmux.service` casually — it drops Atlas's in-memory history
+  (see ~/Projects/agents docs for Hermes rules).
+- **`[[keys.command]]` bindings load only at server startup.** `herdr server
+  reload-config` returns `status: "applied"` without activating new or changed
+  custom key commands (verified 2026-08-18 on 0.8.0: zero dispatches logged for
+  any post-start binding while built-in prefix keys work fine). The jump keys
+  `prefix+a` → atlas / `prefix+d` → axiom stay dead until the next server
+  start. Upstream bug candidate. Related PATH gotcha: the settings→integrations
+  panel probes agent CLIs with the server's bare launchd PATH, so `codex` reads
+  "not found" even when installed — `herdr integration status` from a shell is
+  authoritative.
 - **Scripting:** NDJSON over `~/.config/herdr/herdr.sock`; `herdr api schema`
   emits the full machine-readable surface. Gotcha: `herdr agent wait --until
   done` never fires on a *focused* pane (done = finished-but-unseen) — wait on

--- a/brew/Brewfile
+++ b/brew/Brewfile
@@ -78,6 +78,8 @@ brew "curl"                 # newer curl (opt/curl/bin on PATH)
 brew "wget"
 brew "aria2"                # multi-connection downloader
 brew "yt-dlp"               # video/audio downloader
+brew "mosh"                 # roaming remote shell — VPS tmux attaches (AXIOM/hermes);
+                            # UDP rides inside the Tailscale tunnel, no firewall changes
 
 # --- System monitoring & cleanup ---
 brew "btop"                 # resource monitor
@@ -145,6 +147,8 @@ brew "util-linux"
 brew "xmlto"
 
 # --- Casks ---
+cask "coderabbit"           # CodeRabbit CLI — AI PR review, trial alongside the standing
+                            # dv:gauntlet rule; app-side review rides the GitHub app
 cask "corelocationcli"      # CLI to read macOS CoreLocation (location-based tooling)
 cask "docker-desktop"
 cask "font-fira-code-nerd-font"      # Nerd Font (replaces manual fonts/ + install_fonts.sh)

--- a/dotbot-conf/darwin.yaml
+++ b/dotbot-conf/darwin.yaml
@@ -32,6 +32,7 @@
     # the config path and would orphan a symlink. Hence a shell step here rather
     # than an entry in the `link:` block below.
     - [bash helpers/install_otty.sh, "Seeding Otty config (if absent)"]
+    - [bash helpers/install_herdr_agents.sh, "Linking herdr agent ssh shims"]
 
 - link:
     ~/.claude/CLAUDE.md: claude/CLAUDE.md

--- a/helpers/install_herdr_agents.sh
+++ b/helpers/install_herdr_agents.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # install_herdr_agents.sh — seed the ssh argv[0] shims herdr's agent
-# detection keys on.
+# detection depends on.
 #
 # Herdr identifies a pane's agent by PROCESS NAME against its detection
 # manifests. `hermes-agent` (hermes manifest) and `claude-code` (claude

--- a/helpers/install_herdr_agents.sh
+++ b/helpers/install_herdr_agents.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# install_herdr_agents.sh — seed the ssh argv[0] shims herdr's agent
+# detection keys on.
+#
+# Herdr identifies a pane's agent by PROCESS NAME against its detection
+# manifests. `hermes-agent` (hermes manifest) and `claude-code` (claude
+# manifest) are alias names no real binary uses on this machine, so pointing
+# them at ssh makes a remote attach register as that agent:
+#   hermes-agent -> the VPS Hermes TUI (workspace "atlas")
+#   claude-code  -> the VPS AXIOM Claude Code (workspace "axiom")
+# The HERDR_AGENT env pin does not work for spawned panes on herdr 0.8.0, so
+# the argv[0] trick is the working mechanism. See CLAUDE.md "Herdr".
+#
+# ln -sf is idempotent; a live pane keeps its already-exec'd process either way.
+set -euo pipefail
+
+if [ "${DOTFILES_DRY_RUN:-0}" = "1" ]; then
+  echo "[dry-run] would symlink ~/.local/bin/{hermes-agent,claude-code} -> /usr/bin/ssh"
+  exit 0
+fi
+
+mkdir -p "$HOME/.local/bin"
+ln -sf /usr/bin/ssh "$HOME/.local/bin/hermes-agent"
+ln -sf /usr/bin/ssh "$HOME/.local/bin/claude-code"
+echo "herdr agent shims linked: hermes-agent, claude-code -> /usr/bin/ssh"

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -133,6 +133,12 @@ type = "shell"
 command = "herdr agent focus atlas"
 description = "jump to Atlas"
 
+[[keys.command]]
+key = "prefix+d"
+type = "shell"
+command = "herdr agent focus axiom"
+description = "jump to Axiom"
+
 # Legacy indexed shortcut config is still parsed for compatibility.
 # Prefer switch_tab, switch_workspace, and focus_agent for new configs.
 # [keys.indexed]
@@ -236,6 +242,7 @@ description = "jump to Atlas"
 # Optional canonical agent IDs replace the default rows for matching agents.
 # [ui.sidebar.agents.rows_by_agent]
 # claude = [["state_icon", "workspace", "tab"], ["terminal_title_stripped"], ["agent"]]
+agent_panel_sort = "spaces"
 [ui.sidebar.agents.rows_by_agent]
 hermes = [["state_icon", "workspace"], ["terminal_title_stripped"]]
 


### PR DESCRIPTION
## Summary
Records everything the herdr adoption + review-tool trial left untracked (HANDOFF item 3):

- **Brewfile**: `brew "mosh"`, `cask "coderabbit"` — both installed, previously untracked
- **herdr/config.toml**: `prefix+d` → `herdr agent focus axiom` (mirrors atlas's `prefix+a`; both dead until next server start, see below)
- **New `helpers/install_herdr_agents.sh`** (+ darwin.yaml wiring): the ssh argv[0] shims `~/.local/bin/{hermes-agent,claude-code} → /usr/bin/ssh` that herdr's remote-agent detection keys on are now Dotbot-managed instead of machine-local. Dry-run guarded, idempotent.
- **CLAUDE.md / AGENTS.md**: Atlas bullet generalized to both remote surfaces (`atlas ⚓` / `axiom ∴`) with the post-vault-fold AXIOM attach (`sudo -u node tmux -L axiom attach -t AXIOM`); new gotchas — `[[keys.command]]` loads only at server startup while `reload-config` reports "applied", codex integration installed (v7), integrations panel probes CLIs with bare launchd PATH.

## Test plan
- `shellcheck helpers/install_herdr_agents.sh` clean
- `DOTFILES_DRY_RUN=1` prints the preview and exits without mutation
- Real run idempotent against existing live symlinks
- darwin.yaml YAML-validates; install-matrix exercises the new shell step on macos

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qmr2g3oNNUE1FUiiqdhj62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added roaming remote-shell support and CodeRabbit CLI installation to the development setup.
  - Added automatic SSH shim setup for remote agent integrations on macOS.
  - Added a keyboard shortcut to focus the Axiom agent.
  - Agent panels now sort by workspace.

- **Documentation**
  - Expanded integration guidance for Claude, Codex, Atlas, and Axiom, including setup, detection, status checks, and remote-agent behavior.
  - Documented startup requirements, recovery behavior, and troubleshooting for integration detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->