### PR TITLE
feat(herdr): borealis joins the fleet — sixth agent, out of Forge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,10 +247,9 @@ install via Homebrew casks in `brew/Brewfile`, not a helper.)
   self-closes" rule — drop to an interactive shell on clean detach rather than
   closing. Local agents get the same rule via the pane template
   `["/bin/zsh", "-l", "-c", "claude; exec /bin/zsh -il"]`.
-  Local project agents (e.g. the `melos ♪` workspace, Claude Code in
-  `~/Projects/melos`) need no shim — herdr detects a local claude pane natively;
-  their declarative pane command is `["/bin/zsh", "-l", "-c", "exec claude"]` so
-  the login shell rebuilds PATH from `zshenv` before claude starts (the server
+  Local project agents (`melos ♪`, `sites ✦`, `borealis ❆`) need no shim — herdr
+  detects a local claude pane natively; they use the pane template above, whose
+  login shell rebuilds PATH from `zshenv` before claude starts (the server
   spawns pane commands with its bare launchd env).
 - **`otty/` is copy-seeded, never symlinked — do not add a `link:` entry for it.**
   `otty config set` and the Settings UI write via temp-file + `rename(2)`, which replaces

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,10 +335,14 @@ conversations across server restarts via `claude --resume <id>`.
   route the change through the standard flow** (see the global CLAUDE.md
   "Herdr fleet & agent building").
   - Current local agents on this template: `melos ♪` (`~/Projects/melos`, Spotify
-    curator, jump `prefix+m`) and `sites ✦` (`~/Projects/sites`, umbrella of
+    curator, jump `prefix+m`), `sites ✦` (`~/Projects/sites`, umbrella of
     symlinks to the personal-website repos — davidandbrittanie.com, davidv.sh
     serving villavicencio.dev, ibmcconstruction.com; conventions in that dir's
-    CLAUDE.md). Each site stays its own git repo and Vercel project.
+    CLAUDE.md; each site stays its own git repo and Vercel project), and
+    `borealis ❆` (`~/Projects/borealis`, native SwiftUI prompt-library app, jump
+    `prefix+shift+b` — plain `prefix+b` is toggle_sidebar; migrated out of
+    `~/.forge-projects/` 2026-08-20, the unused Forge web scaffold still rides in
+    the repo).
 - **`[[keys.command]]` `type = "shell"` commands run with the server's bare
   launchd environment** — no `/opt/homebrew/bin` on PATH, so a command like
   `herdr agent focus atlas` dies silently on command-not-found (detached

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -145,6 +145,13 @@ type = "shell"
 command = "/opt/homebrew/bin/herdr agent focus melos"
 description = "jump to Melos"
 
+[[keys.command]]
+# prefix+b is toggle_sidebar's default binding, so Borealis takes shift+b.
+key = "prefix+shift+b"
+type = "shell"
+command = "/opt/homebrew/bin/herdr agent focus borealis"
+description = "jump to Borealis"
+
 # Legacy indexed shortcut config is still parsed for compatibility.
 # Prefer switch_tab, switch_workspace, and focus_agent for new configs.
 # [keys.indexed]


### PR DESCRIPTION
## Summary
- **Borealis** (native SwiftUI prompt-library app) migrated out of Forge: `~/.forge-projects/borealis` → `~/Projects/borealis`, with the standard fleet bootstrap — herdr workspace `borealis ❆` on the fleet pane template, agent renamed, harness memory symlinked for the new project slug (vault `~/Obsidian/borealis` already existed).
- New jump key `prefix+shift+b` (`herdr/config.toml`) — plain `prefix+b` is `toggle_sidebar`'s default binding. Hot-reloaded and applied.
- Fleet roster updated in CLAUDE.md; AGENTS.md's stale `exec claude` pane-command description reconciled with the post-#153 template.

## Done outside this diff (live)
- Directory moved; new-slug memory symlink created; borealis repo HANDOFF.md path-fixed (local ff-merge, no remote); vault memory updated; Linear "Borealis V1.0" project description repointed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qmr2g3oNNUE1FUiiqdhj62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Borealis project to the local agent list, including its directory, purpose, and keyboard shortcut.
  * Added a keyboard shortcut to quickly focus the Borealis agent.
  * Improved guidance for working with local agents and interactive shells.
  * Clarified conventions for independently managed site projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->