### PR TITLE
chore: drop retired external-volume references

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -59,7 +59,6 @@ and remote; stale `feat/herdr` and all merged feature branches pruned), **empty 
   was ever the problem; all `[[keys.command]]` failures were launchd-PATH. Keys hot-reload fine.
 - **Hero styling adopted wholesale** (rows, accent, spacing, priority sort) after screenshot
   comparison; the reference image is herdr.dev's own hero mock, not a stock default.
-- **Eratos claude (w2) deliberately left down** after the reboot — David: leave it closed.
 - **Instrument-verification methodology** is now durable doctrine (see the new best-practices
   doc): calibrate the instrument against a known-true case; in-band probes over outside
   observers; a second reading through the same blind instrument is not corroboration; a probe

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -37,13 +37,8 @@ project's vault only when asked.
 - **Synced vaults (Syncthing ↔ VPS): only `hermes`** (David+Atlas — personal/feeds/brain/
   TaskNotes) **and `axiom`** (work), both served by the single syncthing-hermes container.
   CC project vaults are Mac-local by design — do not add shares for them unless asked.
-- **Exceptions:** projects on `/Volumes/1TB Media` (Erato, Sizes) get NO vault under
-  `~/Obsidian/` and never sync. Erato does keep its own on-volume vault at
-  `/Volumes/1TB Media/Erato` (standard config applied 2026-07-17) — include it in
-  standard-config propagations when the volume is mounted, but never inspect its
-  content, never relocate it, never add a share. Repo-tracked docs (docs/plans,
-  docs/solutions, CLAUDE.md, HANDOFF.md) stay in their repos — vaults are for notes
-  that aren't code-adjacent.
+- **Repo-tracked docs** (docs/plans, docs/solutions, CLAUDE.md, HANDOFF.md) stay in
+  their repos — vaults are for notes that aren't code-adjacent.
 
 ## Reasoning
 
@@ -180,8 +175,8 @@ Three tiers, in order. Reach for the lowest tier that can actually answer the qu
    >
    > **Configured globally as of 2026-08-07** in the root `mcpServers` of `~/.claude.json`, as
    > consumer `mac-global` — available in every project on this Mac. `~/Projects/agents`
-   > (consumer `argus`) and `/Volumes/1TB Media/Erato` (consumer `vault`) keep their own
-   > project-scoped entries and identities; that is deliberate, not drift.
+   > (consumer `argus`) keeps its own project-scoped entry and identity; that is
+   > deliberate, not drift.
    >
    > It reaches the gateway over an SSH tunnel on `127.0.0.1:8080`, held by the launchd job
    > `com.dvillavicencio.browse-gateway-tunnel`. If the tools stop resolving, check that tunnel


### PR DESCRIPTION
The 1TB media volume is gone (drive failure, discarded) and its
projects are retired, so the vault-exception bullet and the
browse-gateway consumer note no longer describe anything real. The
repo-docs-stay-in-repos rule survives as its own bullet.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Qmr2g3oNNUE1FUiiqdhj62


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository guidance for managing tracked documentation.
  * Simplified vault and project configuration instructions.
  * Removed outdated notes about a previously inactive service and obsolete configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->