### PR TITLE
docs(herdr): correct the HERDR_AGENT claim; link upstream issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,8 +283,12 @@ conversations across server restarts via `claude --resume <id>`.
   through a nested tmux.
 - **Remote agent surfaces (`atlas ⚓` / `axiom ∴`):** each workspace hosts a VPS
   TUI through an ssh shim whose *name* matches a detection-manifest alias —
-  herdr identifies agents by process name, and the `HERDR_AGENT` env pin does
-  not work for spawned panes on 0.8.0. `~/.local/bin/hermes-agent → /usr/bin/ssh`
+  herdr identifies agents by process name **only**; 0.8.0 has no env-var
+  identity pin (feature request: herdrdev/herdr#2961). Do not re-derive the
+  2026-08-07 "HERDR_AGENT env pin is dead" finding — it was a measurement
+  artifact: `layout.apply`'s `env` IS delivered to pane processes (verified by
+  in-pane `printenv` 2026-08-18); `ps eww` cannot read other processes' env on
+  modern macOS and shows nothing, which faked the "var absent" result. `~/.local/bin/hermes-agent → /usr/bin/ssh`
   attaches the Hermes TUI (Atlas, detected as hermes);
   `~/.local/bin/claude-code → /usr/bin/ssh` attaches AXIOM's Claude Code
   (detected as claude, renamed `axiom`) via
@@ -300,7 +304,7 @@ conversations across server restarts via `claude --resume <id>`.
   custom key commands (verified 2026-08-18 on 0.8.0: zero dispatches logged for
   any post-start binding while built-in prefix keys work fine). The jump keys
   `prefix+a` → atlas / `prefix+d` → axiom stay dead until the next server
-  start. Upstream bug candidate. Related PATH gotcha: the settings→integrations
+  start. Filed upstream: herdrdev/herdr#2960. Related PATH gotcha: the settings→integrations
   panel probes agent CLIs with the server's bare launchd PATH, so `codex` reads
   "not found" even when installed — `herdr integration status` from a shell is
   authoritative.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -54,10 +54,12 @@ as a review-flow trial. All three PRs merged, master clean, no open PRs, remote 
 
 ## What Didn't Work
 
-- **`HERDR_AGENT` env pinning is dead on 0.8.0 for spawned panes** — both `layout.apply`'s
-  `env` param and an `/usr/bin/env HERDR_AGENT=hermes …` argv wrapper leave the var absent from
-  the pane process (verified via `ps eww`). Process-*name* identification is the working
-  mechanism — hence the ssh symlink. Upstream bug worth filing (repro is clean).
+- ~~**`HERDR_AGENT` env pinning is dead on 0.8.0 for spawned panes**~~ **CORRECTED
+  2026-08-18 (later session):** this was a `ps eww` measurement artifact — it cannot read
+  other processes' env on modern macOS. `layout.apply`'s `env` IS delivered (in-pane
+  `printenv` proof); herdr simply has no env-var identity pin at all, detection is
+  process-name only — hence the ssh symlink. See CLAUDE.md "Herdr" and upstream
+  herdrdev/herdr#2961 (feature request), #2960 (reload-config keys bug).
 - **`herdr agent wait --until done` never fires on a focused pane** (done = finished-but-unseen).
   Wait on `idle`/`blocked` or subscribe to `pane.agent_status_changed`.
 - **`herdr pane run` types into the pane's shell** — the shell stays the pane root process, so

--- a/helpers/install_herdr_agents.sh
+++ b/helpers/install_herdr_agents.sh
@@ -9,8 +9,9 @@
 # them at ssh makes a remote attach register as that agent:
 #   hermes-agent -> the VPS Hermes TUI (workspace "atlas")
 #   claude-code  -> the VPS AXIOM Claude Code (workspace "axiom")
-# The HERDR_AGENT env pin does not work for spawned panes on herdr 0.8.0, so
-# the argv[0] trick is the working mechanism. See CLAUDE.md "Herdr".
+# Herdr 0.8.0 has no env-var identity pin (upstream feature request:
+# herdrdev/herdr#2961), so the argv[0] trick is the working mechanism.
+# See CLAUDE.md "Herdr".
 #
 # ln -sf is idempotent; a live pane keeps its already-exec'd process either way.
 set -euo pipefail


### PR DESCRIPTION
## Summary
Verification before filing upstream overturned a documented finding: the 2026-08-07 "`HERDR_AGENT` env pin is dead for spawned panes" claim was a measurement artifact. `layout.apply`'s `env` **is** delivered to pane processes (proved with an in-pane `printenv` probe); `ps eww` can't read other processes' environments on modern macOS, which faked the "var absent" reading. Herdr has no env-var identity pin at all — detection is process-name only, which is why the argv[0] shims exist.

- CLAUDE.md: replace the false claim with the verified account (and a don't-re-derive note), link the upstream filings
- `helpers/install_herdr_agents.sh`: correct the header comment
- Upstream: [herdrdev/herdr#2960](https://github.com/herdrdev/herdr/issues/2960) (reload-config silently ignores `[[keys.command]]`), [#2961](https://github.com/herdrdev/herdr/issues/2961) (feature request: first-class agent pin, noting env delivery already works)

## Test plan
Docs + comment only; no behavior change. CI runs because a `.sh` file is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qmr2g3oNNUE1FUiiqdhj62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that agent detection relies on process names in Herdr 0.8.0, without an environment-variable identity pin.
  * Updated guidance on pane environments and modern macOS process inspection.
  * Documented the upstream issue affecting custom key bindings.
  * Aligned installation-script comments with the latest detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->