### PR TITLE
docs(claude): rank commit timestamps above mtime for session continuity

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -292,8 +292,8 @@ The user runs in **PST/PDT**. When citing or reasoning about time:
 
 `dv:pickup` is often a context-hygiene move, not a new day. Sessions are routinely back-to-back —
 the user clears the window to reduce cached-context cost and avoid pollution. Before defaulting
-to "overnight" / "tomorrow" / "next morning" framing, check HANDOFF mtime, recent commit
-timestamps, and any continuation cues in the conversation. If signals say same-session,
+to "overnight" / "tomorrow" / "next morning" framing, check recent commit timestamps, HANDOFF
+mtime, and any continuation cues in the conversation. If signals say same-session,
 say so explicitly instead of pretending it's been hours.
 
 ## Personal Boundaries


### PR DESCRIPTION
A word-level reorder in CLAUDE.md's **Time & Session Continuity** rule. It already named both signals — it just listed HANDOFF mtime first.

The commit timestamp is the stronger one: verifiable, and it survives clone/rebase/checkout, all of which rewrite mtime. Zero added length.

## Why only this much

The larger version of this change — a paragraph on whether the handoff frontmatter's `created_at` can be trusted — is **VIL-83**, and it was deliberately left out:

- **n=1.** One bad timestamp observed, which is an anecdote, not a pattern.
- **The fix belongs upstream.** `created_at` read `13:05:00` (exactly on the five-minute mark, zero seconds) while mtime `12:55:08` and commit `12:55:53` carry real seconds — the signature of a model typing a plausible time rather than reading a clock. The fix is one line in `dv:handoff` (stamp from `date -Iseconds`), not a rule teaching every reader to route around the bug.
- **It would obsolete itself.** Once the skill is fixed, "don't trust `created_at`" becomes wrong — and CLAUDE.md is loaded into every session in every project, so it's permanent context cost for guidance with a short shelf life.

VIL-83 now carries that reasoning and the upstream fix. This PR is the always-true half.

Docs-only, so no checks will report — expected, per `install-matrix.yml`'s `paths-ignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYV7xcms9d9Mpiod1QoNvm