### PR TITLE
feat(herdr): fleet expansion — argus, skills, obscura, eidos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,9 +247,10 @@ install via Homebrew casks in `brew/Brewfile`, not a helper.)
   self-closes" rule — drop to an interactive shell on clean detach rather than
   closing. Local agents get the same rule via the pane template
   `["/bin/zsh", "-l", "-c", "claude; exec /bin/zsh -il"]`.
-  Local project agents (`melos ♪`, `sites ✦`, `borealis ❆`) need no shim — herdr
-  detects a local claude pane natively; they use the pane template above, whose
-  login shell rebuilds PATH from `zshenv` before claude starts (the server
+  Local project agents (`melos ♪`, `sites ✦`, `borealis ❆`, `argus ◉`,
+  `skills ⚒`, `obscura ✇`, `eidos ❖` — roster table in CLAUDE.md) need no shim —
+  herdr detects a local claude pane natively; they use the pane template above,
+  whose login shell rebuilds PATH from `zshenv` before claude starts (the server
   spawns pane commands with its bare launchd env).
 - **`otty/` is copy-seeded, never symlinked — do not add a `link:` entry for it.**
   `otty config set` and the Settings UI write via temp-file + `rename(2)`, which replaces

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,15 +334,19 @@ conversations across server restarts via `claude --resume <id>`.
   so it holds fleet-wide. **When building any new agent, use this template and
   route the change through the standard flow** (see the global CLAUDE.md
   "Herdr fleet & agent building").
-  - Current local agents on this template: `melos ♪` (`~/Projects/melos`, Spotify
-    curator, jump `prefix+m`), `sites ✦` (`~/Projects/sites`, umbrella of
-    symlinks to the personal-website repos — davidandbrittanie.com, davidv.sh
-    serving villavicencio.dev, ibmcconstruction.com; conventions in that dir's
-    CLAUDE.md; each site stays its own git repo and Vercel project), and
-    `borealis ❆` (`~/Projects/borealis`, native SwiftUI prompt-library app, jump
-    `prefix+shift+b` — plain `prefix+b` is toggle_sidebar; migrated out of
-    `~/.forge-projects/` 2026-08-20, the unused Forge web scaffold still rides in
-    the repo).
+  - Current local agents on this template (jump keys are `[[keys.command]]`
+    entries in `herdr/config.toml`; shift-chords where the plain letter is taken
+    by a default binding or an earlier agent):
+
+    | Agent | Dir | Purpose | Jump |
+    |---|---|---|---|
+    | `melos ♪` | `~/Projects/melos` | Spotify curator | `prefix+m` |
+    | `sites ✦` | `~/Projects/sites` | umbrella of symlinks to the personal-website repos (davidandbrittanie.com, davidv.sh serving villavicencio.dev, ibmcconstruction.com); each site stays its own repo + Vercel project | — |
+    | `borealis ❆` | `~/Projects/borealis` | native SwiftUI prompt-library app (ex-Forge, migrated 2026-08-20) | `prefix+shift+b` |
+    | `argus ◉` | `~/Projects/agents` | Hermes/Atlas ops project (browse-gateway consumer `argus`) | `prefix+shift+a` |
+    | `skills ⚒` | `~/Projects/skills` | Claude Code skills workshop | `prefix+shift+s` |
+    | `obscura ✇` | `~/Projects/browse-gateway` | the Obscura browse-gateway itself | `prefix+shift+o` |
+    | `eidos ❖` | `~/Projects/eidos` | Eagle library curation | `prefix+shift+i` (`e`/`shift+e` are edit_scrollback / remove_worktree) |
 - **`[[keys.command]]` `type = "shell"` commands run with the server's bare
   launchd environment** — no `/opt/homebrew/bin` on PATH, so a command like
   `herdr agent focus atlas` dies silently on command-not-found (detached

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,6 +347,7 @@ conversations across server restarts via `claude --resume <id>`.
     | `skills ⚒` | `~/Projects/skills` | Claude Code skills workshop | `prefix+shift+s` |
     | `obscura ✇` | `~/Projects/browse-gateway` | the Obscura browse-gateway itself | `prefix+shift+o` |
     | `eidos ❖` | `~/Projects/eidos` | Eagle library curation | `prefix+shift+i` (`e`/`shift+e` are edit_scrollback / remove_worktree) |
+
 - **`[[keys.command]]` `type = "shell"` commands run with the server's bare
   launchd environment** — no `/opt/homebrew/bin` on PATH, so a command like
   `herdr agent focus atlas` dies silently on command-not-found (detached

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -152,6 +152,34 @@ type = "shell"
 command = "/opt/homebrew/bin/herdr agent focus borealis"
 description = "jump to Borealis"
 
+[[keys.command]]
+# plain a is the Atlas jump.
+key = "prefix+shift+a"
+type = "shell"
+command = "/opt/homebrew/bin/herdr agent focus argus"
+description = "jump to Argus"
+
+[[keys.command]]
+# plain s is the settings default.
+key = "prefix+shift+s"
+type = "shell"
+command = "/opt/homebrew/bin/herdr agent focus skills"
+description = "jump to Skills"
+
+[[keys.command]]
+# plain o is the open_notification_target default.
+key = "prefix+shift+o"
+type = "shell"
+command = "/opt/homebrew/bin/herdr agent focus obscura"
+description = "jump to Obscura"
+
+[[keys.command]]
+# e and shift+e are edit_scrollback / remove_worktree, so Eidos takes shift+i.
+key = "prefix+shift+i"
+type = "shell"
+command = "/opt/homebrew/bin/herdr agent focus eidos"
+description = "jump to Eidos"
+
 # Legacy indexed shortcut config is still parsed for compatibility.
 # Prefer switch_tab, switch_workspace, and focus_agent for new configs.
 # [keys.indexed]


### PR DESCRIPTION
## Summary
Four more local project agents join the fleet on the standard pane template (`claude; exec /bin/zsh -il`), migrated from standalone use:

| Agent | Dir | Jump |
|---|---|---|
| `argus ◉` | `~/Projects/agents` | `prefix+shift+a` (plain `a` = Atlas) |
| `skills ⚒` | `~/Projects/skills` | `prefix+shift+s` (plain `s` = settings) |
| `obscura ✇` | `~/Projects/browse-gateway` | `prefix+shift+o` (plain `o` = open_notification_target) |
| `eidos ❖` | `~/Projects/eidos` | `prefix+shift+i` (`e`/`shift+e` = edit_scrollback / remove_worktree) |

- CLAUDE.md roster converted to a table (seven local agents outgrew prose); AGENTS.md list extended.
- Standard bootstrap: agents/skills/browse-gateway already had vault + memory symlink + CLAUDE.md; **eidos** got the full bootstrap (vault stamped from template, slug memory symlink, Vault declaration ff-merged in its repo).
- Workspaces created live via `workspace create` + `layout.apply`, agents renamed, config hot-reloaded (no diagnostics) — fleet is now ten agents (1 dotfiles + 7 local + 2 remote).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qmr2g3oNNUE1FUiiqdhj62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts for quickly focusing the Argus, Skills, Obscura, and Eidos agents.
  * Added dedicated shortcuts using the configured prefix plus Shift+A, Shift+S, Shift+O, and Shift+I.

* **Documentation**
  * Updated local agent documentation with the complete roster, directory details, purposes, and shortcut bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->