### PR TITLE
feat(herdr): add vice ♠ — first local Hermes agent pane

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,6 +261,9 @@ install via Homebrew casks in `brew/Brewfile`, not a helper.)
   need no shim — herdr detects a local claude pane natively; they use the pane
   template above, whose login shell rebuilds PATH from `zshenv` before claude
   starts (the server spawns pane commands with its bare launchd env).
+  `vice ♠` is the first local **hermes** pane — the same template with
+  `hermes chat` in place of `claude`; herdr's hermes manifest detects the
+  venv process natively, so it needs no shim either.
   A pane whose `layout.export` node has no `command` is degraded even though it
   still detects as an agent; rebuild it with `layout.apply` over the socket
   (recipe in CLAUDE.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,6 +375,15 @@ conversations across server restarts via `claude --resume <id>`.
     | `orrery ☉` | `~/.forge-projects/tranquil-dune` (aka `~/Projects/orrery`) | Forge-resident jobs dashboard (orrery.ui8.dev) — see "Forge-resident hybrid agents" below | `prefix+y` (`o`/`shift+o` are open_notification_target / obscura; `y` as in orrer**y**) |
     | `vice ♠` | `~/Obsidian/vice` | Vice Gage — native local **Hermes** agent (personal media curation; Obscura + Eagle MCPs). Pane command is the template with `hermes chat` in place of `claude`; herdr's hermes detection manifest identifies the venv process natively, no shim (verified 2026-08-25). Setup brief: `~/Projects/agents/docs/plans/2026-08-25-001-…` | `prefix+shift+v` (plain `v` is split-vertical's default) |
 
+    Rebuilding the `vice ♠` pane after a degraded restore (#2966) follows the
+    standard recipe above with this pane node, then `herdr agent rename` (renames
+    don't survive pane recreation, and the jump key targets the agent name):
+
+    ```bash
+    echo '{"id":"1","method":"layout.apply","params":{"tab_id":"<wN:tN>","focus":true,"root":{"type":"pane","cwd":"'"$HOME"'/Obsidian/vice","command":["/bin/zsh","-l","-c","hermes chat; exec /bin/zsh -il"]}}}' | nc -U ~/.config/herdr/herdr.sock
+    /opt/homebrew/bin/herdr agent rename <pane-id> vice
+    ```
+
 - **Forge-resident hybrid agents** (SOP, established 2026-08-20 with `orrery ☉`).
   For a project that legitimately *stays* in Forge — UI-heavy, actually using
   Forge's stories canvas / dev server / publishing — but wants plain Claude Code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -373,6 +373,7 @@ conversations across server restarts via `claude --resume <id>`.
     | `obscura ✇` | `~/Projects/browse-gateway` | the Obscura browse-gateway itself | `prefix+shift+o` |
     | `eidos ❖` | `~/Projects/eidos` | Eagle library curation | `prefix+shift+i` (`e`/`shift+e` are edit_scrollback / remove_worktree) |
     | `orrery ☉` | `~/.forge-projects/tranquil-dune` (aka `~/Projects/orrery`) | Forge-resident jobs dashboard (orrery.ui8.dev) — see "Forge-resident hybrid agents" below | `prefix+y` (`o`/`shift+o` are open_notification_target / obscura; `y` as in orrer**y**) |
+    | `vice ♠` | `~/Obsidian/vice` | Vice Gage — native local **Hermes** agent (personal media curation; Obscura + Eagle MCPs). Pane command is the template with `hermes chat` in place of `claude`; herdr's hermes detection manifest identifies the venv process natively, no shim (verified 2026-08-25). Setup brief: `~/Projects/agents/docs/plans/2026-08-25-001-…` | `prefix+shift+v` (plain `v` is split-vertical's default) |
 
 - **Forge-resident hybrid agents** (SOP, established 2026-08-20 with `orrery ☉`).
   For a project that legitimately *stays* in Forge — UI-heavy, actually using

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -187,6 +187,13 @@ type = "shell"
 command = "/opt/homebrew/bin/herdr agent focus orrery"
 description = "jump to Orrery"
 
+[[keys.command]]
+# plain v is split-vertical's default, so Vice takes shift+v.
+key = "prefix+shift+v"
+type = "shell"
+command = "/opt/homebrew/bin/herdr agent focus vice"
+description = "jump to Vice"
+
 # Legacy indexed shortcut config is still parsed for compatibility.
 # Prefer switch_tab, switch_workspace, and focus_agent for new configs.
 # [keys.indexed]


### PR DESCRIPTION
Adds the `vice ♠` fleet entry per the herdr SOP:

- `herdr/config.toml`: `[[keys.command]]` jump key `prefix+shift+v` → `herdr agent focus vice` (absolute path per the launchd-PATH rule; plain `v` is split-vertical's default).
- `CLAUDE.md` / `AGENTS.md`: roster row + note that this is the first local **hermes** pane — the standard template with `hermes chat` in place of `claude`, and herdr's hermes manifest detects the venv process natively (no shim; verified live 2026-08-25).

The workspace itself was created live over the socket (`workspace.create` + `layout.apply`, pane cwd `~/Obsidian/vice`, agent renamed `vice`); this PR tracks the config + docs so a rebuild reproduces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011r11DbhGUtzywHicrNmp1D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Vice local agent to the available agent roster.
  - Added a keyboard shortcut (`prefix+shift+v`) to quickly focus the Vice agent.
  - Documented Vice’s Hermes chat workflow and supported integrations.

- **Documentation**
  - Added setup and usage details for the Vice agent, including its project location and native environment detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
**CodeRabbit triage** (review completed, verdict COMMENTED, 2 actionable):
- **Finding 1 (Major)** — partially applied: the vice-specific pane-rebuild recipe (`layout.apply` node + `agent rename` reapply) is now in CLAUDE.md's roster (second commit). The $BREW_PREFIX half declined: `[[keys.command]]` runs in herdr's bare launchd env where `BREW_PREFIX` doesn't exist — absolute paths are this repo's documented rule for that context (herdrdev/herdr#2960).
- **Finding 2 (Minor)** — declined at both sites, reasons on the threads: same launchd-env constraint for config.toml; the CLAUDE.md roster row uses portable `~` paths consistent with the whole table.

No re-review requested for the second commit — docs-only delta addressing finding 1, declines recorded here and on the threads.