### PR TITLE
docs: handoff — backlog seeded (VIL-82/83), ShipSigma canceled

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,8 +1,8 @@
 ---
-created_at: "2026-08-24T13:05:00-07:00"
+created_at: "2026-08-24T13:15:58-07:00"
 branch: "master"
-head: "2b96e3a"
-resume_focus: "Seed the Linear Dotfiles backlog with the carried items (pane rebuild is done)"
+head: "078c75c"
+resume_focus: "Backlog seeded (VIL-82, VIL-83) and ShipSigma closed — next real work is picking one of the two open tickets"
 ---
 
 # HANDOFF — 2026-08-24 (PDT)
@@ -41,29 +41,41 @@ deliberate model-switch boundary: David is clearing to move Fable 5 → Opus 5).
    `command` at all (bare shell with claude started inside), so it detected fine
    but a server restart would have returned an empty shell. Rebuilt via
    `layout.apply` onto the existing tab; diagnosis + exact invocation are now in
-   CLAUDE.md's Herdr section. **Verify after this pickup:** `layout.export` for
-   w1 should show the template `command`, and the workspace label should still
-   read `dotfiles ~`.
-2. **Seed the Linear "Dotfiles" project backlog** — the backlog is empty while
-   carryovers live in handoff prose, which is exactly what Linear was adopted to
-   fix. Ticket the known items: statusline `BAR_CELLS` 10→20 (+ optional
-   `refreshInterval`) from the 08-20 accuracy discussion; Touch ID `sudo_local`
-   on the work Mac; the CLAUDE.md time-continuity rule update (prefer HANDOFF
-   frontmatter `head`/`created_at` over mtime — gated on skills ticket A
-   shipping).
-3. **Externally gated, act when they arrive:** ShipSigma KPI report-back from
-   Brittanie's machine (VIL-17→20 — ask about the blockers first; suspects: M365
-   admin consent, task↔Project attachment, connector gaps); skills agent's
-   setup-loop report (then David gates implementation ticket-by-ticket).
+   CLAUDE.md's Herdr section. **Verified 2026-08-24 at pickup:** `layout.export`
+   for w1 returns pane `w1:p7` carrying the full template `command`
+   (`/bin/zsh -l -c "claude; exec /bin/zsh -il"`) with the dotfiles cwd, and the
+   workspace label still reads `dotfiles ~`. Not degraded; survives a restart.
+2. ~~Seed the Linear "Dotfiles" project backlog~~ — **done 2026-08-24.** Two
+   tickets, not three: **VIL-82** (statusline — a live side-by-side against the
+   app's usage panel confirmed `5h 3%` / `7d 44%` are *accurate*, so the ticket
+   is coverage, not correctness: add the missing third meter, the premium-model
+   weekly bar the app shows at 76%, plus the `BAR_CELLS` 10→20 widening and
+   optional `refreshInterval`) and **VIL-83** (CLAUDE.md session-continuity
+   rule). Touch ID `sudo_local` on the work Mac was dropped as not needed.
+   VIL-83's premise was corrected while writing it: prefer the frontmatter
+   `head` *commit timestamp* — verifiable, survives checkout — over both mtime
+   and `created_at`, because this very handoff's `created_at` was ~9 minutes
+   ahead of reality and less accurate than its own mtime.
+3. **Pick up VIL-82 or VIL-83.** VIL-82 opens with a verification step: capture
+   one live statusline stdin payload and confirm which `rate_limits` key backs
+   the app's "Fable" row (`seven_day_opus` is the plausible but unconfirmed
+   candidate; `seven_day_sonnet` / `seven_day_overage_included` /
+   `seven_day_oauth_apps` are the other siblings the 2.1.241 bundle exposes).
+   VIL-83 is coupled to skills ticket A, which is underway now.
 4. Passive: herdr upstream #2960/#2961/#2966.
 
 ## Gotchas & Watch-outs
 
 - Model-switch mechanics: cache is per-model; the boundary (clear → switch →
   pickup) is the cheap path. Done deliberately this session.
-- shipsigma-kpi repo rule stands: structure/names in git, never target values;
-  `HANDOFF-brittanie-setup.md` is generated from `package/` — edit sources,
-  regenerate, re-pbcopy.
+- **ShipSigma KPI is closed (2026-08-24).** Work deviated considerably and moved
+  onto Brittanie's laptop, so VIL-17→20 are **Canceled** (not Done — it was not
+  delivered as specced) and the Linear project is Canceled with a note; VIL-21
+  stays Done, it shipped. No report-back is pending; stop treating it as gated.
+  The local-only `~/Projects/shipsigma-kpi` package survives as salvage — its
+  rule still holds if you ever reopen it: structure/names in git, never target
+  values, and `HANDOFF-brittanie-setup.md` is generated from `package/` — edit
+  sources, regenerate, re-pbcopy.
 - Orrery repo: PR flow, never force-add `src/data/dashboard.json`, no pre-commit
   hook there.
 - Do NOT reintroduce a phone gateway (Moshi is SSH/mosh direct; Conduit teardown


### PR DESCRIPTION
Mid-session HANDOFF correction, rather than letting the next `dv:handoff` run pick it up. `dv:handoff` overwrites wholesale, so a stale "What's Next" between writes actively misleads the next pickup — three of its items were wrong as of this session.

## What changed

- **Item 1 — pane rebuild:** was "verify after this pickup," now verified. `layout.export` for w1 returns pane `w1:p7` with the full template `command` and the dotfiles cwd; workspace label still `dotfiles ~`. Not degraded.
- **Item 2 — Linear backlog:** done. Two tickets, not the three planned:
  - **VIL-82** — a live side-by-side against the app's usage panel showed `5h 3%` / `7d 44%` are *accurate*, so this is a coverage ticket (add the premium-model weekly meter the app shows at 76%), not a correctness fix. Carries the `BAR_CELLS` 10→20 widening and optional `refreshInterval`.
  - **VIL-83** — CLAUDE.md session-continuity rule. Its premise was corrected while writing: anchor on the frontmatter `head` *commit timestamp*, not `created_at`, which in this very handoff ran ~9 minutes ahead of reality and was less accurate than its own mtime.
  - Touch ID `sudo_local` on the work Mac: dropped, not needed.
- **Item 3 — ShipSigma:** was listed as externally gated awaiting a report-back. It isn't. Work deviated and moved to Brittanie's laptop; VIL-17→20 are Canceled (not Done — it wasn't delivered as specced), the Linear project is Canceled with a note, VIL-21 stays Done. Rewritten as a gotcha so the next session stops waiting on it. The `~/Projects/shipsigma-kpi` repo rule is kept as salvage.

Docs-only, so `install-matrix.yml`'s `paths-ignore` means no checks will report — that's expected, not a stalled CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYV7xcms9d9Mpiod1QoNvm