### PR TITLE
docs: reconcile CodeRabbit rules across projects and globalize them

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,10 +1,9 @@
 # yaml-language-server: $schema=https://www.coderabbit.ai/integrations/schema.v2.json
 #
 # Why this file exists: CodeRabbit reviews are rate-limited PER DEVELOPER on a rolling
-# hourly window (Trial 3/hr, Pro 5/hr, Pro+ 10/hr — docs.coderabbit.ai/faq; which tier
-# this account is on is not recorded, so check with `@coderabbitai rate limit` rather
-# than assuming). The limit is per developer regardless of tier, so every repo and every
-# parallel agent session draws from one shared pool. By default each push
+# hourly window — this account is Pro+ at 10/hr (confirmed by CodeRabbit's own review
+# footer on PR #171, 2026-08-24). The limit is per developer, not per repo, so every
+# repo and every parallel agent session draws from that same 10. By default each push
 # triggers a re-review and spends from that pool on intermediate commits.
 #
 # auto_incremental_review: false makes re-review a deliberate act. The first review of a

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,8 +1,10 @@
 # yaml-language-server: $schema=https://www.coderabbit.ai/integrations/schema.v2.json
 #
 # Why this file exists: CodeRabbit reviews are rate-limited PER DEVELOPER on a rolling
-# hourly window (Trial 3/hr, Pro 5/hr, Pro+ 10/hr — docs.coderabbit.ai/faq), so every
-# repo and every parallel agent session draws from one shared pool. By default each push
+# hourly window (Trial 3/hr, Pro 5/hr, Pro+ 10/hr — docs.coderabbit.ai/faq; which tier
+# this account is on is not recorded, so check with `@coderabbitai rate limit` rather
+# than assuming). The limit is per developer regardless of tier, so every repo and every
+# parallel agent session draws from one shared pool. By default each push
 # triggers a re-review and spends from that pool on intermediate commits.
 #
 # auto_incremental_review: false makes re-review a deliberate act. The first review of a

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://www.coderabbit.ai/integrations/schema.v2.json
+#
+# Why this file exists: CodeRabbit reviews are rate-limited PER DEVELOPER on a rolling
+# hourly window (Trial 3/hr, Pro 5/hr, Pro+ 10/hr — docs.coderabbit.ai/faq), so every
+# repo and every parallel agent session draws from one shared pool. By default each push
+# triggers a re-review and spends from that pool on intermediate commits.
+#
+# auto_incremental_review: false makes re-review a deliberate act. The first review of a
+# PR is still automatic; each later round is requested with `@coderabbitai review`. That
+# matches the fix -> push -> request -> re-review loop in the global CLAUDE.md "Code
+# Review" section without spending a review on every commit. `@coderabbitai rate limit`
+# reports remaining capacity and does not consume a review.
+#
+# Observed 2026-08-24 (PR #170): a one-line comment fix was pushed, the automatic
+# re-review it triggered came back rate-limited, and the PR was left showing a stale
+# CHANGES_REQUESTED it could not clear. This file is the fix for that loop.
+reviews:
+  auto_review:
+    auto_incremental_review: false
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,8 @@ tickets. Avoid committing directly to `master`.
 - **Docs-only PRs skip the install matrix, not the review** — `install-matrix.yml` sets
   `paths-ignore: ['docs/**', '**.md', 'claude/**/*.md']`, so a markdown-only change never
   triggers `linux`/`macos`; don't wait for a run that will never start. CodeRabbit still
-  reviews markdown, so wait for its check to leave `pending` and triage the findings —
+  reviews markdown on any review-eligible PR (drafts and `WIP` / `DO NOT MERGE` titles are
+  excluded), so wait for its check to leave `pending` and triage the findings —
   `mergeStateStatus: CLEAN` also reads clean while a review is pending or throttled.
 
 Issue tracking: Linear, project `Dotfiles`, team `Villavicencio` (key `VIL`) —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,13 @@ https://linear.app/villavicencio/project/dotfiles-74974922348e (migrated off the
 GitHub Projects board 2026-08-20; the board and closed GitHub issues are read-only
 history — never create new GitHub issues).
 
+- **PR review is CodeRabbit** (`.coderabbit.yaml` at repo root sets
+  `auto_incremental_review: false`, so re-review is requested with an `@coderabbitai review`
+  comment rather than fired by every push). Wait for its verdict and for each re-review before
+  merging — a stale `CHANGES_REQUESTED` is not permission, and a `Review rate limited` check
+  passes by design without any review having run. Full procedure, rate-limit mechanics, and when
+  to escalate to `dv:gauntlet` instead: the **Code Review** section of the global CLAUDE.md.
+
 ---
 
 ## Install pipeline (what `./install` does)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,10 +185,11 @@ tickets. Avoid committing directly to `master`.
 - **One PR per logical change**; push and open with `gh pr create`. Keep `master` green.
 - **Merge, then clean up**: delete the branch, mark any linked Linear issue `Done`.
 - **Trivial exceptions** (typo, one-line doc tweak) may go straight to `master`.
-- **Docs-only PRs report "no checks reported"** — `install-matrix.yml` sets
+- **Docs-only PRs skip the install matrix, not the review** — `install-matrix.yml` sets
   `paths-ignore: ['docs/**', '**.md', 'claude/**/*.md']`, so a markdown-only change never
-  triggers the matrix. Merge on `mergeStateStatus: CLEAN`; don't wait for a run that
-  will never start.
+  triggers `linux`/`macos`; don't wait for a run that will never start. CodeRabbit still
+  reviews markdown, so wait for its check to leave `pending` and triage the findings —
+  `mergeStateStatus: CLEAN` also reads clean while a review is pending or throttled.
 
 Issue tracking: Linear, project `Dotfiles`, team `Villavicencio` (key `VIL`) —
 https://linear.app/villavicencio/project/dotfiles-74974922348e (migrated off the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -581,11 +581,13 @@ this repo, not just ticket work. Avoid committing directly to `master`.
 Picking up a board ticket always gets its own branch (never work a ticket on
 `master`).
 
-**A docs-only PR reports "no checks reported" — that is correct, not a stalled CI.**
+**A docs-only PR skips the install matrix — but not the review.**
 `install-matrix.yml` declares `paths-ignore: ['docs/**', '**.md', 'claude/**/*.md']`,
-so a change touching only markdown never triggers the matrix and `gh pr checks` has
-nothing to show. `gh pr view --json mergeStateStatus` reading `CLEAN` is the signal to
-merge on; do not wait for a run that will never start.
+so a markdown-only change never triggers `linux`/`macos`; do not wait for a run that
+will never start. **CodeRabbit still reviews it** (it has findings on markdown, and did
+on #171), so `mergeStateStatus: CLEAN` is not by itself the merge signal — wait for the
+CodeRabbit check to leave `pending` and triage its findings first. `CLEAN` only tells you
+nothing is *blocking*; a throttled or still-running review also reads clean.
 
 ### Claude Code permissions: one allowlist, not two
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -571,6 +571,12 @@ this repo, not just ticket work. Avoid committing directly to `master`.
 - **Trivial exceptions** (typo fixes, a one-line doc tweak) may go straight to
   `master` at the author's discretion — the rule targets behavior and config
   changes, where review and a clean history matter.
+- **PR review is CodeRabbit** (`.coderabbit.yaml` at repo root sets
+  `auto_incremental_review: false`, so re-review is requested with an `@coderabbitai review`
+  comment rather than fired by every push). Wait for its verdict and for each re-review before
+  merging — a stale `CHANGES_REQUESTED` is not permission, and a `Review rate limited` check
+  passes by design without any review having run. Full procedure, rate-limit mechanics, and when
+  to escalate to `dv:gauntlet` instead: the **Code Review** section of the global CLAUDE.md.
 
 Picking up a board ticket always gets its own branch (never work a ticket on
 `master`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -584,8 +584,9 @@ Picking up a board ticket always gets its own branch (never work a ticket on
 **A docs-only PR skips the install matrix — but not the review.**
 `install-matrix.yml` declares `paths-ignore: ['docs/**', '**.md', 'claude/**/*.md']`,
 so a markdown-only change never triggers `linux`/`macos`; do not wait for a run that
-will never start. **CodeRabbit still reviews it** (it has findings on markdown, and did
-on #171), so `mergeStateStatus: CLEAN` is not by itself the merge signal — wait for the
+will never start. **CodeRabbit still reviews it** if the PR is review-eligible — drafts and
+`WIP` / `DO NOT MERGE` titles are excluded — and it does have findings on markdown, as it did
+on #171. So `mergeStateStatus: CLEAN` is not by itself the merge signal — wait for the
 CodeRabbit check to leave `pending` and triage its findings first. `CLEAN` only tells you
 nothing is *blocking*; a throttled or still-running review also reads clean.
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -129,10 +129,11 @@ Limits are **per developer on a rolling hour**, so every repo and every parallel
 draws from one shared pool: a quiet repo can hit the ceiling it never spent. Per
 [docs.coderabbit.ai/faq](https://docs.coderabbit.ai/faq) (fetched 2026-08-24): **Trial 3/hr, Pro
 5/hr, Pro+ 10/hr**, with fair-usage spacing above the 95th percentile of recent usage and an
-optional usage-based add-on. **Which tier this account is on is not recorded here** — a 14-day
-trial started 2026-08-18, so don't assume a number. `@coderabbitai rate limit` reports the real
-remaining capacity **without consuming a review**; use it rather than doing arithmetic from the
-table above.
+optional usage-based add-on. **This account is Pro+ — 10/hr** (CodeRabbit's own review footer on
+dotfiles #171, 2026-08-24: "Your plan provides up to 10 included reviews per hour"). Ten is not
+much when a single ticket spans several PRs across repos and parallel agents, so treat it as a
+budget: `@coderabbitai rate limit` reports real remaining capacity **without consuming a review**,
+and the review footer prints what is left after each run.
 
 **A throttled CodeRabbit is unavailable, not clean.** A throttled PR shows a *passing* check
 reading `Review rate limited` and no review runs — passing by design so it never blocks merging,

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -85,20 +85,66 @@ too). Repos with their own stricter rules keep them.
 
 ## Code Review
 
-**Adversarial code review → invoke `dv:gauntlet`** (dv suite ≥ 0.2.0, installed user-scope, so it
-resolves in every project); do **not** hand-roll `codex exec review` or Claude↔Codex review loops.
-Bare `dv:gauntlet` is the full autonomous find→refute→fix→commit loop (staged, cost-tiered,
-budgeted); `dv:gauntlet report` is a single report-only round. The skill owns the procedure —
-rounds, budgets, the fingerprint ledger, stop rules, read-only peer runs — so don't re-derive it
-per project.
+**PR review runs through CodeRabbit; `dv:gauntlet` is the escalation, not the default**
+(reconciled across dotfiles / borealis / skills, 2026-08-24). Before this, the global rule named
+gauntlet as the blanket default while two repos had already overridden it per-project — this
+section is the single source of truth, and per-repo `AGENTS.md` files should point here rather
+than restate it.
 
-**This holds even under `/effort ultracode` or dynamic workflow orchestration, and even when
-another project's vault or SOP describes its own `codex exec review`/Claude↔Codex loop** — those
-are superseded by `dv:gauntlet`, so discovering one elsewhere does not override the standing tool.
-Custom multi-agent workflows may supply research or critique *lenses* upstream, but the adversarial
-review of your own diff still routes through `dv:gauntlet` (bare for your own branch, `report` for a
-read-only pass on someone else's). If you catch yourself about to "fan out reviewers," "spin up a
-skeptic panel," or "drive the Codex loop," stop and invoke `dv:gauntlet` first.
+**Reach for CodeRabbit** for review of a PR diff. **Reach for `dv:gauntlet`** when the diff is
+large or risky enough to warrant a convergent find→refute→fix loop, when CodeRabbit is throttled
+and the review genuinely cannot wait, or when reviewing something that is not a PR. Bare
+`dv:gauntlet` is the full autonomous loop (it fixes and commits); `dv:gauntlet report` is a single
+report-only round and is the right rate-limit fallback. The skill owns its own procedure — rounds,
+budgets, the fingerprint ledger, stop rules — so don't re-derive it per project.
+
+Either way, **don't hand-roll a review**: no `codex exec review`, no Claude↔Codex loops, no
+"fan out reviewers" or "spin up a skeptic panel," including under `/effort ultracode` or workflow
+orchestration. Custom workflows may supply research or critique *lenses* upstream; the review of
+the diff itself routes through one of the two tools above.
+
+### Merging on a CodeRabbit review
+
+- **Wait for the review, and wait for each re-review** (David, 2026-08-24). Do not merge while its
+  verdict is `CHANGES_REQUESTED`, even after pushing a fix that you believe resolves the finding —
+  the stale verdict is not permission. If the re-review is throttled, wait for the window.
+- **Poll the check line, not the reviews API**: `gh pr checks <N> | grep -i '^CodeRabbit'` until it
+  stops saying `pending`. The bot posts as `coderabbitai` on some PRs and `coderabbitai[bot]` on
+  others, and its replies to your thread replies register as `COMMENTED` reviews — both make a
+  reviews-API poll fire early or never. `gh api .../comments/<id>` 404s for review comments; use
+  the list endpoint `.../pulls/<N>/comments?per_page=100` and filter by id.
+- **Triage every finding**: fix it on the branch, or decline it with the reason recorded both on
+  the thread and in the PR body. A finding you disagree with is a standoff you document, not one
+  you merge past silently.
+- **A trivial diff may skip review**, but the skip and its reason must be stated when reporting
+  the merge. The skip is fine; the silence isn't.
+- **`mergeStateStatus: CLEAN` does not mean reviewed.** See throttling below.
+
+### Rate limits — per developer, not per repository
+
+Limits are **per developer on a rolling hour**, so every repo and every parallel agent session
+draws from one shared pool: a quiet repo can hit the ceiling it never spent. Per
+[docs.coderabbit.ai/faq](https://docs.coderabbit.ai/faq) (fetched 2026-08-24): **Trial 3/hr, Pro
+5/hr, Pro+ 10/hr**, with fair-usage spacing above the 95th percentile of recent usage and an
+optional usage-based add-on. `@coderabbitai rate limit` reports remaining capacity **without
+consuming a review**; use it before assuming you have headroom.
+
+**A throttled CodeRabbit is unavailable, not clean.** A throttled PR shows a *passing* check
+reading `Review rate limited` and no review runs — passing by design so it never blocks merging,
+which makes it easy to misread as approval. Merging anyway is allowed only when every other gate
+is green **and** the PR body records that CodeRabbit was throttled rather than silent. For
+anything beyond docs and config, wait for capacity.
+
+### `.coderabbit.yaml` — every repo under review should have one
+
+Set `reviews.auto_review.auto_incremental_review: false`. By default **every push re-reviews**,
+spending the shared per-developer allowance on intermediate commits; with it false the first
+review is still automatic and each later round is requested deliberately with an
+`@coderabbitai review` comment. This matches the fix → push → request → re-review loop above.
+Repos carrying this config: `skills`, `dotfiles`. Repos still on push-triggered re-review:
+`borealis`.
+
+**Naming a ticket id in a PR body can auto-close that issue on merge** — see the Linear section.
 
 ## Subagents
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -149,6 +149,12 @@ excluded — and each later round is requested deliberately with an `@coderabbit
 Repos carrying this config: `skills`, `dotfiles`. Repos still on push-triggered re-review:
 `borealis`.
 
+The config is read from the **PR head branch, not the base** — verified on dotfiles #171, the PR
+that added the file: its own later push was skipped rather than auto-reviewed. So a PR introducing
+`.coderabbit.yaml` governs itself immediately, and a suppressed round shows up as a *passing*
+check reading `Review skipped: incremental reviews are disabled` — another clean-looking check
+that means no review ran.
+
 **Naming a ticket id in a PR body can auto-close that issue on merge** — see the Linear section.
 
 ## Subagents

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -107,12 +107,15 @@ the diff itself routes through one of the two tools above.
 
 - **Wait for the review, and wait for each re-review** (David, 2026-08-24). Do not merge while its
   verdict is `CHANGES_REQUESTED`, even after pushing a fix that you believe resolves the finding —
-  the stale verdict is not permission. If the re-review is throttled, wait for the window.
+  the stale verdict is not permission. If the re-review is throttled, wait for the window; the one
+  exception is the docs/config carve-out under "Rate limits" below, and it requires recording the
+  throttle in the PR body.
 - **Poll the check line, not the reviews API**: `gh pr checks <N> | grep -i '^CodeRabbit'` until it
   stops saying `pending`. The bot posts as `coderabbitai` on some PRs and `coderabbitai[bot]` on
   others, and its replies to your thread replies register as `COMMENTED` reviews — both make a
   reviews-API poll fire early or never. `gh api .../comments/<id>` 404s for review comments; use
-  the list endpoint `.../pulls/<N>/comments?per_page=100` and filter by id.
+  the list endpoint with `gh api --paginate .../pulls/<N>/comments` and filter by id — `per_page`
+  alone caps at one page and silently drops findings past it.
 - **Triage every finding**: fix it on the branch, or decline it with the reason recorded both on
   the thread and in the PR body. A finding you disagree with is a standoff you document, not one
   you merge past silently.
@@ -126,8 +129,10 @@ Limits are **per developer on a rolling hour**, so every repo and every parallel
 draws from one shared pool: a quiet repo can hit the ceiling it never spent. Per
 [docs.coderabbit.ai/faq](https://docs.coderabbit.ai/faq) (fetched 2026-08-24): **Trial 3/hr, Pro
 5/hr, Pro+ 10/hr**, with fair-usage spacing above the 95th percentile of recent usage and an
-optional usage-based add-on. `@coderabbitai rate limit` reports remaining capacity **without
-consuming a review**; use it before assuming you have headroom.
+optional usage-based add-on. **Which tier this account is on is not recorded here** — a 14-day
+trial started 2026-08-18, so don't assume a number. `@coderabbitai rate limit` reports the real
+remaining capacity **without consuming a review**; use it rather than doing arithmetic from the
+table above.
 
 **A throttled CodeRabbit is unavailable, not clean.** A throttled PR shows a *passing* check
 reading `Review rate limited` and no review runs — passing by design so it never blocks merging,
@@ -139,8 +144,8 @@ anything beyond docs and config, wait for capacity.
 
 Set `reviews.auto_review.auto_incremental_review: false`. By default **every push re-reviews**,
 spending the shared per-developer allowance on intermediate commits; with it false the first
-review is still automatic and each later round is requested deliberately with an
-`@coderabbitai review` comment. This matches the fix → push → request → re-review loop above.
+*eligible* review is still automatic — `ignore_title_keywords` (WIP / DO NOT MERGE) and drafts are
+excluded — and each later round is requested deliberately with an `@coderabbitai review` comment. This matches the fix → push → request → re-review loop above.
 Repos carrying this config: `skills`, `dotfiles`. Repos still on push-triggered re-review:
 `borealis`.
 


### PR DESCRIPTION
Swept every project for CodeRabbit references and reconciled them into one global rule. Four sources had rules, and they disagreed with each other **and** with the global doc.

## What conflicted

| Source | Said |
|---|---|
| Global `claude/CLAUDE.md` | No mention of CodeRabbit at all — "adversarial review → `dv:gauntlet`", and that other projects' review SOPs are *superseded* |
| dotfiles memory | Trial mode, gauntlet standing; "3/hr"; pushes retrigger review |
| borealis `AGENTS.md` + memory | CodeRabbit **local CLI** overrides gauntlet here; trivial diffs may skip if stated |
| skills `AGENTS.md` + memory + `.coderabbit.yaml` | CodeRabbit **GH app**; merge only on APPROVED; `auto_incremental_review: false`; per-developer limits |

Four real conflicts:

1. **The global rule contradicted two repos that had already overridden it.** Resolved in favor of CodeRabbit primary, `dv:gauntlet` as escalation — which is what all three repos actually do.
2. **Rate limits disagreed.** Grounded against [docs.coderabbit.ai/faq](https://docs.coderabbit.ai/faq): Trial 3/hr, Pro 5/hr, Pro+ 10/hr, all **per developer, not per repository**, on a rolling hour. Both memories were right for different tiers; neither dotfiles nor borealis recorded the shared-pool scope, which is why a quiet repo can hit a ceiling it never spent.
3. **Only `skills` had a `.coderabbit.yaml`.** Everywhere else each push auto-triggers a re-review and drains the shared allowance. Added here; `borealis` still lacks one.
4. **The merge gate differed per repo.** Now one rule: wait for the review and for each re-review. A stale `CHANGES_REQUESTED` is not permission, and a throttled check *passes* without any review having run.

## Why now

Conflicts 3 and 4 are exactly what went wrong on #170 earlier today: a pushed fix triggered an automatic re-review, that re-review came back throttled, and the PR merged on the stale `CHANGES_REQUESTED`. Both holes are closed by this change.

## Scope

Global section + dotfiles only. `borealis` and `skills` are other agents' repos and the skills agent is mid-task, so their edits go to them as a changelist rather than being made here.

Docs and config only — no checks will report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYV7xcms9d9Mpiod1QoNvm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded repository guidance for CodeRabbit pull-request reviews, including documentation-only changes.
  * Clarified merge requirements, review eligibility, findings triage, manual re-reviews, stale reviews, rate limits, and escalation procedures.
  * Documented shared Pro+ review capacity, remaining-capacity checks, and branch-specific configuration behavior.

* **Chores**
  * Added review configuration to ignore work-in-progress and “do not merge” pull requests.
  * Disabled automatic incremental reviews after the initial review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## ⏸️ Held: CodeRabbit throttled

As of 2026-08-24 21:55Z the CodeRabbit check reads `Review rate limited` — the Pro+ allowance (10/hr, per developer across all repos) was exhausted by this session. **Commit `95fed9f` has not been reviewed.**

The two prior rounds reviewed everything through `cde3c41` and all six findings were addressed. `95fed9f` adds only the "review-eligible" qualifier and the confirmed Pro+ tier.

Recording this rather than merging on it: the check passes by design when throttled, which is precisely the misreading this PR exists to prevent. Holding for capacity.
