### PR TITLE
chore(iterm): drop the Claude-Code dock-bounce trigger

### DIFF
--- a/iterm/profile-dynamic.json
+++ b/iterm/profile-dynamic.json
@@ -288,18 +288,6 @@
       "Terminal Type": "xterm-256color",
       "Thin Strokes": 4,
       "Transparency": 0.0,
-      "Triggers": [
-        {
-          "action": "BounceTrigger",
-          "contentregex": "",
-          "disabled": 0,
-          "matchType": 0,
-          "name": "Claude Code Needs Input",
-          "parameter": "",
-          "partial": true,
-          "regex": "Do you want to proceed"
-        }
-      ],
       "Unicode Normalization": 0,
       "Unicode Version": 9,
       "Unlimited Scrollback": false,


### PR DESCRIPTION
iTerm evaluates profile triggers against every output line; under herdr's
full-screen repaint volume this single regex tripped iTerm's slow-triggers
warning. The trigger only ever fired inside the TUI, and that job is
covered twice over now — the tmux-attention glyph (PermissionRequest hook)
and herdr's blocked-state toasts — so it's redundant, not just slow.
Dynamic profile is symlinked, so the removal is live on save.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Qmr2g3oNNUE1FUiiqdhj62


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the terminal bounce animation that occurred when Claude Code requested input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->