### PR TITLE
chore: drop the project-scoped dv plugin pin so dotfiles follows user scope

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,5 @@
 {
-  "enabledPlugins": {
-    "dv@villavicencio-skills": true
-  },
+  "enabledPlugins": {},
   "extraKnownMarketplaces": {
     "villavicencio-skills": {
       "source": {


### PR DESCRIPTION
`dv` was installed at **both** user scope (0.4.0) and project scope (0.3.0, pinned 2026-08-07). Project scope wins, so every session in this repo loaded the 0.3.0 skills while 0.4.0 sat unused in the cache.

That was invisible until tonight, when it started to matter: the global CLAUDE.md now tells agents to anchor handoff freshness on the frontmatter's `head` and report "N commits since `<head>`" — and 0.3.0's `dv:pickup` has none of that logic. The rule and the tool disagreed, in this project only.

## What changed

Ran `claude plugin uninstall dv@villavicencio-skills -s project`, which cleared the project-level `enabledPlugins` entry. The `-s project` flag is load-bearing: the command defaults to `user` scope, which would have removed the 0.4.0 install you want to keep.

Verified `dv` is still enabled here via user scope (`claude plugin list` from this directory reports `0.4.0 / user / ✔ enabled`), so nothing lost the plugin — it just resolves to the current version on the next session.

## Note

One stale entry remains in `~/.claude/plugins/installed_plugins.json`: a project pin for `~/.herdr/worktrees/dotfiles/worktree-calm-meadow-6be9`, a herdr worktree that no longer exists. It's machine-local dead config, not tracked here, and can't affect this path. `claude plugin prune` would clear it.

Config change, so `install-matrix.yml` won't skip it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYV7xcms9d9Mpiod1QoNvm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application configuration by disabling an optional plugin.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->