### PR TITLE
feat(herdr): auto-reconnect shim wrappers + sites local agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,8 +236,11 @@ install via Homebrew casks in `brew/Brewfile`, not a helper.)
   codex installed, both v7). Custom `[[keys.command]]` shell commands run
   with the server's bare launchd PATH and fail silently — use absolute paths
   (`/opt/homebrew/bin/herdr …`); key changes themselves hot-reload fine. The ssh shims
-  herdr's remote-agent detection depends on (`~/.local/bin/{hermes-agent,claude-code}`
-  → `/usr/bin/ssh`) are seeded by `helpers/install_herdr_agents.sh` (darwin.yaml).
+  herdr's remote-agent detection depends on (`~/.local/bin/{hermes-agent,claude-code}`)
+  are repo-tracked auto-reconnect wrappers (`herdr/shims/`) seeded by
+  `helpers/install_herdr_agents.sh` (darwin.yaml); each execs a same-named raw ssh
+  alias in `~/.local/libexec/` (preserving the detected process name) in a retry
+  loop, so remote panes survive sleep/network loss and only close on clean detach.
   Local project agents (e.g. the `melos ♪` workspace, Claude Code in
   `~/Projects/melos`) need no shim — herdr detects a local claude pane natively;
   their declarative pane command is `["/bin/zsh", "-l", "-c", "exec claude"]` so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,12 +297,21 @@ conversations across server restarts via `claude --resume <id>`.
   delivered to pane processes (verified by in-pane `printenv`); `ps eww`
   cannot read other processes' env on modern macOS and shows nothing, which
   faked the "var absent" result. Full write-up:
-  `docs/solutions/best-practices/verify-the-instrument-before-trusting-a-negative.md`. `~/.local/bin/hermes-agent → /usr/bin/ssh`
+  `docs/solutions/best-practices/verify-the-instrument-before-trusting-a-negative.md`. `~/.local/bin/hermes-agent`
   attaches the Hermes TUI (Atlas, detected as hermes);
-  `~/.local/bin/claude-code → /usr/bin/ssh` attaches AXIOM's Claude Code
+  `~/.local/bin/claude-code` attaches AXIOM's Claude Code
   (detected as claude, renamed `axiom`) via
   `sudo -u node tmux -L axiom attach -t AXIOM` — since the 2026-07-14 vault
-  fold AXIOM runs as **node** on the dedicated socket `-L axiom`. Both shims
+  fold AXIOM runs as **node** on the dedicated socket `-L axiom`. **Since
+  2026-08-19 each shim is a repo-tracked auto-reconnect wrapper**
+  (`herdr/shims/`, symlinked into `~/.local/bin`): it loops ssh via a raw
+  alias in `~/.local/libexec/<same-name>` (which preserves the detected
+  process name), retrying every 10s on any nonzero exit and closing only on
+  a clean detach (exit 0). Panes therefore survive sleep/network loss — the
+  single-pane workspaces no longer vanish overnight, agent renames persist,
+  and the #2966 restore boot-race self-heals. Client keepalives back it up:
+  `~/.ssh/config` `Host openclaw-prod` carries `ServerAliveInterval 60` +
+  `ServerAliveCountMax 120` (machine-local, untracked). Both shims
   are Dotbot-managed (`helpers/install_herdr_agents.sh`, darwin.yaml). Each
   remote tmux carries `set-titles on` + `set-titles-string "#{pane_title}"` so
   the TUIs' OSC titles drive herdr states through the nested tmux. Never
@@ -319,7 +328,12 @@ conversations across server restarts via `claude --resume <id>`.
   (`herdr agent rename`); renames don't survive pane recreation — reapply
   after a degraded restore, along with `layout.apply` if the command was
   dropped (#2966). Jump key: `prefix+m`. Use this pane-command shape as the
-  template for future local project agents.
+  template for future local project agents. Second local agent on the same
+  template: `sites ✦` (added 2026-08-19) — Claude Code in `~/Projects/sites`,
+  an umbrella dir of symlinks to the personal-website repos
+  (davidandbrittanie.com, davidv.sh, villavicencio.dev pending a repo); one
+  agent covers all the Vercel-hosted personal sites, each still its own git
+  repo and Vercel project (conventions in that dir's CLAUDE.md).
 - **`[[keys.command]]` `type = "shell"` commands run with the server's bare
   launchd environment** — no `/opt/homebrew/bin` on PATH, so a command like
   `herdr agent focus atlas` dies silently on command-not-found (detached

--- a/helpers/install_herdr_agents.sh
+++ b/helpers/install_herdr_agents.sh
@@ -13,15 +13,27 @@
 # herdrdev/herdr#2961), so the argv[0] trick is the working mechanism.
 # See CLAUDE.md "Herdr".
 #
+# Since 2026-08-19 each shim is a repo-tracked auto-reconnect WRAPPER
+# (herdr/shims/) symlinked into ~/.local/bin; the raw ssh alias each wrapper
+# execs lives in ~/.local/libexec under the same name so the detected process
+# name is unchanged. Wrappers retry on any nonzero ssh exit, so the panes
+# survive sleep/network loss instead of closing their workspaces.
+#
 # ln -sf is idempotent; a live pane keeps its already-exec'd process either way.
 set -euo pipefail
 
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
 if [ "${DOTFILES_DRY_RUN:-0}" = "1" ]; then
-  echo "[dry-run] would symlink ~/.local/bin/{hermes-agent,claude-code} -> /usr/bin/ssh"
+  echo "[dry-run] would symlink ~/.local/bin/{hermes-agent,claude-code} -> herdr/shims/ wrappers"
+  echo "[dry-run] would symlink ~/.local/libexec/{hermes-agent,claude-code} -> /usr/bin/ssh"
   exit 0
 fi
 
-mkdir -p "$HOME/.local/bin"
-ln -sf /usr/bin/ssh "$HOME/.local/bin/hermes-agent"
-ln -sf /usr/bin/ssh "$HOME/.local/bin/claude-code"
-echo "herdr agent shims linked: hermes-agent, claude-code -> /usr/bin/ssh"
+mkdir -p "$HOME/.local/bin" "$HOME/.local/libexec"
+chmod +x "$REPO_ROOT/herdr/shims/hermes-agent" "$REPO_ROOT/herdr/shims/claude-code"
+ln -sf "$REPO_ROOT/herdr/shims/hermes-agent" "$HOME/.local/bin/hermes-agent"
+ln -sf "$REPO_ROOT/herdr/shims/claude-code" "$HOME/.local/bin/claude-code"
+ln -sf /usr/bin/ssh "$HOME/.local/libexec/hermes-agent"
+ln -sf /usr/bin/ssh "$HOME/.local/libexec/claude-code"
+echo "herdr agent shims installed: wrappers in ~/.local/bin, ssh aliases in ~/.local/libexec"

--- a/herdr/shims/claude-code
+++ b/herdr/shims/claude-code
@@ -1,0 +1,19 @@
+#!/bin/bash
+# herdr remote-agent shim with auto-reconnect (installed by helpers/install_herdr_agents.sh
+# as ~/.local/bin/claude-code; herdr pane command invokes it by this name).
+#
+# The inner alias ~/.local/libexec/claude-code -> /usr/bin/ssh preserves the process
+# name herdr's detection manifest matches — the wrapper itself is NOT the detected
+# process, its ssh child is.
+#
+# Loop semantics: a clean detach (ssh exit 0) closes the pane; any failure — network
+# drop, Mac sleep, VPS reboot — retries forever. See the hermes-agent twin for the
+# full rationale.
+ALIAS="$HOME/.local/libexec/claude-code"
+while true; do
+  "$ALIAS" -o ConnectTimeout=15 "$@"
+  code=$?
+  [ "$code" -eq 0 ] && exit 0
+  printf '\n[claude-code] connection lost (ssh exit %s) — retrying in 10s\n' "$code"
+  sleep 10
+done

--- a/herdr/shims/hermes-agent
+++ b/herdr/shims/hermes-agent
@@ -1,0 +1,21 @@
+#!/bin/bash
+# herdr remote-agent shim with auto-reconnect (installed by helpers/install_herdr_agents.sh
+# as ~/.local/bin/hermes-agent; herdr pane command invokes it by this name).
+#
+# The inner alias ~/.local/libexec/hermes-agent -> /usr/bin/ssh preserves the process
+# name herdr's detection manifest matches — the wrapper itself is NOT the detected
+# process, its ssh child is.
+#
+# Loop semantics: a clean detach (ssh exit 0) closes the pane; any failure — network
+# drop, Mac sleep, VPS reboot — retries forever. This is what keeps the atlas/axiom
+# workspaces alive across nights: the pane process never exits on connection loss, so
+# herdr never closes the single-pane workspace (and the #2966 restore boot-race heals
+# itself, since a restore-time ssh failure just retries once the network is up).
+ALIAS="$HOME/.local/libexec/hermes-agent"
+while true; do
+  "$ALIAS" -o ConnectTimeout=15 "$@"
+  code=$?
+  [ "$code" -eq 0 ] && exit 0
+  printf '\n[hermes-agent] connection lost (ssh exit %s) — retrying in 10s\n' "$code"
+  sleep 10
+done


### PR DESCRIPTION
Atlas and axiom vanished overnight: both ssh panes died on sleep (exit
255, 00:48), and herdr closes a single-pane workspace when its only pane
process exits. Fix at the pane layer — each shim in ~/.local/bin is now a
repo-tracked wrapper (herdr/shims/) that loops ssh via a same-named raw
alias in ~/.local/libexec (preserving the process name herdr's detection
manifests match), retrying every 10s on nonzero exit and closing only on
clean detach. Live-tested: detection survives the wrapper (hermes/claude
both register), and a killed ssh respawns in ~10s with workspace, agent
name, and rename all intact. The #2966 restore boot-race self-heals too,
since a restore-time ssh failure now retries instead of degrading.

Client keepalives back it up (machine-local ~/.ssh/config: Interval 60,
CountMax 120 — the old implicit CountMax 3 was the overnight killer).

Also documents the second local agent on the melos template: sites ✦ —
Claude Code in ~/Projects/sites, an umbrella of symlinks covering the
Vercel-hosted personal sites (davidandbrittanie.com, davidv.sh,
villavicencio.dev pending a repo), one agent, one vault, per-site repos
and Vercel projects unchanged.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Qmr2g3oNNUE1FUiiqdhj62


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic reconnection for remote agent sessions after sleep, network interruptions, or other transient connection failures.
  * Remote sessions retry every 10 seconds and close only after a clean detach.
  * Added support for separate local workspaces and preserved remote process names.
* **Documentation**
  * Updated setup and usage guidance for remote agents, reconnect behavior, SSH aliases, and workspace configuration.
* **Improvements**
  * Installer now deploys and links the reconnecting agent commands and their SSH connections automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->