### PR TITLE
docs: never push mid-review; anchor session continuity on handoff frontmatter

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -110,6 +110,12 @@ the diff itself routes through one of the two tools above.
   the stale verdict is not permission. If the re-review is throttled, wait for the window; the one
   exception is the docs/config carve-out under "Rate limits" below, and it requires recording the
   throttle in the PR body.
+- **Never push while a review is in flight.** A push that lands mid-review *aborts* it —
+  CodeRabbit posts "Review failed — the head commit changed during the review" — and the spent
+  review is gone with nothing to show for it, still charged against the hourly allowance. Land
+  every edit first, *then* request the round. This matters most when addressing findings: batch
+  the fixes, push once, then comment `@coderabbitai review`. (Observed on skills#36, in the very
+  commit documenting the throttle rules.)
 - **Poll the check line, not the reviews API**: `gh pr checks <N> | grep -i '^CodeRabbit'` until it
   stops saying `pending`. The bot posts as `coderabbitai` on some PRs and `coderabbitai[bot]` on
   others, and its replies to your thread replies register as `COMMENTED` reviews — both make a
@@ -358,9 +364,19 @@ The user runs in **PST/PDT**. When citing or reasoning about time:
 
 `dv:pickup` is often a context-hygiene move, not a new day. Sessions are routinely back-to-back —
 the user clears the window to reduce cached-context cost and avoid pollution. Before defaulting
-to "overnight" / "tomorrow" / "next morning" framing, check recent commit timestamps, HANDOFF
-mtime, and any continuation cues in the conversation. If signals say same-session,
-say so explicitly instead of pretending it's been hours.
+to "overnight" / "tomorrow" / "next morning" framing, **check the handoff's own frontmatter
+first**. `dv:handoff` (dv 0.4.0+) writes `created_at`, `branch`, and `head` above the header,
+stamped from the shell rather than authored by the model, and `dv:pickup` reports `git log
+<head>..HEAD` — so staleness is "N commits since `<head>`", which is a fact, not an inference
+from file age. `head` is the anchor that matters: it survives clone/rebase/checkout, all of which
+rewrite mtime, and it pins the handoff to a tree state rather than a moment.
+
+Fall back to HANDOFF mtime only when there is no frontmatter, and say so when you do. A
+**pre-0.4.0** handoff's `created_at` was model-written and can be wrong — one was observed nine
+minutes *ahead* of both its own mtime and the commit it described, i.e. less accurate than the
+mtime it was meant to replace. Also weigh recent commit timestamps and any continuation cues in
+the conversation. If signals say same-session, say so explicitly instead of pretending it's been
+hours.
 
 ## Personal Boundaries
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -368,15 +368,26 @@ to "overnight" / "tomorrow" / "next morning" framing, **check the handoff's own 
 first**. `dv:handoff` (dv 0.4.0+) writes `created_at`, `branch`, and `head` above the header,
 stamped from the shell rather than authored by the model, and `dv:pickup` reports `git log
 <head>..HEAD` — so staleness is "N commits since `<head>`", which is a fact, not an inference
-from file age. `head` is the anchor that matters: it survives clone/rebase/checkout, all of which
-rewrite mtime, and it pins the handoff to a tree state rather than a moment.
+from file age. `head` is the anchor that matters: it pins the handoff to a tree state rather than
+a moment.
 
-Fall back to HANDOFF mtime only when there is no frontmatter, and say so when you do. A
-**pre-0.4.0** handoff's `created_at` was model-written and can be wrong — one was observed nine
-minutes *ahead* of both its own mtime and the commit it described, i.e. less accurate than the
-mtime it was meant to replace. Also weigh recent commit timestamps and any continuation cues in
-the conversation. If signals say same-session, say so explicitly instead of pretending it's been
-hours.
+**Validate `head` before trusting the count**, in two steps — `git cat-file -e <head>^{commit}`
+(is the object here at all) then `git merge-base --is-ancestor <head> HEAD` (is it actually behind
+us). Only if both pass is `git rev-list --count <head>..HEAD` meaningful. Three ways it isn't:
+
+- **Present but not an ancestor** — a squash-merge or rebase rewrote the commit the handoff
+  recorded. This repo squash-merges every PR, so it is the common case, and it **fails silently**:
+  `rev-list` still returns a believable number. Verified 2026-08-25 — an orphaned pre-squash SHA
+  reported `3` when the true distance was `5`. Do not report the count; fall back and say why.
+- **Object absent** — fresh clone, or gc'd. `rev-list` errors loudly rather than lying.
+- **Frontmatter with no `head`** — possible on pre-0.4.0 handoffs. Nothing to anchor to.
+
+In all three, fall back to HANDOFF mtime and **announce the fallback**, since mtime is destroyed
+by any fresh checkout. Do not substitute `created_at`: on **pre-0.4.0** handoffs it was
+model-written and can be wrong — one was observed nine minutes *ahead* of both its own mtime and
+the commit it described, i.e. less accurate than the mtime it was meant to replace. Also weigh
+recent commit timestamps and any continuation cues in the conversation. If signals say
+same-session, say so explicitly instead of pretending it's been hours.
 
 ## Personal Boundaries
 


### PR DESCRIPTION
Two additions from the skills session, where the globalized rules got their first heavy workout — nine PRs, 35 CodeRabbit findings. Both additive; the section otherwise held up.

## 1. Never push while a review is in flight

A push landing mid-review **aborts** it: CodeRabbit posts *"Review failed — the head commit changed during the review"*, and the review is gone — still charged against the hourly allowance, with no findings to show. Observed on skills#36, in the commit that was documenting the throttle rules.

This generalizes to every repo, so it lands in the global section rather than staying in `skills/AGENTS.md`. Practical form: batch the fixes, push once, *then* comment `@coderabbitai review`.

## 2. Session continuity anchors on the handoff's commit, not its mtime

dv 0.4.0 (VIL-76) makes `dv:handoff` write commit-anchored frontmatter and `dv:pickup` report `git log <head>..HEAD`. Staleness becomes "N commits since `<head>`" — a fact rather than an inference from file age.

**One deliberate deviation from the suggested wording:** it ranks `head` *above* `created_at` rather than pairing them.

I checked the installed 0.4.0 handoff skill before writing this. It stamps `created_at` from the shell (`date +%Y-%m-%dT%H:%M:%S%z`, line 73) and instructs the writer to copy it verbatim, never from memory (line 137) — so it is trustworthy going forward, and that's the upstream fix VIL-83 argued for. But **pre-0.4.0** handoffs were model-authored, and one in this repo was observed nine minutes *ahead* of both its own mtime and the commit it described — less accurate than the mtime it was meant to replace.

So `head` leads because it survives clone/rebase/checkout (all of which rewrite mtime) and pins a tree state rather than a moment. The `created_at` caveat is explicitly scoped to pre-0.4.0 handoffs, so it retires itself.

Closes VIL-83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYV7xcms9d9Mpiod1QoNvm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance to avoid pushing changes while reviews are in progress.
  * Clarified how to batch fixes and request follow-up reviews.
  * Improved session handoff continuity guidance, including validation of commit references and fallback behavior for older handoffs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->