### PR TITLE
docs: Linear is personal-Mac only — work Mac uses other tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -468,8 +468,9 @@ board (https://github.com/users/villavicencio/projects/2) and the repo's 44 clos
 GitHub issues remain as read-only history. **Never create new GitHub issues**; use
 `/ticket` (which drives `mcp__linear__save_issue`) or the Linear UI. The Linear MCP
 server is configured globally in `~/.claude.json` (machine-local; personal Mac only —
-the work Mac deliberately does not use Linear, work tracking lives in other tools);
-its tools are deferred, so load them via ToolSearch first.
+the work Mac deliberately does not use Linear MCP, work tracking lives in other tools);
+its tools are deferred, so load them via ToolSearch first. On the work Mac, `/ticket`'s
+MCP path is unavailable — capture dotfiles tickets via the Linear web UI instead.
 
 ### Branching & pull requests
 Work on a **feature branch and merge via pull request** — this is the default for

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -467,8 +467,9 @@ Migrated off the GitHub Projects board on 2026-08-20 with zero open issues — t
 board (https://github.com/users/villavicencio/projects/2) and the repo's 44 closed
 GitHub issues remain as read-only history. **Never create new GitHub issues**; use
 `/ticket` (which drives `mcp__linear__save_issue`) or the Linear UI. The Linear MCP
-server is configured globally in `~/.claude.json` (machine-local — the work Mac needs
-its own `/mcp` add + auth); its tools are deferred, so load them via ToolSearch first.
+server is configured globally in `~/.claude.json` (machine-local; personal Mac only —
+the work Mac deliberately does not use Linear, work tracking lives in other tools);
+its tools are deferred, so load them via ToolSearch first.
 
 ### Branching & pull requests
 Work on a **feature branch and merge via pull request** — this is the default for

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -160,7 +160,8 @@ single team `Villavicencio`, key `VIL`), for both personal tasks and per-project
 Linear *project* per repo/area as needed. The MCP server is configured globally as `linear`
 in the root `mcpServers` of `~/.claude.json` (added 2026-08-20; machine-local). **Personal
 Mac only — the work Mac deliberately does not use Linear** (work tracking lives in other
-tools; David, 2026-08-20 — do not set it up there). Its `mcp__linear__*` tools are deferred — load via
+tools; David, 2026-08-20 — do not set it up there; personal-project tickets from the work
+Mac go through the Linear web UI). Its `mcp__linear__*` tools are deferred — load via
 ToolSearch (e.g. `select:mcp__linear__save_issue,mcp__linear__list_issues`).
 
 - **Dotfiles issue tracking lives in the Linear project `Dotfiles`** —

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -158,8 +158,9 @@ rather than improvising a different shape in whatever project you're in:
 **Linear is the issue tracker** (workspace `Villavicencio`, https://linear.app/villavicencio,
 single team `Villavicencio`, key `VIL`), for both personal tasks and per-project work — one
 Linear *project* per repo/area as needed. The MCP server is configured globally as `linear`
-in the root `mcpServers` of `~/.claude.json` (added 2026-08-20; machine-local, so the work
-Mac needs its own `/mcp` add + auth). Its `mcp__linear__*` tools are deferred — load via
+in the root `mcpServers` of `~/.claude.json` (added 2026-08-20; machine-local). **Personal
+Mac only — the work Mac deliberately does not use Linear** (work tracking lives in other
+tools; David, 2026-08-20 — do not set it up there). Its `mcp__linear__*` tools are deferred — load via
 ToolSearch (e.g. `select:mcp__linear__save_issue,mcp__linear__list_issues`).
 
 - **Dotfiles issue tracking lives in the Linear project `Dotfiles`** —


### PR DESCRIPTION
Corrects #155's note that the work Mac "needs its own /mcp add + auth" — David confirmed the work Mac deliberately won't use Linear (work tracking lives in other tools). Global claude/CLAUDE.md + repo CLAUDE.md updated so no future work-Mac session treats Linear setup as a to-do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qmr2g3oNNUE1FUiiqdhj62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Linear integration is available only on the personal Mac.
  * Documented that dotfiles tickets created from the work Mac should be captured through the Linear web interface.
  * Added guidance that deferred tools still require ToolSearch before use.
  * Clarified that the `/ticket` workflow cannot use Linear integration from the work Mac.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->