### PR TITLE
chore: migrate issue tracking from GitHub Projects to Linear

### DIFF
--- a/.claude/commands/ticket.md
+++ b/.claude/commands/ticket.md
@@ -1,17 +1,31 @@
-# /ticket — Create a GitHub Issue on the Dotfiles Kanban Board
+# /ticket — Create a Linear Issue in the Dotfiles Project
 
-Use this command to capture bugs, improvements, cross-machine issues, or refactoring tasks as properly structured GitHub issues and add them to the project board.
+Use this command to capture bugs, improvements, cross-machine issues, or refactoring tasks as properly structured Linear issues in the Dotfiles project.
 
-## Repo & Board
-- **Repo:** `villavicencio/dotfiles`
-- **Board:** https://github.com/users/villavicencio/projects/2
-- **Project ID:** `PVT_kwHOAA0r6c4BRdxZ`
+## Workspace & Project
+- **Workspace:** Villavicencio — https://linear.app/villavicencio
+- **Team:** `Villavicencio` (key `VIL`)
+- **Project:** `Dotfiles` — https://linear.app/villavicencio/project/dotfiles-74974922348e
+- Issue tracking migrated here from the GitHub Projects board on 2026-08-20; the old
+  board (https://github.com/users/villavicencio/projects/2) is closed history only —
+  never create new GitHub issues.
+
+## Tooling
+The Linear MCP tools are deferred — load what you need in ONE ToolSearch call before
+creating anything:
+
+```
+ToolSearch("select:mcp__linear__save_issue,mcp__linear__list_issue_labels")
+```
 
 ## Labels Available
+Workspace defaults plus repo-specific area labels:
+
 | Label | Use for |
 |-------|---------|
-| `bug` | Something broken, incorrect behavior, or errors on shell startup |
-| `enhancement` | New feature, alias, function, or tool integration |
+| `Bug` | Something broken, incorrect behavior, or errors on shell startup |
+| `Feature` | New feature, alias, function, or tool integration |
+| `Improvement` | Refinement of something that already works |
 | `zsh` | Zsh shell config (zshrc, zshenv, aliases, functions, options) |
 | `brew` | Homebrew packages, casks, or Brewfile changes |
 | `git-config` | Git configuration (gitconfig, gitignore, gitattributes) |
@@ -26,7 +40,7 @@ Use this command to capture bugs, improvements, cross-machine issues, or refacto
 ### Step 1 — Understand the request
 Read the user's description carefully. Identify:
 - Which config files are affected
-- Whether this is a bug, enhancement, or cleanup
+- Whether this is a bug, feature, or cleanup
 - Whether it affects one or both machines (personal/work)
 
 ### Step 2 — Compose the issue
@@ -35,7 +49,7 @@ Write a well-structured issue with:
 ```
 Title: [Short, action-oriented. Start with a verb. E.g. "Fix duplicate PATH entries in zshenv"]
 
-Body:
+Description:
 ## Context
 [What prompted this. Reference the specific file, line, or shell behavior.]
 
@@ -50,39 +64,22 @@ Body:
 ```
 
 ### Step 3 — Pick labels
-Choose 1-3 labels from the table above. When in doubt: `zsh` for shell config, `cross-machine` if it affects work Mac parity, `cleanup` for dead code removal.
+Choose 1-3 labels from the table above. When in doubt: `zsh` for shell config,
+`cross-machine` if it affects work Mac parity, `cleanup` for dead code removal.
 
 ### Step 4 — Create the issue
-```bash
-ISSUE_URL=$(gh issue create \
-  --repo villavicencio/dotfiles \
-  --title "<title>" \
-  --label "<label1>,<label2>" \
-  --body "<body>")
+Call `mcp__linear__save_issue` (no `id` — that would be an update):
 
-echo "Created: $ISSUE_URL"
-```
+- `team`: `"Villavicencio"`
+- `project`: `"Dotfiles"`
+- `state`: `"Todo"` (actionable now) or `"Backlog"` (someday/needs decision)
+- `title` / `description`: from Step 2 — pass real newlines in markdown, not `\n` escapes
+- `labels`: from Step 3, e.g. `["Bug", "zsh"]`
 
-### Step 5 — Add to the Kanban board
-Get the issue node ID and add it to the project:
-```bash
-ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -o '[0-9]*$')
-ISSUE_ID=$(gh api repos/villavicencio/dotfiles/issues/$ISSUE_NUMBER --jq '.node_id')
-
-gh api graphql -f query='
-mutation($projectId: ID!, $contentId: ID!) {
-  addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
-    item { id }
-  }
-}' -f projectId="PVT_kwHOAA0r6c4BRdxZ" -f contentId="$ISSUE_ID"
-
-echo "Added to board"
-```
-
-### Step 6 — Confirm
+### Step 5 — Confirm
 Reply with:
-- Issue title
-- Issue URL
+- Issue identifier (e.g. `VIL-12`) and title
+- Issue URL (from the save_issue result)
 - Labels applied
 - One-line summary of what was captured
 
@@ -90,5 +87,6 @@ Reply with:
 - One issue per distinct problem — don't bundle unrelated fixes
 - Reference file paths relative to repo root: `zsh/zshenv`, `zsh/zshrc`, `helpers/install_node.sh`
 - Note which machine(s) are affected when relevant (personal, work, or both)
-- If the fix is obvious and small (< 5 min), note it in the body so the next session can blitz through it
+- If the fix is obvious and small (< 5 min), note it in the description so the next session can blitz through it
 - Use `$HOME` not `/Users/<user>/` and `$BREW_PREFIX` not `/opt/homebrew/` per CLAUDE.md conventions
+- When resolving a ticket, set its state to `Done` via `save_issue` (id + `state: "Done"`) as part of the merge workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,14 +183,17 @@ Work on a **feature branch and merge via PR** — the default for this repo, not
 tickets. Avoid committing directly to `master`.
 - **Branch per change**, named by type: `feat/…`, `fix/…`, `chore/…`, `docs/…`, `style/…`.
 - **One PR per logical change**; push and open with `gh pr create`. Keep `master` green.
-- **Merge, then clean up**: delete the branch, close any linked issue (`gh issue close`).
+- **Merge, then clean up**: delete the branch, mark any linked Linear issue `Done`.
 - **Trivial exceptions** (typo, one-line doc tweak) may go straight to `master`.
 - **Docs-only PRs report "no checks reported"** — `install-matrix.yml` sets
   `paths-ignore: ['docs/**', '**.md', 'claude/**/*.md']`, so a markdown-only change never
   triggers the matrix. Merge on `mergeStateStatus: CLEAN`; don't wait for a run that
   will never start.
 
-Project board: https://github.com/users/villavicencio/projects/2
+Issue tracking: Linear, project `Dotfiles`, team `Villavicencio` (key `VIL`) —
+https://linear.app/villavicencio/project/dotfiles-74974922348e (migrated off the
+GitHub Projects board 2026-08-20; the board and closed GitHub issues are read-only
+history — never create new GitHub issues).
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -459,8 +459,16 @@ find "$FAKE" -mindepth 1 | wc -l   # must be 0 (Library/Caches/com.apple.python 
 rm -rf "$FAKE"
 ```
 
-### Project board
-GitHub Project board: https://github.com/users/villavicencio/projects/2
+### Issue tracking — Linear
+Issues live in **Linear**, project `Dotfiles`, team `Villavicencio` (key `VIL`):
+https://linear.app/villavicencio/project/dotfiles-74974922348e
+
+Migrated off the GitHub Projects board on 2026-08-20 with zero open issues — the old
+board (https://github.com/users/villavicencio/projects/2) and the repo's 44 closed
+GitHub issues remain as read-only history. **Never create new GitHub issues**; use
+`/ticket` (which drives `mcp__linear__save_issue`) or the Linear UI. The Linear MCP
+server is configured globally in `~/.claude.json` (machine-local — the work Mac needs
+its own `/mcp` add + auth); its tools are deferred, so load them via ToolSearch first.
 
 ### Branching & pull requests
 Work on a **feature branch and merge via pull request** — this is the default for
@@ -471,8 +479,9 @@ this repo, not just ticket work. Avoid committing directly to `master`.
   `style/…` (e.g. `feat/statusline-slider-bars`).
 - **One PR per logical change.** Push the branch and open a PR with `gh pr create`;
   let the PR carry the review surface. Keep `master` always-green.
-- **Merge, then clean up.** After merge, delete the branch and close any linked
-  issue (`gh issue close`) as part of the workflow.
+- **Merge, then clean up.** After merge, delete the branch and mark any linked
+  Linear issue `Done` (`mcp__linear__save_issue` with the issue id + `state: "Done"`)
+  as part of the workflow.
 - **Trivial exceptions** (typo fixes, a one-line doc tweak) may go straight to
   `master` at the author's discretion — the rule targets behavior and config
   changes, where review and a clean history matter.

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -153,6 +153,23 @@ rather than improvising a different shape in whatever project you're in:
   NDJSON API, rename-on-recreate, restore boot-race — lives in dotfiles, not here; this is
   the pointer that keeps every project routing through it.
 
+## Linear — issue tracking
+
+**Linear is the issue tracker** (workspace `Villavicencio`, https://linear.app/villavicencio,
+single team `Villavicencio`, key `VIL`), for both personal tasks and per-project work — one
+Linear *project* per repo/area as needed. The MCP server is configured globally as `linear`
+in the root `mcpServers` of `~/.claude.json` (added 2026-08-20; machine-local, so the work
+Mac needs its own `/mcp` add + auth). Its `mcp__linear__*` tools are deferred — load via
+ToolSearch (e.g. `select:mcp__linear__save_issue,mcp__linear__list_issues`).
+
+- **Dotfiles issue tracking lives in the Linear project `Dotfiles`** —
+  migrated off the GitHub Projects board 2026-08-20. Do not create new GitHub issues for
+  repos whose tracking has moved to Linear; the old board and closed GH issues are
+  read-only history.
+- `save_issue`/`save_project` create *or* update (pass `id` to update); mark linked issues
+  `Done` at merge time as part of the branch→PR→merge cleanup.
+- Pass real newlines in markdown content, never literal `\n` escape sequences.
+
 ## Research
 
 When you hit a wall — unfamiliar tool, unknown API, missing docs — always perform a web search


### PR DESCRIPTION
## Summary
- Issue tracking moves from the GitHub Projects board (https://github.com/users/villavicencio/projects/2) to **Linear** — workspace `Villavicencio` (team key `VIL`), project [`Dotfiles`](https://linear.app/villavicencio/project/dotfiles-74974922348e).
- Workflow repoint, not a data migration: the board had **zero open issues** at cutover (44 closed). The board and closed GH issues stay as read-only history; no new GitHub issues from here on.
- `/ticket` rewritten to create Linear issues via `mcp__linear__save_issue` (team + project + labels + Todo/Backlog state) instead of `gh issue create` + board GraphQL.
- `CLAUDE.md` / `AGENTS.md`: board section → Linear coordinates; merge cleanup now marks the linked Linear issue `Done` instead of `gh issue close`.
- Global `claude/CLAUDE.md`: new "Linear — issue tracking" section — MCP server is global in `~/.claude.json` but machine-local (work Mac needs its own `/mcp` add + auth); tools are deferred, load via ToolSearch.

## Linear-side setup (already live, not in this diff)
- Project `Dotfiles` created with links back to the repo and retired board.
- Area labels recreated as workspace labels: `zsh`, `brew`, `git-config`, `cross-machine`, `performance`, `cleanup`, `nvim`, `tmux` (defaults `Bug`/`Feature`/`Improvement` cover the old `bug`/`enhancement`).

Docs-only change — no CI expected (`paths-ignore`); merge on `mergeStateStatus: CLEAN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qmr2g3oNNUE1FUiiqdhj62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated issue-tracking guidance to use Linear instead of GitHub Issues and project boards.
  * `/ticket` now creates and confirms Linear feature issues in the Dotfiles project.
  * Updated branching, pull-request, and post-merge instructions to link work and mark completed Linear issues as Done.
  * Documented the migration status and clarified that the former GitHub project is retained as read-only history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->