### PR TITLE
feat(herdr): melos local agent workspace + prefix+m jump key

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,11 @@ install via Homebrew casks in `brew/Brewfile`, not a helper.)
   (`/opt/homebrew/bin/herdr …`); key changes themselves hot-reload fine. The ssh shims
   herdr's remote-agent detection depends on (`~/.local/bin/{hermes-agent,claude-code}`
   → `/usr/bin/ssh`) are seeded by `helpers/install_herdr_agents.sh` (darwin.yaml).
+  Local project agents (e.g. the `melos ♪` workspace, Claude Code in
+  `~/Projects/melos`) need no shim — herdr detects a local claude pane natively;
+  their declarative pane command is `["/bin/zsh", "-l", "-c", "exec claude"]` so
+  the login shell rebuilds PATH from `zshenv` before claude starts (the server
+  spawns pane commands with its bare launchd env).
 - **`otty/` is copy-seeded, never symlinked — do not add a `link:` entry for it.**
   `otty config set` and the Settings UI write via temp-file + `rename(2)`, which replaces
   the path and destroys a symlink on the first settings change; the CLI still exits 0 and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,6 +308,18 @@ conversations across server restarts via `claude --resume <id>`.
   the TUIs' OSC titles drive herdr states through the nested tmux. Never
   restart `hermes-tmux.service` casually — it drops Atlas's in-memory history
   (see ~/Projects/agents docs for Hermes rules).
+- **Local agent workspace (`melos ♪`, added 2026-08-18):** Claude Code running
+  in `~/Projects/melos` (the Spotify curator agent) as a declarative pane —
+  command `["/bin/zsh", "-l", "-c", "exec claude"]`, cwd `~/Projects/melos`.
+  No ssh shim: herdr's claude integration detects it natively and
+  resume-on-restore carries the conversation across server restarts. The
+  login-zsh wrapper is deliberate — the server spawns pane commands with its
+  bare launchd env, and `-l` rebuilds PATH from `zshenv` so both `claude`
+  itself and its subshells resolve tools. Agent renamed `melos`
+  (`herdr agent rename`); renames don't survive pane recreation — reapply
+  after a degraded restore, along with `layout.apply` if the command was
+  dropped (#2966). Jump key: `prefix+m`. Use this pane-command shape as the
+  template for future local project agents.
 - **`[[keys.command]]` `type = "shell"` commands run with the server's bare
   launchd environment** — no `/opt/homebrew/bin` on PATH, so a command like
   `herdr agent focus atlas` dies silently on command-not-found (detached

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -139,6 +139,12 @@ type = "shell"
 command = "/opt/homebrew/bin/herdr agent focus axiom"
 description = "jump to Axiom"
 
+[[keys.command]]
+key = "prefix+m"
+type = "shell"
+command = "/opt/homebrew/bin/herdr agent focus melos"
+description = "jump to Melos"
+
 # Legacy indexed shortcut config is still parsed for compatibility.
 # Prefer switch_tab, switch_workspace, and focus_agent for new configs.
 # [keys.indexed]


### PR DESCRIPTION
Adds **Melos** (the Spotify curator agent — Claude Code running in `~/Projects/melos`) to the herdr fleet as the first **local** project agent, alongside the remote `atlas ⚓` / `axiom ∴` surfaces.

## What changed
- `herdr/config.toml`: `[[keys.command]]` `prefix+m` → `/opt/homebrew/bin/herdr agent focus melos` (absolute path per the launchd-PATH rule). Hot-reloaded live, zero diagnostics.
- `CLAUDE.md` / `AGENTS.md`: document the local-agent pattern — declarative pane command `["/bin/zsh", "-l", "-c", "exec claude"]` so the login shell rebuilds PATH from `zshenv` before claude starts (the server spawns pane commands with its bare launchd env). No ssh shim needed: herdr detects a local claude pane natively; resume-on-restore carries the conversation across restarts.

## Runtime state applied live (recorded docs-only, like axiom in #140)
- Workspace `melos ♪` created, single declarative pane, cwd `~/Projects/melos`
- Agent detected as claude, renamed `melos` (session id reported via the integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qmr2g3oNNUE1FUiiqdhj62