### PR TITLE
docs: handoff — Linear, fleet expansion, Moshi, ShipSigma KPI arc

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,112 +1,105 @@
-# HANDOFF — 2026-08-19 (PDT), afternoon
+# HANDOFF — 2026-08-22 (PDT)
 
-**Fleet-builder day.** Continuation of the herdr work: recovered atlas/axiom after an
-overnight disappearance, hardened the fleet against connection loss and stray `/exit`,
-stood up a `sites ✦` umbrella agent for personal-website work (absorbing three retired
-standalone projects), and formalized the herdr-admin role. Also a full David-directed
-privacy sweep tail (the "Erato" scrub — see prior handoff + Decisions). **End state:
-five-agent fleet on one standard, single-branch repo, empty board, no open PRs, clean
-tree.**
+**Two-day infrastructure + family-project arc** (2026-08-20 → 08-22, sessions
+back-to-back). Three threads: (1) Linear replaced GitHub Projects as the issue
+tracker and the herdr fleet grew from five agents to eleven — including the first
+Forge-resident hybrid (orrery) and Borealis's full de-Forge migration; (2) phone
+access moved from Conduit to Moshi with the Conduit VPS pieces torn down; (3) a new
+family project — automated KPI reporting for Brittanie (CRO @ ShipSigma) — was
+designed, packaged, and handed off to *her* Claude account, where David reports
+progress plus some blockers being worked through. **End state: dotfiles master
+clean at `e0501b7`, no open PRs anywhere, board in Linear, KPI project live-in-
+progress on Brittanie's MacBook.**
 
 ## What We Built
 
-- **PR #148 — melos herdr agent** (from prior session, merged this arc): `melos ♪`, first
-  local agent.
-- **PR #149 — dropped retired external-volume references** (the 1TB drive that failed).
-- **PR #151 — auto-reconnect shims + sites agent.** `herdr/shims/{hermes-agent,claude-code}`
-  became repo-tracked wrapper scripts (symlinked into `~/.local/bin`; each execs a
-  same-named raw ssh alias in `~/.local/libexec/` to preserve herdr's detected process
-  name) that retry ssh forever on failure. Fixes atlas/axiom vanishing overnight (both ssh
-  panes died on sleep, exit 255; herdr closes a single-pane workspace when its pane exits).
-  `~/.ssh/config` `openclaw-prod` also got `ServerAliveInterval 60` + `ServerAliveCountMax
-  120` (machine-local; the old implicit CountMax 3 was the killer). Live-tested: killed
-  atlas ssh, wrapper respawned it in ~10s with workspace/name/rename intact.
-- **PR #152 — dropped the iTerm dock-bounce trigger.** `iterm/profile-dynamic.json`'s lone
-  `Do you want to proceed → Bounce` trigger tripped iTerm's slow-triggers warning under
-  herdr's repaint volume; it only fired inside the TUI and is covered twice over now
-  (tmux-attention glyph + herdr toasts). Removed.
-- **PR #153 — fleet "a pane never self-closes" + admin role.** Local agent pane template is
-  now `["/bin/zsh","-l","-c","claude; exec /bin/zsh -il"]` (was `exec claude`) — on `/exit`
-  or crash the pane drops to a login shell instead of closing its tab. Remote shims now
-  `break`+`exec zsh` on clean detach too. Applied live to melos/atlas/axiom/sites-hub
-  (rebuilt). Global CLAUDE.md gained a "Herdr fleet & agent building" section; dotfiles
-  CLAUDE.md/AGENTS.md updated with the new template.
-- **sites umbrella** (`~/Projects/sites`, its own minimal local git repo, no remote): CLAUDE.md
-  roster + symlinks to davidandbrittanie.com, davidv.sh, ibmcconstruction.com. Herdr
-  workspace `sites ✦`, tabs `hub`/`davidv`/`wedding`/`foreman` (hub = agent, rest = shells
-  cd'd into each repo). Folded in the wedding site + ibmcconstruction (Foreman instance #1),
-  migrating their memory into `~/Obsidian/sites/memory/`.
-- **davidv.sh PR #1 — repo CLAUDE.md** documenting the two-domain architecture:
-  villavicencio.dev = professional face (homepage + public routes served from this repo);
-  davidv.sh = engineering persona (`/x/*` experiments + `/ops/*` magic-link-gated living
-  runbooks); davidv.sh homepage 307s to villavicencio.dev by design (redirect map in
-  `vercel.json` is source of truth). Deployed on merge.
-- **dataworks-website eliminated** (repo + vault + harness project — moved to David's
-  engineers; FedEx remote `FedEx/eai-3542344-dataworks-web` untouched).
-- **Memory:** `feedback_herdr_admin_role.md` (the admin designation), `melos_herdr_workspace.md`
-  (prior). Global claude/CLAUDE.md is the symlinked source for `~/.claude/CLAUDE.md`.
+- **Linear migration (#155, #156).** Workspace `Villavicencio` (team `VIL`),
+  project `Dotfiles`; old GH board (zero open, 44 closed) is read-only history.
+  `/ticket` now drives `mcp__linear__save_issue`; merge cleanup marks issues Done.
+  Linear MCP is global in `~/.claude.json` — **personal Mac only** (work Mac uses
+  other tools; tickets from there via Linear web UI).
+- **Borealis de-Forged (#157).** `~/.forge-projects/borealis` → `~/Projects/borealis`,
+  new-slug memory symlink, workspace `borealis ❆`, jump `prefix+shift+b`. The
+  Borealis agent then deleted its Forge scaffold (its commit `13e9cec`).
+- **Fleet expansion (#158).** `argus ◉` (~/Projects/agents), `skills ⚒`,
+  `obscura ✇` (~/Projects/browse-gateway), `eidos ❖` (~/Projects/eidos — got the
+  full vault bootstrap). Jump keys shift+a/s/o/i; CLAUDE.md roster is now a table.
+- **Forge-resident hybrid SOP + orrery (#159, #160).** `tranquil-dune` IS Orrery
+  (live dashboard at orrery.ui8.dev) — herdr-ized in place as `orrery ☉`
+  (jump `prefix+y`), `~/Projects/orrery` symlink is ergonomics-only. SOP in the
+  Herdr section: physical-path pane cwd, shared slug across both harnesses,
+  one-writer-at-a-time; **hybrid repos get a private remote and the PR is the
+  seam** (orrery git-initialized → private `villavicencio/orrery`).
+- **Moshi replaces Conduit (#161).** Phone → fleet is Moshi SSH/mosh to
+  `zs-macbook-pro.tail31dc0a.ts.net` (key `moshi` in authorized_keys, `herdr`
+  in-session). Conduit teardown on openclaw-prod: `conduit_push` plugin disabled +
+  removed, pairing deleted, `tailscale serve` reset; gateway restarted healthy.
+  Reversal: `/home/node/.hermes/backups/conduit-teardown-20260821-144904.tgz`.
+- **ShipSigma KPI project** (private repo `villavicencio/shipsigma-kpi`, Linear
+  project "ShipSigma KPI", VIL-17→21): full design package for Brittanie's
+  automated CRO reporting — KPI definitions template, report formats, Project
+  instructions, daily/weekly task prompts, sit-down walkthrough, truth-test
+  checklist, sample brief + boss report, dashboard mockup artifact (Week/Goals/
+  QoQ/YoY view switcher): https://claude.ai/code/artifact/64f049b6-9324-4bdf-b502-2fe62a58d3c6
+  — plus the self-contained `HANDOFF-brittanie-setup.md` David pasted into her
+  Claude.
 
 ## Decisions Made
 
-- **Herdr admin / agent-builder is a standing role** (David, this session): one consistent
-  owner + one documented flow, enforced via the global CLAUDE.md pointer + dotfiles
-  procedure + memory. New agents use the fleet pane template and the standard bootstrap
-  (vault + CLAUDE.md + jump key), routed through dotfiles branch/PR — no per-project
-  freelancing.
-- **"A pane never self-closes"** is the fleet rule — local via `; exec zsh` fallback, remote
-  via the shim wrappers' break+exec. Rationale: `exec claude` makes the pane *be* claude, so
-  `/exit` killed the whole tab (happened live to the sites hub).
-- **Auto-reconnect is event-driven, not polling** — a wrapper blocked on its ssh child uses
-  zero CPU; it only loops (every 10s) while actually disconnected AND awake. Chosen over a
-  launchd timer / "warm-up of the day" daemon precisely to avoid constant polling.
-  ServerAliveCountMax 120 (not infinite) on purpose: keeps keepalives load-bearing while
-  awake and converts a truly-dead link into an honest failure instead of a zombie pane.
-- **sites is the general web-dev workhorse**, not just personal sites — folds maintenance-mode
-  projects (wedding, Foreman #1) behind one agent/vault; each site stays its own repo +
-  Vercel project. Standalone projects archived read-only, not deleted.
-- **davidv.sh homepage redirect is load-bearing** — never "fix" it to give the short domain
-  its own homepage; that's the whole point (short domain → professional long domain).
+- **Architecture: everything in Brittanie's own Max account** — official HubSpot
+  connector (her admin OAuth) + Microsoft 365 connector (goals Excel on SharePoint,
+  read fresh every run) + Cowork scheduled tasks (cloud-run). Zero custom infra;
+  nothing on any of our machines at runtime. Ruled out: running it on David's
+  side (compliance-gray for company CRM data).
+- **Chat side, not Code tab**, on her app: Project for setup/Q&A, Scheduled page
+  for the two tasks. Artifact-per-run reached from the Scheduled page; a stable
+  bookmark URL is only a bonus if cross-run artifact updates prove out.
+- **QoQ/YoY are same-point pacing** (QTD vs same-days-elapsed), never full-vs-partial;
+  YoY carries a data-vintage caveat. Goals absent from the workbook render "no
+  goal set," never inferred.
+- **Truth test is the acceptance gate**: number-for-number vs her latest manual
+  report, then one parallel cycle before she retires the manual process.
+- Dotfiles CodeRabbit flow settled into: push → tracked background watcher →
+  review findings → merge on CLEAN. (Detached `&` background jobs do NOT survive
+  the Bash call — use `run_in_background` watchers only.)
 
 ## What Didn't Work
 
-- **Auto-mode classifier blocks bulk file mutations** (mass rm/scrub bundles) even when
-  user-directed — decompose into single-purpose commands, or hand the user a reviewed
-  `--apply` script to run via `!` (user-typed commands bypass the agent classifier; but `!`
-  still shares the session's TCC identity, so `~/Library/Containers` paths can still refuse).
-- **Can't rebuild my own pane** (`dotfiles ~`, w1) — rebuilding it mid-session would kill this
-  session. It keeps the old `exec claude` shape until next recreation.
+- **`tranquil-dune` was almost condemned as a Forge demo** — it's Orrery. The
+  Borealis cleanup mission's step-4 got a correction blob; deletion was gated on
+  confirmation so nothing was lost. Lesson: no-git + codename ≠ scaffold.
+- Compound multi-line Bash scripts intermittently lose PATH (jq/nc "not found")
+  and zsh doesn't word-split like bash — flat one-liners with absolute paths are
+  the reliable shape for herdr socket/API scripting.
+- `layout.apply` with `workspace_id: null` targets the FOCUSED workspace (dropped
+  a stray tab into w1) — create the workspace first, then apply to its tab.
 
 ## What's Next
 
-1. **Nothing open.** Board empty, no PRs, clean tree.
-2. **Onboard the new/rebuilt agents' fresh context**: the `sites ✦` hub may show a
-   first-run folder-trust prompt — accept it. melos/sites reloaded fresh (melos now has its
-   muse persona).
-3. **Optional Vercel task** raised in the sites session (not yet done): pull the "Your
-   receipt from Vercel Inc." email + check the wedding project's plan tier (Pro?) now that
-   it's post-wedding — likely can drop to Hobby. Hub-lane work.
-4. **David post-session** (commands in clipboard): run the Erato-scrub `--apply` if not
-   already, delete this session's transcript + scratchpad, Raycast → Clipboard History →
-   Delete All, physically destroy the failed 1TB drive.
-5. Carryover: Touch ID sudo_local on the **work** Mac; passive herdr upstream watches
-   (#2960/#2961/#2966); `dotfiles ~` pane still on the old pane shape.
+1. **ShipSigma KPI sit-down is IN PROGRESS on Brittanie's MacBook** — David
+   reports progress + blockers being figured out. When he returns with the
+   report-back items (final KPI definitions, truth-test results, what the
+   blockers were), fold them into `~/Projects/shipsigma-kpi`, update the mockup
+   to her layout decisions, close VIL-17→19 as earned. **Ask about the blockers
+   first** — likely candidates: M365 connector admin consent, scheduled-task
+   Project attachment, or connector data gaps.
+2. Parallel-run cycle (VIL-20) once automation is live.
+3. Passive: herdr upstream watches (#2960/#2961/#2966); `dotfiles ~` pane still
+   on the old `exec claude` shape (rebuild kills the session — do it at a natural
+   break).
 
 ## Gotchas & Watch-outs
 
-- **iTerm "Dynamic Profiles Error" after a merge is a benign race** — git's unlink-then-create
-  swap of `iterm/profile-dynamic.json` (symlinked into iTerm) briefly dangles the symlink;
-  iTerm recovers on the next fs event. Dismiss it; `touch` the file to force a re-read.
-- **Rebuilding a remote pane is lossless** — atlas/axiom sessions live in tmux on the VPS
-  (`hermes` / `-L axiom AXIOM`); respawning the local pane just re-attaches. Rebuilding a
-  *local* agent pane DOES drop its in-memory session (transcript on disk, `--continue`-able).
-- **Agent renames don't survive pane recreation** — reapply `herdr agent rename` after any
-  rebuild or degraded restore (#2966), plus `layout.apply` if the command was dropped.
-- **New tab inherits umbrella cwd, not the repo** — a hand-made herdr tab lands at the
-  workspace cwd; `cd` it into the intended repo (bit us with the `davidv` tab).
-- **Parallel sites sessions**: start a second `claude` only after `cd ~/Projects/sites` (or
-  split the hub tab) — launching claude *inside* a site dir resolves that repo's own
-  standalone (archived) project, not the sites umbrella.
-- Carried: docs-only PRs report "no checks" by design (merge on `mergeStateStatus: CLEAN`);
-  launchd bare-PATH rule for anything herdr's server executes (absolute paths); herdr
-  keys/UI hot-reload via `reload-config`; herdr agent-detection keys on process *name* (the
-  shim-alias mechanism).
+- **shipsigma-kpi repo rule: structure and names in git, never target values** —
+  company data stays in her workbook; the repo is the design bench only.
+  `HANDOFF-brittanie-setup.md` is *generated* from `package/` by concatenation —
+  edit package files, regenerate, re-pbcopy (assembly recipe in PR #8/#9 commits).
+- Orrery repo: PR flow now (remote exists — no more local ff-merges); never
+  force-add `src/data/dashboard.json`; no pre-commit hook, scan before committing
+  data-shaped files.
+- Moshi: first connect may pop the macOS firewall prompt for mosh-server; Conduit
+  app on the phone is dead and deletable. Do NOT reintroduce a phone gateway.
+- Linear MCP tools are deferred — ToolSearch first; pass real newlines in
+  markdown, never `\n` escapes.
+- Fleet roster + jump keys live as a table in dotfiles CLAUDE.md (Herdr section);
+  renames still don't survive pane recreation — reapply after degraded restores.


### PR DESCRIPTION
Session handoff covering #155–#161 plus the ShipSigma KPI project (now in progress on Brittanie's machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qmr2g3oNNUE1FUiiqdhj62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the operational handoff for August 22, 2026.
  * Documented the Linear migration, Borealis infrastructure transition, fleet expansion, and Orrery integration.
  * Recorded the replacement of Conduit with Moshi and progress on the ShipSigma KPI project.
  * Refreshed decisions, failure notes, next steps, infrastructure watch-outs, and ongoing KPI work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->