### PR TITLE
docs(herdr): degraded-pane diagnosis + layout.apply rebuild recipe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,6 +252,9 @@ install via Homebrew casks in `brew/Brewfile`, not a helper.)
   need no shim — herdr detects a local claude pane natively; they use the pane
   template above, whose login shell rebuilds PATH from `zshenv` before claude
   starts (the server spawns pane commands with its bare launchd env).
+  A pane whose `layout.export` node has no `command` is degraded even though it
+  still detects as an agent; rebuild it with `layout.apply` over the socket
+  (recipe in CLAUDE.md).
   `orrery ☉` is the **Forge-resident hybrid** pattern (full SOP in CLAUDE.md):
   the project stays Forge-managed, the pane targets the physical
   `~/.forge-projects/<codename>` path (herdr `chdir` resolves symlinks, so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,6 +334,28 @@ conversations across server restarts via `claude --resume <id>`.
   so it holds fleet-wide. **When building any new agent, use this template and
   route the change through the standard flow** (see the global CLAUDE.md
   "Herdr fleet & agent building").
+  - **Diagnosing and rebuilding a degraded pane.** `layout.export` is the test:
+    a pane node with **no `command`** key is degraded — it came back as a bare
+    shell (the #2966 boot-race, or a pane made by hand) and someone started
+    `claude` inside it, so it *looks* fine and is detected normally, but the next
+    server restart returns an empty shell. `ps` confirms it: a healthy pane's
+    claude is a child of `herdr server` or of `/bin/zsh -l -c …`, a degraded
+    one's is a child of plain `-zsh`. Rebuild by applying the template to the
+    **existing tab** — workspace and tab survive, so the workspace label and jump
+    key are untouched — and **omit `pane_id`** so herdr replaces the pane instead
+    of re-tagging the running one. NDJSON over the socket; `nc -U` works on macOS
+    and returns immediately:
+
+    ```bash
+    S=~/.config/herdr/herdr.sock
+    echo '{"id":"1","method":"layout.export","params":{"workspace_id":"w1"}}' | nc -U $S
+    echo '{"id":"1","method":"layout.apply","params":{"workspace_id":"w1","tab_id":"w1:t1","root":{"type":"pane","cwd":"'"$HOME"'/Projects/Personal/dotfiles","command":["/bin/zsh","-l","-c","claude; exec /bin/zsh -il"]}}}' | nc -U $S
+    ```
+
+    Every request needs a `params` key — even the list calls, which take `{}`;
+    omitting it errors with `missing field params`. This kills the pane's live
+    agent session, so do it at a boundary (a `/clear` or model switch), not
+    mid-task, and reapply `herdr agent rename` afterward if that pane had one.
   - Current local agents on this template (jump keys are `[[keys.command]]`
     entries in `herdr/config.toml`; shift-chords where the plain letter is taken
     by a default binding or an earlier agent):


### PR DESCRIPTION
The `dotfiles ~` pane (w1) has been degraded since #153: its `layout.export` node carries **no `command`**, meaning it came back as a bare shell and someone started `claude` inside it. It detects normally and looks healthy — the only tells are the missing `command` and a `ps` chain rooted at plain `-zsh` instead of `herdr server` / `/bin/zsh -l -c …`. The next server restart would return an empty shell.

Records in CLAUDE.md's Herdr section:

- the `layout.export` test and the `ps` confirmation
- the exact socket invocation that rebuilds it — apply the fleet template to the **existing tab**, omitting `pane_id` so herdr replaces the pane rather than re-tagging the running one (workspace + tab survive, so label and jump key are untouched)
- `nc -U` works on macOS for the NDJSON API, and every request needs a `params` key — list calls take `{}`, omitting it errors `missing field params`
- the rebuild kills the live agent session, so it belongs at a boundary

AGENTS.md gets the one-line tool-neutral pointer.

Docs-only, so `install-matrix.yml`'s `paths-ignore` means no checks will report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qmr2g3oNNUE1FUiiqdhj62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for degraded Herdr panes whose exported layout lacks a command.
  * Documented how to identify affected panes, verify process ancestry, rebuild them through the existing tab, and reapply agent names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->