### PR TITLE
docs: phone access is Moshi SSH/mosh — Conduit torn down

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,7 +395,8 @@ conversations across server restarts via `claude --resume <id>`.
   PATH. **No server-side infrastructure exists for mobile access** — Conduit's
   pieces (the `conduit_push` Hermes plugin + a tailnet-only `tailscale serve`
   HTTPS proxy to the Hermes gateway on openclaw-prod) were torn down
-  2026-08-21 (reversal tarball in `/home/node/.hermes/backups/`); don't
+  2026-08-21 (reversal tarball:
+  `/home/node/.hermes/backups/conduit-teardown-20260821-144904.tgz`); don't
   reintroduce a gateway/relay for phone use.
 - **`[[keys.command]]` `type = "shell"` commands run with the server's bare
   launchd environment** — no `/opt/homebrew/bin` on PATH, so a command like

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,6 +386,17 @@ conversations across server restarts via `claude --resume <id>`.
     Renaming is Forge's job; moving out entirely is a deliberate de-Forge
     migration (borealis, 2026-08-20: mv + new-slug memory symlink + doc/Linear
     repoints — old-slug transcripts stay behind).
+- **Phone access is Moshi (SSH/mosh), not a gateway app** (since 2026-08-21;
+  replaced Conduit). Moshi (getmoshi.app) connects straight to this Mac —
+  `zs-macbook-pro.tail31dc0a.ts.net`:22, user `dvillavicencio`, Key File auth
+  (the `moshi`-comment line in `~/.ssh/authorized_keys`), Connection "Auto" →
+  Mosh — then `herdr` in the session attaches the whole fleet. Requires
+  Tailscale active on the phone; `mosh-server` rides the Brewfile and zshenv's
+  PATH. **No server-side infrastructure exists for mobile access** — Conduit's
+  pieces (the `conduit_push` Hermes plugin + a tailnet-only `tailscale serve`
+  HTTPS proxy to the Hermes gateway on openclaw-prod) were torn down
+  2026-08-21 (reversal tarball in `/home/node/.hermes/backups/`); don't
+  reintroduce a gateway/relay for phone use.
 - **`[[keys.command]]` `type = "shell"` commands run with the server's bare
   launchd environment** — no `/opt/homebrew/bin` on PATH, so a command like
   `herdr agent focus atlas` dies silently on command-not-found (detached


### PR DESCRIPTION
Adds the fleet phone-access bullet to the Herdr section: Moshi (SSH/mosh straight to the Mac, `herdr` in-session) replaced Conduit 2026-08-21, and **no server-side mobile infrastructure exists anymore** — Conduit's `conduit_push` Hermes plugin and the tailnet-only `tailscale serve` HTTPS proxy on openclaw-prod were torn down (gateway restarted healthy; reversal tarball in `/home/node/.hermes/backups/conduit-teardown-20260821-144904.tgz`). The bullet exists so no future session rebuilds a gateway/relay for phone use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qmr2g3oNNUE1FUiiqdhj62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for accessing the phone through Moshi using SSH/Mosh and Tailscale.
  * Documented authentication and `herdr` session usage.
  * Clarified that the former Conduit gateway, plugin, and proxy infrastructure has been removed and should not be restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->