### PR TITLE
fix(docs): layout.apply takes tab_id or workspace_id, never both

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -349,13 +349,16 @@ conversations across server restarts via `claude --resume <id>`.
     ```bash
     S=~/.config/herdr/herdr.sock
     echo '{"id":"1","method":"layout.export","params":{"workspace_id":"w1"}}' | nc -U $S
-    echo '{"id":"1","method":"layout.apply","params":{"workspace_id":"w1","tab_id":"w1:t1","root":{"type":"pane","cwd":"'"$HOME"'/Projects/Personal/dotfiles","command":["/bin/zsh","-l","-c","claude; exec /bin/zsh -il"]}}}' | nc -U $S
+    echo '{"id":"1","method":"layout.apply","params":{"tab_id":"w1:t1","focus":true,"root":{"type":"pane","cwd":"'"$HOME"'/Projects/Personal/dotfiles","command":["/bin/zsh","-l","-c","claude; exec /bin/zsh -il"]}}}' | nc -U $S
     ```
 
-    Every request needs a `params` key — even the list calls, which take `{}`;
-    omitting it errors with `missing field params`. This kills the pane's live
-    agent session, so do it at a boundary (a `/clear` or model switch), not
-    mid-task, and reapply `herdr agent rename` afterward if that pane had one.
+    Two API gotchas, both fail-fast: `layout.apply` takes **`tab_id` or
+    `workspace_id`, never both** (`invalid_target`) — pass `tab_id` alone when
+    rebuilding one pane in place; and every request needs a `params` key, even
+    the list calls, which take `{}` (`missing field params`). This kills the
+    pane's live agent session, so do it at a boundary (a `/clear` or model
+    switch), not mid-task, and reapply `herdr agent rename` afterward if that
+    pane had one.
   - Current local agents on this template (jump keys are `[[keys.command]]`
     entries in `herdr/config.toml`; shift-chords where the plain letter is taken
     by a default binding or an earlier agent):


### PR DESCRIPTION
The rebuild recipe landed in #165 passed both `workspace_id` and `tab_id`; herdr rejects that with `invalid_target`. Caught on first real use, before the destructive call. Pass `tab_id` alone when rebuilding a single pane in place.

Documents both fail-fast API gotchas together (the other: every request needs `params`, list calls take `{}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qmr2g3oNNUE1FUiiqdhj62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the pane-rebuild example to target a specific tab and focus it.
  * Clarified that layout applications use either a tab ID or workspace ID, not both.
  * Documented that all requests require parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->