### PR TITLE
fix(zsh): command-guard the RVM and pyenv lazy-loader shims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,11 @@ conversations across server restarts via `claude --resume <id>`.
   `brew services restart` after an upgrade) **kills all pane processes**; layout
   is snapshot-restored and supported agent conversations resume
   (`[session] resume_agents_on_restore`), but plain shells restart fresh.
+  Boot-race caveat (reboot, 2026-08-18): if a declarative pane's `command`
+  fails at restore (ssh before the network is up), the pane degrades to a
+  plain shell AND the command is silently dropped from the layout — later
+  restarts restore the shell. Fix: re-run `layout.apply` with the original
+  pane node. Filed upstream: herdrdev/herdr#2966.
 - **Updates ride `brew upgrade`** (topgrade covers it). `herdr update` and the
   experimental `--handoff` live-update are disabled for Homebrew installs.
 - **`herdr integration install <agent>` is a human step** — it writes hooks into

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -255,9 +255,10 @@ hermes = [["state_icon", "workspace"], ["state_text", { token = "agent", fg = "#
 # Expanded space rows. Built-ins are state_icon, state_text, workspace, branch, and git_status.
 # Custom values reported through workspace metadata use a $name token, for example $jj_status.
 # Inline token styles accept strict #RGB/#RRGGBB foregrounds plus bold and dim booleans.
-# [ui.sidebar.spaces]
-# Blank rows between space entries. Set to 1 to restore the previous spacing.
-# row_gap = 0
+# Vertical spacing between workspace entries, mirroring the agents panel's
+# row_gap for the hero look.
+[ui.sidebar.spaces]
+row_gap = 1
 # rows = [["state_icon", "workspace"], ["branch", "git_status"]]
 
 # Accent color for highlights, borders, and navigation UI.

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -117,9 +117,13 @@ if command -v pyenv 1>/dev/null 2>&1; then
     eval "$(command pyenv init -)"
     eval "$(command pyenv init --path)"
   }
+  # pyenv stays a bare call (init defines a shell function the shim must reach);
+  # python/pip resolve to PATH shims after init, so `command` guards them against
+  # self-recursion if _load_pyenv is ever missing (e.g. harness shell snapshots
+  # that replay shims without underscore-prefixed helpers).
   pyenv()  { _load_pyenv; pyenv "$@"; }
-  python() { _load_pyenv; python "$@"; }
-  pip()    { _load_pyenv; pip "$@"; }
+  python() { _load_pyenv; command python "$@"; }
+  pip()    { _load_pyenv; command pip "$@"; }
 fi
 
 # Lazy load NVM. NVM_DIR is exported once in zshenv ($XDG_CONFIG_HOME/nvm).
@@ -153,11 +157,16 @@ if [[ -s "$HOME/.rvm/scripts/rvm" ]]; then
     unset -f _load_rvm rvm ruby gem rake bundle
     source "$HOME/.rvm/scripts/rvm"
   }
+  # rvm stays a bare call (the sourced script defines the rvm function the shim
+  # must reach); the rest are PATH binaries after load, so `command` prevents
+  # FUNCNEST self-recursion when _load_rvm is missing (observed: harness shell
+  # snapshots replay these shims without the underscore-prefixed loader, and a
+  # bare `ruby "$@"` then recursed to "maximum nested function level").
   rvm()    { _load_rvm; rvm "$@"; }
-  ruby()   { _load_rvm; ruby "$@"; }
-  gem()    { _load_rvm; gem "$@"; }
-  rake()   { _load_rvm; rake "$@"; }
-  bundle() { _load_rvm; bundle "$@"; }
+  ruby()   { _load_rvm; command ruby "$@"; }
+  gem()    { _load_rvm; command gem "$@"; }
+  rake()   { _load_rvm; command rake "$@"; }
+  bundle() { _load_rvm; command bundle "$@"; }
 fi
 
 # Initialize starship prompt


### PR DESCRIPTION
## Summary
`ruby` (and the other RVM shims, plus pyenv's `python`/`pip`) recursed to FUNCNEST in any shell where the `_load_*` helper is absent while the shims survive — observed live in harness shell snapshots, which replay the shim functions without the underscore-prefixed loaders. The lazy-loader convention in CLAUDE.md already prescribes `command <tool>` after `_load_*`; the NVM block follows it (which is why `node` failed with one clean error where `ruby` exploded), RVM and pyenv didn't.

- `ruby`/`gem`/`rake`/`bundle` and `python`/`pip` now call `command <tool> "$@"` after the loader
- `rvm` and `pyenv` deliberately stay bare — their loaders define same-named shell functions the shim must invoke

## Test plan
- Orphan simulation, old form: `FUNCNEST=20; ruby() { _load_rvm; ruby "$@" }` → "maximum nested function level" (bug reproduced)
- Orphan simulation, new form: one `command not found: _load_rvm` line, then system ruby runs, exit 0
- Real load path: sourcing the actual `~/.rvm/scripts/rvm` through `_load_rvm` still resolves `ruby --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qmr2g3oNNUE1FUiiqdhj62