### PR TITLE
docs: handoff — CodeRabbit rules globalized, six PRs merged

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -38,7 +38,7 @@ fleet, Moshi, ShipSigma) is now fully closed out.
   Done because it shipped.
 - **Two handoff changelists**, durable in the vault:
   `~/Obsidian/dotfiles/coderabbit-changelist-skills.md` and
-  `coderabbit-changelist-borealis.md`. Paste with
+  `~/Obsidian/dotfiles/coderabbit-changelist-borealis.md`. Paste either with
   `pbcopy < ~/Obsidian/dotfiles/coderabbit-changelist-skills.md`. Each is
   self-contained — the receiving agent needs no context from this session.
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,84 +1,116 @@
 ---
-created_at: "2026-08-24T13:15:58-07:00"
+created_at: "2026-08-25T09:08:30-07:00"
 branch: "master"
-head: "078c75c"
-resume_focus: "Backlog seeded (VIL-82, VIL-83) and ShipSigma closed — next real work is picking one of the two open tickets"
+head: "289225d"
+resume_focus: "Paste the skills changelist (scratchpad, or regenerate), then the borealis one — both repos still carry pre-reconciliation CodeRabbit rules"
 ---
 
-# HANDOFF — 2026-08-24 (PDT)
+# HANDOFF — 2026-08-25, morning (PDT)
 
-Tail of the 08-20→08-24 arc (prior handoff #162 covers Linear migration, the
-eleven-agent fleet, Moshi/Conduit, and the ShipSigma KPI design — read that PR's
-version for the full arc; this refresh adds the last two days and marks a
-deliberate model-switch boundary: David is clearing to move Fable 5 → Opus 5).
+Started as the small task the last handoff left: seed the empty Linear `Dotfiles`
+backlog. It turned into a CodeRabbit governance consolidation after David asked to
+sweep every project for CodeRabbit references and globalize the rules. Six PRs
+merged (#168–#173), all reviewed. The previous arc (Linear migration, eleven-agent
+fleet, Moshi, ShipSigma) is now fully closed out.
 
-## What We Built (since #162)
+## What We Built
 
-- **Moshi connect failure diagnosed** — not Moshi: the iPhone was off the tailnet
-  (last seen 22h). Fix = toggle Tailscale on the phone. Mac side verified healthy
-  (sshd, moshi key, mosh-server, firewall disabled).
-- **Stale Tailscale Funnel on this Mac found and cleared** — Funnel was publicly
-  mapping `zs-macbook-pro.tail31dc0a.ts.net` → 127.0.0.1:18789 with *nothing
-  listening*: a loaded gun (any future bind of 18789 would've been public).
-  `tailscale serve reset` with David's approval; serve config now empty.
-- **ce-handoff adoption verdict (ce-pov, Tier 1): Reject supersede.** dv:handoff
-  + dv:pickup stay the daily ritual (repo-tracked, PR'd, zero-question orient);
-  ce-handoff's default store is impermanent /tmp and its resume ceremony is
-  friction here — but it owns the cross-boundary-transfer lane (another
-  agent/machine, resume-from-anything).
-- **Four piecemeal adoptions specced for the dv plugin** (source: ~/Projects/skills,
-  the skills ⚒ agent's turf): (A) frontmatter metadata + commit-anchored staleness
-  in pickup — *this very handoff demonstrates the frontmatter*, (B) prose
-  redaction pass, (C) pointer-first bodies, (D) drift-led orientation. Spec is a
-  SETUP-ONLY mission (orient → create Linear project "Skills" + tickets A–E →
-  report and stop); David pastes it to the skills agent (last copied to clipboard
-  2026-08-24).
+- **PR #171 — the CodeRabbit reconciliation, the centerpiece.** Global CLAUDE.md's
+  "Code Review" section is now the single source of truth: CodeRabbit primary,
+  `dv:gauntlet` escalation. Read the section before touching any per-repo review
+  rule; the whole point was ending the duplication.
+- **PR #172 — two rules from the skills session's workout of #171** (nine PRs, 35
+  findings): never push mid-review, and anchor session continuity on the handoff's
+  `head`. Both live in the same global section.
+- **PR #170 — `BAR_CELLS` 10→20** (`claude/statusline-command.sh:53`). David picked
+  20 from rendered previews at 10/15/20. The comment there records what widening
+  actually buys, which is *not* what the ticket claimed — see What Didn't Work.
+- **PR #173 — dropped the project-scoped `dv` pin.** dotfiles had `dv` at both user
+  scope (0.4.0) and project scope (0.3.0, pinned 2026-08-07); project wins, so every
+  session here silently ran 0.3.0. `.coderabbit.yaml` (new, repo root) sets
+  `auto_incremental_review: false`.
+- **PRs #168/#169 — mid-session handoff correction and the continuity reorder.**
+  #168 is the precedent for fixing HANDOFF mid-session rather than waiting for the
+  next `dv:handoff` run.
+- **Linear:** VIL-83 **Done** (closed by #172). VIL-82 retitled and **blocked** —
+  it carries a 30-second recheck procedure for the next Claude Code version bump.
+  ShipSigma KPI: VIL-17→20 **Canceled**, project Canceled with a note, VIL-21 left
+  Done because it shipped.
+- **Two handoff changelists** at
+  `/private/tmp/claude-505/-Users-dvillavicencio-Projects-Personal-dotfiles/0cfd7da4-.../scratchpad/`
+  — `changelist-skills.md` and `changelist-borealis.md`. Scratchpad is session-scoped
+  and may be swept; both are reproducible from #171's diff if gone.
 
-## What's Next (recommended order for the fresh session)
+## Decisions Made
 
-1. ~~Rebuild the `dotfiles ~` pane (w1)~~ — **done 2026-08-24 (#165).** The real
-   state was worse than "old `exec claude` shape": the exported pane node had no
-   `command` at all (bare shell with claude started inside), so it detected fine
-   but a server restart would have returned an empty shell. Rebuilt via
-   `layout.apply` onto the existing tab; diagnosis + exact invocation are now in
-   CLAUDE.md's Herdr section. **Verified 2026-08-24 at pickup:** `layout.export`
-   for w1 returns pane `w1:p7` carrying the full template `command`
-   (`/bin/zsh -l -c "claude; exec /bin/zsh -il"`) with the dotfiles cwd, and the
-   workspace label still reads `dotfiles ~`. Not degraded; survives a restart.
-2. ~~Seed the Linear "Dotfiles" project backlog~~ — **done 2026-08-24.** Two
-   tickets, not three: **VIL-82** (statusline — a live side-by-side against the
-   app's usage panel confirmed `5h 3%` / `7d 44%` are *accurate*, so the ticket
-   is coverage, not correctness: add the missing third meter, the premium-model
-   weekly bar the app shows at 76%, plus the `BAR_CELLS` 10→20 widening and
-   optional `refreshInterval`) and **VIL-83** (CLAUDE.md session-continuity
-   rule). Touch ID `sudo_local` on the work Mac was dropped as not needed.
-   VIL-83's premise was corrected while writing it: prefer the frontmatter
-   `head` *commit timestamp* — verifiable, survives checkout — over both mtime
-   and `created_at`, because this very handoff's `created_at` was ~9 minutes
-   ahead of reality and less accurate than its own mtime.
-3. **Pick up VIL-82 or VIL-83.** VIL-82 opens with a verification step: capture
-   one live statusline stdin payload and confirm which `rate_limits` key backs
-   the app's "Fable" row (`seven_day_opus` is the plausible but unconfirmed
-   candidate; `seven_day_sonnet` / `seven_day_overage_included` /
-   `seven_day_oauth_apps` are the other siblings the 2.1.241 bundle exposes).
-   VIL-83 is coupled to skills ticket A, which is underway now.
-4. Passive: herdr upstream #2960/#2961/#2966.
+- **CodeRabbit is the primary PR reviewer; `dv:gauntlet` is the escalation** — David's
+  call, replacing the 2026-08-18 "trial, no decision yet" state. Gauntlet keeps three
+  lanes: large/risky diffs, CodeRabbit throttled and can't wait, and non-PR review.
+- **Global + dotfiles only; borealis and skills got changelists, not commits.** They
+  are other agents' repos and the skills agent was mid-task — one writer per tree.
+- **`head` ranks above `created_at`** in the continuity rule, deviating from the
+  wording the skills session suggested. dv 0.4.0's handoff skill stamps `created_at`
+  from the shell (`skills/handoff/SKILL.md:73`), so it is trustworthy *going forward*,
+  but pre-0.4.0 values were model-authored. `head` also survives rebase/checkout.
+  The caveat is scoped to pre-0.4.0 so it retires itself.
+- **ShipSigma closed as Canceled, not Done** — it was not delivered as specced; the
+  work moved to Brittanie's laptop.
+- **Merged #170 over a stale `CHANGES_REQUESTED`** — David corrected this, and the
+  correction became the rule in #172. Recorded here as the origin of that rule.
+
+## What Didn't Work
+
+- **The Fable/premium-model statusline meter cannot be built.** A captured live
+  payload has exactly two entries under `rate_limits` — `five_hour` and `seven_day`.
+  `seven_day_opus` / `seven_day_sonnet` exist in the 2.1.241 bundle but serve the API
+  rate-limit and warning paths, never the statusline. Not fixable by updating:
+  2.1.241 is latest. The negative is trustworthy — the premium limit was at 76%, the
+  most interesting of the three, and still absent.
+- **My quantization reasoning was wrong twice**, both caught by CodeRabbit. 3%/7% do
+  *not* collide at 10 cells (they differ, and collide at 20); 12%/15% differ at both
+  widths; the low end *does* generally improve. Check claims against
+  `(pct * BAR_CELLS + 50) / 100` rather than reasoning about them.
+- **"Prefer `created_at` over mtime" was the wrong premise** for VIL-83. The observed
+  bad value was model-authored, so the fix belonged upstream in `dv:handoff` — which
+  is where it shipped (VIL-76, dv 0.4.0).
+
+## What's Next
+
+1. **Paste the skills changelist, then the borealis one.** Skills first: it ships PRs
+   actively, so the new rules bite there soonest. Borealis has the one functional gap
+   — no `.coderabbit.yaml`, so every push there still auto-re-reviews off the shared
+   pool.
+2. **Restart sessions to pick up dv 0.4.0.** Every project inherits it from user scope
+   now. This is what makes `dv:pickup` report "N commits since `<head>`" instead of
+   guessing from file age.
+3. **VIL-82 stays blocked** — no action until a Claude Code version bump; the recheck
+   is on the ticket.
+4. Housekeeping, both harmless: `claude plugin prune` clears a dead project pin for a
+   herdr worktree that no longer exists; the VPS `axiom` user still has dv **0.1.0**
+   (the live Axiom agent runs as `node` and has 0.4.0, so nothing is broken).
 
 ## Gotchas & Watch-outs
 
-- Model-switch mechanics: cache is per-model; the boundary (clear → switch →
-  pickup) is the cheap path. Done deliberately this session.
-- **ShipSigma KPI is closed (2026-08-24).** Work deviated considerably and moved
-  onto Brittanie's laptop, so VIL-17→20 are **Canceled** (not Done — it was not
-  delivered as specced) and the Linear project is Canceled with a note; VIL-21
-  stays Done, it shipped. No report-back is pending; stop treating it as gated.
-  The local-only `~/Projects/shipsigma-kpi` package survives as salvage — its
-  rule still holds if you ever reopen it: structure/names in git, never target
-  values, and `HANDOFF-brittanie-setup.md` is generated from `package/` — edit
-  sources, regenerate, re-pbcopy.
-- Orrery repo: PR flow, never force-add `src/data/dashboard.json`, no pre-commit
-  hook there.
-- Do NOT reintroduce a phone gateway (Moshi is SSH/mosh direct; Conduit teardown
-  reversal tarball: `/home/node/.hermes/backups/conduit-teardown-20260821-144904.tgz`).
-- Linear MCP tools are deferred (ToolSearch first); real newlines in markdown
-  params. Fleet roster + jump keys: table in CLAUDE.md Herdr section.
+- **Naming a `VIL-…` id in a PR body can auto-close that issue on merge.** #168 merely
+  *recapped* VIL-82 and closed it 13 seconds after merge, auto-assigning it. VIL-83,
+  named in the same body, was untouched — so the trigger is narrower than "any id" but
+  not predictable. After merging any PR naming ticket ids, re-check their states. Now
+  in global CLAUDE.md's Linear section.
+- **CodeRabbit limits are per *developer*, not per repo** — 10/hr, confirmed Pro+ from
+  the bot's own review footer. Every repo and parallel agent draws from the same 10.
+  `@coderabbitai rate limit` reports capacity without consuming a review.
+- **Three CodeRabbit check states pass while no review ran**: `pending`,
+  `Review rate limited`, and `Review skipped: incremental reviews are disabled`. So
+  `mergeStateStatus: CLEAN` is never evidence of review.
+- **`.coderabbit.yaml` applies from the PR head, not the base** — a PR adding it
+  governs itself immediately.
+- **This repo squash-merges every PR, which orphans a handoff's `head`.** An orphaned
+  SHA still returns a *believable* commit count (verified: reported 3 when the true
+  distance was 5) — it fails silently. dv 0.4.0's pickup already guards this with
+  `cat-file -e` + `merge-base --is-ancestor`; don't hand-roll a count without both.
+- **`HANDOFF.md` is tracked in this repo, so the handoff commit rides a branch** per
+  the standing never-commit-to-master rule. The `dv:handoff` skill's auto-commit block
+  assumes committing on the current branch — on `master` that would violate the rule,
+  so branch first.
+- Fleet roster, jump keys, and the herdr pane template: CLAUDE.md's Herdr section.
+  Passive upstream: herdr #2960/#2961/#2966.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -2,7 +2,7 @@
 created_at: "2026-08-25T09:08:30-07:00"
 branch: "master"
 head: "289225d"
-resume_focus: "Paste the skills changelist (scratchpad, or regenerate), then the borealis one — both repos still carry pre-reconciliation CodeRabbit rules"
+resume_focus: "Paste the skills changelist, then the borealis one (both in ~/Obsidian/dotfiles/) — those repos still carry pre-reconciliation CodeRabbit rules"
 ---
 
 # HANDOFF — 2026-08-25, morning (PDT)

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -36,10 +36,11 @@ fleet, Moshi, ShipSigma) is now fully closed out.
   it carries a 30-second recheck procedure for the next Claude Code version bump.
   ShipSigma KPI: VIL-17→20 **Canceled**, project Canceled with a note, VIL-21 left
   Done because it shipped.
-- **Two handoff changelists** at
-  `/private/tmp/claude-505/-Users-dvillavicencio-Projects-Personal-dotfiles/0cfd7da4-.../scratchpad/`
-  — `changelist-skills.md` and `changelist-borealis.md`. Scratchpad is session-scoped
-  and may be swept; both are reproducible from #171's diff if gone.
+- **Two handoff changelists**, durable in the vault:
+  `~/Obsidian/dotfiles/coderabbit-changelist-skills.md` and
+  `coderabbit-changelist-borealis.md`. Paste with
+  `pbcopy < ~/Obsidian/dotfiles/coderabbit-changelist-skills.md`. Each is
+  self-contained — the receiving agent needs no context from this session.
 
 ## Decisions Made
 
@@ -76,10 +77,10 @@ fleet, Moshi, ShipSigma) is now fully closed out.
 
 ## What's Next
 
-1. **Paste the skills changelist, then the borealis one.** Skills first: it ships PRs
-   actively, so the new rules bite there soonest. Borealis has the one functional gap
-   — no `.coderabbit.yaml`, so every push there still auto-re-reviews off the shared
-   pool.
+1. **Paste the skills changelist, then the borealis one** (vault paths above). Skills
+   first: it ships PRs actively, so the new rules bite there soonest. Borealis has the
+   one functional gap — no `.coderabbit.yaml`, so every push there still
+   auto-re-reviews off the shared pool.
 2. **Restart sessions to pick up dv 0.4.0.** Every project inherits it from user scope
    now. This is what makes `dv:pickup` report "N commits since `<head>`" instead of
    guessing from file age.
@@ -108,9 +109,10 @@ fleet, Moshi, ShipSigma) is now fully closed out.
   SHA still returns a *believable* commit count (verified: reported 3 when the true
   distance was 5) — it fails silently. dv 0.4.0's pickup already guards this with
   `cat-file -e` + `merge-base --is-ancestor`; don't hand-roll a count without both.
-- **`HANDOFF.md` is tracked in this repo, so the handoff commit rides a branch** per
-  the standing never-commit-to-master rule. The `dv:handoff` skill's auto-commit block
-  assumes committing on the current branch — on `master` that would violate the rule,
-  so branch first.
+- **Docs and small changes may now go straight to `master`** (David, 2026-08-25),
+  relaxing the previous never-commit-to-master standing order. Behavior and config
+  changes still ride a branch and PR. This handoff was PR'd (#174) because it was
+  written before the relaxation; the next one can commit directly, which also means
+  the `dv:handoff` skill's own auto-commit block is now fine to let run.
 - Fleet roster, jump keys, and the herdr pane template: CLAUDE.md's Herdr section.
   Passive upstream: herdr #2960/#2961/#2966.


### PR DESCRIPTION
Session handoff for 2026-08-25. The session began with the previous handoff's small task — seed the empty Linear `Dotfiles` backlog — and became a CodeRabbit governance consolidation after a sweep of every project's review rules.

Six PRs merged this session (#168–#173), all reviewed. Highlights captured in the handoff:

- **The reconciliation** (#171) — global CLAUDE.md's Code Review section is now the single source of truth; CodeRabbit primary, `dv:gauntlet` escalation.
- **Two rules from the skills session** (#172) — never push mid-review, and anchor continuity on the handoff's `head`.
- **What didn't work** — the Fable statusline meter is blocked upstream (the field isn't in the payload and 2.1.241 is latest), and my quantization reasoning was wrong twice, both caught in review.
- **The origin of the never-merge-on-stale-verdict rule** — I merged #170 over a stale `CHANGES_REQUESTED`; David corrected it, and that became the rule.

Two items carry forward: the skills and borealis changelists still need pasting, and sessions need a restart to pick up dv 0.4.0.

Committed on a branch rather than through the skill's auto-commit block, which would have landed on `master` — `HANDOFF.md` is tracked here, so the standing branch rule covers it. That's now recorded in the handoff's gotchas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYV7xcms9d9Mpiod1QoNvm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated handoff guidance with durable references for skills and Borealis changelists.
  * Added copy instructions and consolidated project status into a self-contained handoff.
  * Clarified when documentation and small changes may be committed directly, and when branches and pull requests are required.
  * Updated next-step instructions to reflect the latest workflow, including the option to use the automated handoff commit flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->