### PR TITLE
feat(statusline): widen usage meters to 20 cells

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -182,6 +182,14 @@ ToolSearch (e.g. `select:mcp__linear__save_issue,mcp__linear__list_issues`).
 - `save_issue`/`save_project` create *or* update (pass `id` to update); mark linked issues
   `Done` at merge time as part of the branch→PR→merge cleanup.
 - Pass real newlines in markdown content, never literal `\n` escape sequences.
+- **Naming a `VIL-…` id in a PR body can auto-close that issue on merge.** Linear's GitHub
+  integration scans PR text, attaches the PR, and moves the issue to Done when it merges —
+  including when the PR merely *mentions* the ticket in passing rather than completing it.
+  Observed 2026-08-24: a handoff PR recapping which tickets had been filed closed VIL-82
+  thirteen seconds after merge and auto-assigned it, while VIL-83 — named in the same body —
+  was untouched, so the trigger is narrower than "any id in the text" but not predictable
+  from the outside. Treat it as: after merging any PR that names ticket ids, re-check their
+  states and reopen what you didn't actually finish.
 
 ## Research
 

--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -50,7 +50,13 @@ meter_color() {
 # \342\226\221). $2 is raw escape bytes (e.g. from meter_color). Playhead rounds
 # to nearest cell: (pct * BAR_CELLS + 50) / 100; at 100% the bar is fully filled
 # with no cursor. Each cell is one character, so the slider stays compact.
-BAR_CELLS=10
+# 20 cells = 5pp per cell; three meters render ~105 columns, which fits a
+# full-width pane but would wrap in a split one — that width is the ceiling,
+# not a starting point. Note nearest-cell rounding means any two values inside
+# one cell's band still collapse, so more cells buys resolution in the MIDDLE
+# of the range (12% vs 15% separate at 20, not at 10), never at the very low
+# end — 3% and 7% differ at 10 cells and collide at 20. See VIL-82.
+BAR_CELLS=20
 bar() {
   _bf=$(( ($1 * BAR_CELLS + 50) / 100 )); [ "$_bf" -gt "$BAR_CELLS" ] && _bf=$BAR_CELLS
   _bi=0

--- a/claude/statusline-command.sh
+++ b/claude/statusline-command.sh
@@ -52,10 +52,12 @@ meter_color() {
 # with no cursor. Each cell is one character, so the slider stays compact.
 # 20 cells = 5pp per cell; three meters render ~105 columns, which fits a
 # full-width pane but would wrap in a split one — that width is the ceiling,
-# not a starting point. Note nearest-cell rounding means any two values inside
-# one cell's band still collapse, so more cells buys resolution in the MIDDLE
-# of the range (12% vs 15% separate at 20, not at 10), never at the very low
-# end — 3% and 7% differ at 10 cells and collide at 20. See VIL-82.
+# not a starting point. Halving the step separates most pairs that used to
+# share a cell (1%/4%, 5%/9%, 17%/22% all collide at 10 and split at 20), but
+# nearest-cell rounding still collapses anything inside one band, and a pair
+# straddling the new boundaries can regress: 3% and 7% differ at 10 cells and
+# collide at 20. Net gain across the range, not a guarantee for any one pair.
+# See VIL-82.
 BAR_CELLS=20
 bar() {
   _bf=$(( ($1 * BAR_CELLS + 50) / 100 )); [ "$_bf" -gt "$BAR_CELLS" ] && _bf=$BAR_CELLS


### PR DESCRIPTION
Widens the usage sliders from 10 to 20 cells — 5pp per cell instead of 10pp. Three meters render ~105 columns.

> Note: the statusline ticket is deliberately not named by id in this body. Mentioning one auto-closed a still-open ticket when an earlier PR merged, and that ticket stays open here — the ticket link is added manually after merge. The gotcha is documented in `claude/CLAUDE.md` in this same PR.

## The premise was wrong, and the comment now says so

The stated reason for widening was that 3% and 7% are indistinguishable at 10 cells. Measured, that's backwards:

| pct | 10 cells | 15 | 20 |
|---|---|---|---|
| 3% | 0 | 0 | 1 |
| 7% | 1 | 1 | 1 |
| 12% | 1 | 2 | 2 |
| 15% | 2 | 2 | 3 |

3% and 7% already differ at 10 and **collide at 20**. Nearest-cell rounding collapses any two values sharing a cell's band regardless of cell count — widening only moves the boundaries. The real gain is in the middle of the range, and the code comment now records this so nobody re-derives it.

## What did not land

The other half of the ticket — a meter for the premium-model weekly limit the app shows at 76% — **can't be built.** A captured live payload has exactly two entries under `rate_limits`:

```json
"five_hour": { "used_percentage": 4 },
"seven_day": { "used_percentage": 44 }
```

`seven_day_opus` / `seven_day_sonnet` exist in the 2.1.241 bundle but serve the API rate-limit and warning paths; they never reach the statusline. Not fixable by updating — 2.1.241 is already latest. Findings are recorded on the ticket.

## Verification

- Live payload: renders correctly at 20 cells.
- Vertex path (`rate_limits` absent): 5h/7d degrade to nothing, not `0%`.
- 100% (fully filled, no cursor) and 0% (cursor at origin) edges correct.
- `dot check` clean; `sh -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYV7xcms9d9Mpiod1QoNvm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for managing Linear issue references in merged pull requests and verifying ticket status afterward.
  * Updated statusline documentation to reflect the wider slider and its layout constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->