### PR TITLE
feat(herdr): Forge-resident hybrid agents SOP + orrery joins the fleet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,10 +248,16 @@ install via Homebrew casks in `brew/Brewfile`, not a helper.)
   closing. Local agents get the same rule via the pane template
   `["/bin/zsh", "-l", "-c", "claude; exec /bin/zsh -il"]`.
   Local project agents (`melos ♪`, `sites ✦`, `borealis ❆`, `argus ◉`,
-  `skills ⚒`, `obscura ✇`, `eidos ❖` — roster table in CLAUDE.md) need no shim —
-  herdr detects a local claude pane natively; they use the pane template above,
-  whose login shell rebuilds PATH from `zshenv` before claude starts (the server
-  spawns pane commands with its bare launchd env).
+  `skills ⚒`, `obscura ✇`, `eidos ❖`, `orrery ☉` — roster table in CLAUDE.md)
+  need no shim — herdr detects a local claude pane natively; they use the pane
+  template above, whose login shell rebuilds PATH from `zshenv` before claude
+  starts (the server spawns pane commands with its bare launchd env).
+  `orrery ☉` is the **Forge-resident hybrid** pattern (full SOP in CLAUDE.md):
+  the project stays Forge-managed, the pane targets the physical
+  `~/.forge-projects/<codename>` path (herdr `chdir` resolves symlinks, so
+  identity always lands there), `~/Projects/<name>` is an ergonomics-only
+  symlink, and both harnesses share one project slug — shared vault memory and
+  `--resume` continuity across Forge ACP sessions and the pane.
 - **`otty/` is copy-seeded, never symlinked — do not add a `link:` entry for it.**
   `otty config set` and the Settings UI write via temp-file + `rename(2)`, which replaces
   the path and destroys a symlink on the first settings change; the CLI still exits 0 and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,7 +347,39 @@ conversations across server restarts via `claude --resume <id>`.
     | `skills ⚒` | `~/Projects/skills` | Claude Code skills workshop | `prefix+shift+s` |
     | `obscura ✇` | `~/Projects/browse-gateway` | the Obscura browse-gateway itself | `prefix+shift+o` |
     | `eidos ❖` | `~/Projects/eidos` | Eagle library curation | `prefix+shift+i` (`e`/`shift+e` are edit_scrollback / remove_worktree) |
+    | `orrery ☉` | `~/.forge-projects/tranquil-dune` (aka `~/Projects/orrery`) | Forge-resident jobs dashboard (orrery.ui8.dev) — see "Forge-resident hybrid agents" below | `prefix+y` (`o`/`shift+o` are open_notification_target / obscura; `y` as in orrer**y**) |
 
+- **Forge-resident hybrid agents** (SOP, established 2026-08-20 with `orrery ☉`).
+  For a project that legitimately *stays* in Forge — UI-heavy, actually using
+  Forge's stories canvas / dev server / publishing — but wants plain Claude Code
+  in herdr for non-UI lanes, herdr-ize it **in place**:
+  - **Pane cwd = the physical `~/.forge-projects/<codename>` path.** Herdr spawns
+    pane processes via `chdir`, and the kernel resolves symlinks there, so Claude
+    Code's project identity is always the physical path — pointing the pane at a
+    symlink buys nothing and hides the mechanism. Otherwise it's the standard
+    fleet pane template.
+  - **Add a convenience symlink `~/Projects/<name>` → the codename dir.** Pure
+    ergonomics: it gives the project its human name (Forge dirs carry codenames
+    like `tranquil-dune`) and keeps the one-projects-dir view complete. It does
+    not affect harness identity (see above).
+  - **One slug, two harnesses — that's the payoff.** Forge's embedded ACP
+    sessions and the herdr pane share the same project slug, so they share the
+    memory symlink → vault AND the transcript history: `--resume`/`--continue`
+    in the herdr pane lists the Forge sessions' conversations. Continuity is
+    free; don't "fix" the shared slug.
+  - **Standard bootstrap still applies — verify, don't redo.** The Forge
+    sessions have usually already done vault + CLAUDE.md Vault declaration +
+    memory symlink; the herdr-side additions are just workspace, rename, jump
+    key, roster row.
+  - **One working tree, one writer at a time.** Don't run the Forge ACP agent
+    and the herdr pane on overlapping edits — split lanes (UI in Forge, non-UI
+    in the pane) and let HANDOFF/vault memory carry the seam. Interactive-only
+    flows (MCP OAuth, `/mcp` auth) can't run in Forge's non-interactive ACP
+    sessions — do them in the herdr pane.
+  - **Never move or rename the Forge dir from outside** — Forge manages it.
+    Renaming is Forge's job; moving out entirely is a deliberate de-Forge
+    migration (borealis, 2026-08-20: mv + new-slug memory symlink + doc/Linear
+    repoints — old-slug transcripts stay behind).
 - **`[[keys.command]]` `type = "shell"` commands run with the server's bare
   launchd environment** — no `/opt/homebrew/bin` on PATH, so a command like
   `herdr agent focus atlas` dies silently on command-not-found (detached

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -180,6 +180,13 @@ type = "shell"
 command = "/opt/homebrew/bin/herdr agent focus eidos"
 description = "jump to Eidos"
 
+[[keys.command]]
+# o and shift+o are open_notification_target / Obscura; y as in orrerY.
+key = "prefix+y"
+type = "shell"
+command = "/opt/homebrew/bin/herdr agent focus orrery"
+description = "jump to Orrery"
+
 # Legacy indexed shortcut config is still parsed for compatibility.
 # Prefer switch_tab, switch_workspace, and focus_agent for new configs.
 # [keys.indexed]


### PR DESCRIPTION
## Summary
- **New fleet pattern — Forge-resident hybrid** (no precedent before this): a project that legitimately stays in Forge (UI-heavy, uses Forge's canvas/dev-server/publishing) gets a plain Claude Code pane in herdr for non-UI lanes. First instance: **`orrery ☉`** (jobs dashboard, orrery.ui8.dev, Forge codename dir `tranquil-dune`).
- **SOP added to the Herdr section** of CLAUDE.md (mirrored briefly in AGENTS.md): pane cwd targets the *physical* `~/.forge-projects/<codename>` path (herdr spawns via `chdir`; the kernel resolves symlinks, so CC project identity always lands there); `~/Projects/<name>` is an ergonomics-only symlink that gives the codename dir its human name; both harnesses share one project slug → shared vault memory and `--resume` continuity across Forge ACP sessions and the pane; one working tree = one writer at a time (UI lane in Forge, non-UI in the pane; interactive flows like MCP OAuth only work in the pane); never move/rename a Forge dir from outside (de-Forge is a deliberate migration — borealis precedent).
- Jump key `prefix+y` (`o`/`shift+o` taken by open_notification_target / obscura; `y` as in orrer**y**). Config hot-reloaded, no diagnostics.

## Live outside this diff
- Workspace `orrery ☉` created on the fleet template, agent renamed, currently at the first-run folder-trust prompt.
- `~/Projects/orrery` → `~/.forge-projects/tranquil-dune` symlink created.
- Orrery's bootstrap (vault, CLAUDE.md Vault declaration, slug memory symlink) was already complete from its Forge sessions — verified, not redone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qmr2g3oNNUE1FUiiqdhj62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the `orrery` agent to the Herdr roster.
  * Documented setup guidance for its hybrid Forge and Herdr workflow, including project paths, symlinks, shared sessions, and safe directory handling.

* **Configuration**
  * Added a keyboard shortcut to quickly focus the Orrery agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->