### PR TITLE
feat(herdr): fleet-wide "a pane never self-closes" + admin role

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,7 +240,10 @@ install via Homebrew casks in `brew/Brewfile`, not a helper.)
   are repo-tracked auto-reconnect wrappers (`herdr/shims/`) seeded by
   `helpers/install_herdr_agents.sh` (darwin.yaml); each execs a same-named raw ssh
   alias in `~/.local/libexec/` (preserving the detected process name) in a retry
-  loop, so remote panes survive sleep/network loss and only close on clean detach.
+  loop, so remote panes survive sleep/network loss and — the fleet "a pane never
+  self-closes" rule — drop to an interactive shell on clean detach rather than
+  closing. Local agents get the same rule via the pane template
+  `["/bin/zsh", "-l", "-c", "claude; exec /bin/zsh -il"]`.
   Local project agents (e.g. the `melos ♪` workspace, Claude Code in
   `~/Projects/melos`) need no shim — herdr detects a local claude pane natively;
   their declarative pane command is `["/bin/zsh", "-l", "-c", "exec claude"]` so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,23 +317,28 @@ conversations across server restarts via `claude --resume <id>`.
   the TUIs' OSC titles drive herdr states through the nested tmux. Never
   restart `hermes-tmux.service` casually — it drops Atlas's in-memory history
   (see ~/Projects/agents docs for Hermes rules).
-- **Local agent workspace (`melos ♪`, added 2026-08-18):** Claude Code running
-  in `~/Projects/melos` (the Spotify curator agent) as a declarative pane —
-  command `["/bin/zsh", "-l", "-c", "exec claude"]`, cwd `~/Projects/melos`.
-  No ssh shim: herdr's claude integration detects it natively and
-  resume-on-restore carries the conversation across server restarts. The
-  login-zsh wrapper is deliberate — the server spawns pane commands with its
-  bare launchd env, and `-l` rebuilds PATH from `zshenv` so both `claude`
-  itself and its subshells resolve tools. Agent renamed `melos`
-  (`herdr agent rename`); renames don't survive pane recreation — reapply
-  after a degraded restore, along with `layout.apply` if the command was
-  dropped (#2966). Jump key: `prefix+m`. Use this pane-command shape as the
-  template for future local project agents. Second local agent on the same
-  template: `sites ✦` (added 2026-08-19) — Claude Code in `~/Projects/sites`,
-  an umbrella dir of symlinks to the personal-website repos
-  (davidandbrittanie.com, davidv.sh, villavicencio.dev pending a repo); one
-  agent covers all the Vercel-hosted personal sites, each still its own git
-  repo and Vercel project (conventions in that dir's CLAUDE.md).
+- **Local agent pane template (fleet standard, revised 2026-08-19):** a local
+  Claude Code agent runs as a declarative pane with command
+  `["/bin/zsh", "-l", "-c", "claude; exec /bin/zsh -il"]` and its project dir as
+  cwd. Two deliberate parts: the **login zsh** (`-l`) rebuilds PATH from `zshenv`
+  because the herdr server spawns pane commands with its bare launchd env (so
+  both `claude` and its subshells resolve tools); the **`; exec /bin/zsh -il`
+  fallback** is the fleet's "a pane never self-closes" rule — when claude exits
+  (a stray `/exit`, a crash), the pane drops to an interactive shell instead of
+  vanishing and closing its tab. Type `claude` to relaunch. No ssh shim for local
+  agents — herdr's claude integration detects them natively and resume-on-restore
+  carries the conversation across server restarts. Rename with `herdr agent
+  rename`; renames don't survive pane recreation — reapply after a degraded
+  restore, along with `layout.apply` if the command was dropped (#2966). The same
+  never-self-close rule is baked into the remote shim wrappers (`herdr/shims/`),
+  so it holds fleet-wide. **When building any new agent, use this template and
+  route the change through the standard flow** (see the global CLAUDE.md
+  "Herdr fleet & agent building").
+  - Current local agents on this template: `melos ♪` (`~/Projects/melos`, Spotify
+    curator, jump `prefix+m`) and `sites ✦` (`~/Projects/sites`, umbrella of
+    symlinks to the personal-website repos — davidandbrittanie.com, davidv.sh
+    serving villavicencio.dev, ibmcconstruction.com; conventions in that dir's
+    CLAUDE.md). Each site stays its own git repo and Vercel project.
 - **`[[keys.command]]` `type = "shell"` commands run with the server's bare
   launchd environment** — no `/opt/homebrew/bin` on PATH, so a command like
   `herdr agent focus atlas` dies silently on command-not-found (detached

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -132,6 +132,27 @@ it's discovered** — not deferred to `HANDOFF.md`. `dv:handoff` overwrites HAND
 handoff itself drifts from reality between writes. If you find yourself writing "the rule we
 established this session" into HANDOFF, stop and also land it in the durable doc.
 
+## Herdr fleet & agent building
+
+The **herdr agent fleet is administered consistently, not per-project-freelance** (David's
+standing designation, 2026-08-19). Whenever work touches the fleet — creating a new agent
+workspace, changing a pane command, adding/renaming an agent, editing the shims or jump
+keys — follow the one documented flow in the **dotfiles project CLAUDE.md "Herdr" section**
+rather than improvising a different shape in whatever project you're in:
+
+- **New agents use the fleet pane template** — local: `["/bin/zsh", "-l", "-c", "claude;
+  exec /bin/zsh -il"]` (login shell rebuilds PATH from the bare launchd env; the trailing
+  `exec zsh` is the "a pane never self-closes on `/exit`/crash" rule). Remote surfaces use
+  the repo-tracked auto-reconnect shims in `dotfiles/herdr/shims/`.
+- **Config, shims, and the helper are dotfiles-tracked** — herdr changes ride a dotfiles
+  branch/PR (config.toml is symlinked and writes back), never an ad-hoc edit to
+  `~/.config/herdr/`.
+- **New local project agent → also do the standard bootstrap**: per-agent Obsidian vault
+  (see the vault section above), a project CLAUDE.md, and a jump key.
+- The canonical, detailed procedure — pane templates, the launchd-PATH rule, the socket
+  NDJSON API, rename-on-recreate, restore boot-race — lives in dotfiles, not here; this is
+  the pointer that keeps every project routing through it.
+
 ## Research
 
 When you hit a wall — unfamiliar tool, unknown API, missing docs — always perform a web search

--- a/herdr/shims/claude-code
+++ b/herdr/shims/claude-code
@@ -6,14 +6,17 @@
 # name herdr's detection manifest matches — the wrapper itself is NOT the detected
 # process, its ssh child is.
 #
-# Loop semantics: a clean detach (ssh exit 0) closes the pane; any failure — network
-# drop, Mac sleep, VPS reboot — retries forever. See the hermes-agent twin for the
-# full rationale.
+# Loop semantics (fleet rule: an agent pane never self-closes): any failure — network
+# drop, Mac sleep, VPS reboot — retries forever; a clean detach (ssh exit 0) drops to
+# an interactive shell instead of closing. See the hermes-agent twin for the full
+# rationale.
 ALIAS="$HOME/.local/libexec/claude-code"
 while true; do
   "$ALIAS" -o ConnectTimeout=15 "$@"
   code=$?
-  [ "$code" -eq 0 ] && exit 0
+  [ "$code" -eq 0 ] && break
   printf '\n[claude-code] connection lost (ssh exit %s) — retrying in 10s\n' "$code"
   sleep 10
 done
+printf '\n[claude-code] detached cleanly — shell fallback (re-run the attach, or exit to close this pane)\n'
+exec /bin/zsh -il

--- a/herdr/shims/hermes-agent
+++ b/herdr/shims/hermes-agent
@@ -6,16 +6,19 @@
 # name herdr's detection manifest matches — the wrapper itself is NOT the detected
 # process, its ssh child is.
 #
-# Loop semantics: a clean detach (ssh exit 0) closes the pane; any failure — network
-# drop, Mac sleep, VPS reboot — retries forever. This is what keeps the atlas/axiom
-# workspaces alive across nights: the pane process never exits on connection loss, so
-# herdr never closes the single-pane workspace (and the #2966 restore boot-race heals
-# itself, since a restore-time ssh failure just retries once the network is up).
+# Loop semantics (fleet rule: an agent pane never self-closes): any failure — network
+# drop, Mac sleep, VPS reboot — retries forever; a clean detach (ssh exit 0) drops to
+# an interactive shell instead of closing, so the pane/workspace survives every normal
+# exit path. This keeps the atlas/axiom workspaces alive across nights (the pane
+# process never exits) and the #2966 restore boot-race heals itself, since a
+# restore-time ssh failure just retries once the network is up.
 ALIAS="$HOME/.local/libexec/hermes-agent"
 while true; do
   "$ALIAS" -o ConnectTimeout=15 "$@"
   code=$?
-  [ "$code" -eq 0 ] && exit 0
+  [ "$code" -eq 0 ] && break
   printf '\n[hermes-agent] connection lost (ssh exit %s) — retrying in 10s\n' "$code"
   sleep 10
 done
+printf '\n[hermes-agent] detached cleanly — shell fallback (re-run the attach, or exit to close this pane)\n'
+exec /bin/zsh -il


### PR DESCRIPTION
A stray /exit killed the sites hub tab because `exec claude` makes the
pane *be* claude. Make non-vanishing the uniform fleet rule:

- Local agent template is now ["/bin/zsh","-l","-c","claude; exec /bin/zsh -il"]
  — when claude exits (/exit or crash) the pane drops to a login shell in
  the project dir instead of closing its tab. Type `claude` to relaunch.
- Remote shim wrappers (herdr/shims/) now `break` + `exec /bin/zsh -il` on
  clean detach (ssh exit 0) instead of exiting, so the workspace survives a
  detach the same way it survives connection loss.
- Applied live: melos, atlas, axiom, sites-hub all rebuilt on the new shape
  (remote sessions persist on the VPS; local ones reload fresh — melos also
  picks up its new muse persona). dotfiles pane (this session) unchanged;
  it inherits the shape on next recreation.
- Global CLAUDE.md gains a "Herdr fleet & agent building" section: fleet
  admin and new-agent creation route through the one documented dotfiles
  flow (pane template, tracked shims, branch/PR, vault bootstrap) rather
  than per-project freelancing.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Qmr2g3oNNUE1FUiiqdhj62


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote and local agent panes now remain open in an interactive shell after a clean detach or agent exit.
  * Connection failures continue retrying automatically with periodic diagnostics.

* **Documentation**
  * Updated guidance for pane behavior, local agent setup, fleet administration, and agent-building procedures.
  * Clarified that the pane-preservation template applies to current and future local agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->