### PR TITLE
chore(zsh): drop vestigial NVM shims; correct the "globals need a shim" rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,9 +115,9 @@ POSIX `. ` sourcing → the `[[ -f … ]] &&` guard pattern before committing.
 4. `dot doctor` also reports unmet Brewfile entries. Commit `brew/Brewfile`.
 
 ### Add a global npm CLI
-Add it to `npm/npm-requirements.txt`. If the CLI must be on `PATH` before `node` is first
-called, add an NVM lazy-loader shim in `zshrc` (see below) — otherwise it won't resolve
-until the loader fires.
+Add it to `npm/npm-requirements.txt` (registry-installable packages only — an `npm link`ed
+local package like `browse-gateway`/`obscura` cannot be installed from that manifest). It is
+already on `PATH` in a fresh shell via the lazy-loader's node-bin prepend; no shim needed.
 
 ### Add an Oh My Zsh plugin
 Add it to the `plugins=()` list in `zshrc` **and** add the matching `git clone` to
@@ -128,9 +128,11 @@ Copy an existing `_load_X` block. Direct-sourcing heavy tools (NVM alone is +200
 blows the shell-startup budget — the lazy pattern keeps `zsh -i -c exit` under 300 ms.
 Use `command <tool>` (not bare `<tool>`) after `_load_*` to avoid infinite shim recursion.
 
-### Add a global CLI behind the NVM shim
-NVM is lazy-loaded. Add the CLI's name to the `unset -f` line in `_load_nvm()` and add a
-`<tool>() { _load_nvm; <tool> "$@"; }` shim. Current shims: `nvm node npm npx bb browse`.
+### NVM lazy-loader shims
+A globally-installed npm CLI needs **no** NVM shim — the lazy-loader block prepends the default
+node version's `bin` dir to `PATH` at startup, and `#!/usr/bin/env node` shebangs resolve through
+it, so the CLI works in a fresh shell with nvm unloaded. Only add a shim for a global installed
+under a NON-default node version. Current shims: `nvm node npm npx` (nvm's own commands).
 (`claude` needs no shim — it is not an npm global; `helpers/install_claude_code.sh`
 installs it via Anthropic's native installer to `~/.local/bin/claude`, which `zshenv`
 puts ahead of Homebrew on `PATH`. The Brewfile does not manage it — the Homebrew cask

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,8 +116,10 @@ POSIX `. ` sourcing → the `[[ -f … ]] &&` guard pattern before committing.
 
 ### Add a global npm CLI
 Add it to `npm/npm-requirements.txt` (registry-installable packages only — an `npm link`ed
-local package like `browse-gateway`/`obscura` cannot be installed from that manifest). It is
-already on `PATH` in a fresh shell via the lazy-loader's node-bin prepend; no shim needed.
+local package like `browse-gateway`/`obscura` cannot be installed from that manifest). If it
+was installed under the **highest installed** node version — the usual case — it is already on
+`PATH` in a fresh shell via the lazy-loader's node-bin prepend and needs no shim. See the
+shim section below for the exception.
 
 ### Add an Oh My Zsh plugin
 Add it to the `plugins=()` list in `zshrc` **and** add the matching `git clone` to
@@ -132,7 +134,9 @@ Use `command <tool>` (not bare `<tool>`) after `_load_*` to avoid infinite shim 
 A globally-installed npm CLI needs **no** NVM shim — the lazy-loader block prepends the default
 node version's `bin` dir to `PATH` at startup, and `#!/usr/bin/env node` shebangs resolve through
 it, so the CLI works in a fresh shell with nvm unloaded. Only add a shim for a global installed
-under a NON-default node version. Current shims: `nvm node npm npx` (nvm's own commands).
+under a node version other than the highest installed one — the prepend resolves
+`sort -V | tail -1`, NOT nvm's `alias/default`, and the two can diverge.
+Current shims: `nvm node npm npx` (nvm's own commands).
 (`claude` needs no shim — it is not an npm global; `helpers/install_claude_code.sh`
 installs it via Anthropic's native installer to `~/.local/bin/claude`, which `zshenv`
 puts ahead of Homebrew on `PATH`. The Brewfile does not manage it — the Homebrew cask

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,13 +164,21 @@ When adding a new lazy loader, copy an existing one as a template. Never duplica
 logic across multiple wrapper functions. Use `command <tool>` (not bare `<tool>`) after
 `_load_*` to prevent infinite recursion when the shim name matches the binary name.
 
-### NVM lazy loader shims
-NVM is lazy-loaded for startup speed. Any npm-globally-installed CLI (e.g., `claude`) must be
-added as a shim in the NVM lazy loader block in `zshrc`, or it won't be on PATH until `node`
-is first called. When adding a new global CLI: add its name to the `unset -f` line in `_load_nvm()`
-and add a `<tool>() { _load_nvm; <tool> "$@"; }` shim.
+### NVM lazy loader shims — globals do NOT need one
+NVM is lazy-loaded for startup speed. **A globally-installed npm CLI does not need a shim.**
+The block prepends the default node version's `bin` dir to `PATH` at shell startup, and these
+CLIs are `#!/usr/bin/env node` shebangs that resolve through that same prepend — so they work
+in a fresh shell with nvm still unloaded. Verified 2026-08-25: in `zsh -i`, `obscura` resolves
+to its real path while `_load_nvm` is still defined (i.e. nvm was never sourced).
 
-Current shims: `nvm`, `node`, `npm`, `npx`, `bb`, `browse`.
+An earlier version of this section claimed the opposite, and that error outlived the fact:
+the PATH prepend landed 2026-03-11 (`83968b9`), but `bb`/`browse` shims were still added
+2026-05-07 (`5ed5c28`) and bought nothing except a needless 200–400 ms `nvm.sh` source on
+first call. Both were removed 2026-08-25 along with their retired Browserbase packages.
+
+Current shims: `nvm`, `node`, `npm`, `npx` — nvm's own management commands, which genuinely
+need `nvm.sh` sourced. **The one case that does need a shim** is a global installed under a
+NON-default node version, which the prepend does not cover.
 
 Note: `claude` does not need an NVM shim — it is not an npm global. `helpers/install_claude_code.sh`
 installs it via Anthropic's native installer (`curl -fsSL https://claude.ai/install.sh | bash`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ logic across multiple wrapper functions. Use `command <tool>` (not bare `<tool>`
 
 ### NVM lazy loader shims — globals do NOT need one
 NVM is lazy-loaded for startup speed. **A globally-installed npm CLI does not need a shim.**
-The block prepends the default node version's `bin` dir to `PATH` at shell startup, and these
+The block prepends the highest installed node version's `bin` dir to `PATH` at shell startup, and these
 CLIs are `#!/usr/bin/env node` shebangs that resolve through that same prepend — so they work
 in a fresh shell with nvm still unloaded. Verified 2026-08-25: in `zsh -i`, `obscura` resolves
 to its real path while `_load_nvm` is still defined (i.e. nvm was never sourced).
@@ -178,7 +178,13 @@ first call. Both were removed 2026-08-25 along with their retired Browserbase pa
 
 Current shims: `nvm`, `node`, `npm`, `npx` — nvm's own management commands, which genuinely
 need `nvm.sh` sourced. **The one case that does need a shim** is a global installed under a
-NON-default node version, which the prepend does not cover.
+version other than the highest installed one, which the prepend does not cover.
+
+**The prepend picks the highest installed version, not nvm's `alias/default`** (`sort -V |
+tail -1`). Both resolve to v24.13.0 on this Mac, but seven versions are installed and nothing
+keeps them aligned: point the alias at an older version and PATH still carries the highest,
+while `_load_nvm` — once anything triggers it — sources `nvm.sh`, applies the alias, and
+switches `node` mid-shell. Worth knowing before trusting either as "the" node version.
 
 Note: `claude` does not need an NVM shim — it is not an npm global. `helpers/install_claude_code.sh`
 installs it via Anthropic's native installer (`curl -fsSL https://claude.ai/install.sh | bash`)

--- a/npm/npm-requirements.txt
+++ b/npm/npm-requirements.txt
@@ -1,5 +1,14 @@
-@browserbasehq/browse-cli
-@browserbasehq/cli
+# Global npm packages installed by helpers/install_node.sh (comments are stripped).
+# Only registry-installable packages belong here.
+#
+# NOT listed, deliberately:
+#   browse-gateway (the `obscura` CLI) — an `npm link` from ~/Projects/browse-gateway,
+#   not a registry package, so it cannot be installed from this manifest. It comes
+#   from that repo; `npm ls -g` shows it as a symlink.
+#
+# Removed 2026-08-25: @browserbasehq/cli + @browserbasehq/browse-cli (the `bb` and
+# `browse` CLIs). Browserbase was retired 2026-08-07 in favour of Obscura; a fresh
+# machine should not reinstall them.
 bash-language-server
 corepack
 npm

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -139,11 +139,17 @@ if [[ -s "$NVM_DIR/nvm.sh" ]]; then
   unset DEFAULT_NODE_PATH
 
   # Only nvm's own management commands get shims. A globally-installed CLI does
-  # NOT need one: the PATH prepend above already puts the default node version's
-  # bin dir on PATH, and these CLIs are `#!/usr/bin/env node` shebangs that
-  # resolve through that same prepend. A shim would only force a needless
-  # nvm.sh source (200-400ms) on first call. The exception is a global installed
-  # under a NON-default node version, which the prepend does not cover.
+  # NOT need one: the PATH prepend above already puts the HIGHEST INSTALLED node
+  # version's bin dir on PATH, and these CLIs are `#!/usr/bin/env node` shebangs
+  # that resolve through that same prepend. A shim would only force a needless
+  # nvm.sh source (200-400ms) on first call.
+  #
+  # Note the prepend selects the highest installed version (`sort -V | tail -1`),
+  # NOT nvm's `alias/default`. They agree on both Macs today, but if the alias is
+  # ever pointed at an older version they diverge, and a global installed under
+  # that version is off PATH until nvm loads (at which point sourcing nvm.sh
+  # applies the alias and switches node mid-shell). A global under any
+  # non-highest version is the one case that does need a shim.
   _load_nvm() {
     unset -f _load_nvm nvm node npm npx
     source "$NVM_DIR/nvm.sh"

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -138,8 +138,14 @@ if [[ -s "$NVM_DIR/nvm.sh" ]]; then
   [[ -d "$DEFAULT_NODE_PATH" ]] && export PATH="$DEFAULT_NODE_PATH:$PATH"
   unset DEFAULT_NODE_PATH
 
+  # Only nvm's own management commands get shims. A globally-installed CLI does
+  # NOT need one: the PATH prepend above already puts the default node version's
+  # bin dir on PATH, and these CLIs are `#!/usr/bin/env node` shebangs that
+  # resolve through that same prepend. A shim would only force a needless
+  # nvm.sh source (200-400ms) on first call. The exception is a global installed
+  # under a NON-default node version, which the prepend does not cover.
   _load_nvm() {
-    unset -f _load_nvm nvm node npm npx bb browse
+    unset -f _load_nvm nvm node npm npx
     source "$NVM_DIR/nvm.sh"
     [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
   }
@@ -147,8 +153,6 @@ if [[ -s "$NVM_DIR/nvm.sh" ]]; then
   node()   { _load_nvm; command node "$@"; }
   npm()    { _load_nvm; command npm "$@"; }
   npx()    { _load_nvm; command npx "$@"; }
-  bb()     { _load_nvm; command bb "$@"; }
-  browse() { _load_nvm; command browse "$@"; }
 fi
 
 # Lazy load RVM


### PR DESCRIPTION
## What & why

Follow-up 1 was filed as *"add `obscura` to the NVM lazy-loader shims — it's invisible in fresh shells until `node` runs."* **That premise is wrong**, and the repo's own docs are what made it look right.

The lazy-loader block already prepends the default node version's `bin` dir to `PATH` at shell startup, and these CLIs are `#!/usr/bin/env node` shebangs that resolve through that same prepend.

```
$ zsh -i -c 'command -v obscura; typeset -f _load_nvm >/dev/null && echo "nvm NOT loaded"'
/Users/…/.config/nvm/versions/node/v24.13.0/bin/obscura
nvm NOT loaded
```

`obscura` resolves while nvm is still unloaded. No shim was ever needed — so this PR *closes* follow-up 1 rather than implementing it.

## The shims that were there

`git log -S` dates the mistake: the PATH prepend landed **2026-03-11** (`83968b9`), but the `bb`/`browse` shims were added **2026-05-07** (`5ed5c28`) — two months later, into a shell where they were already redundant. They bought nothing except forcing a needless 200–400 ms `nvm.sh` source on first call, and they shimmed the **Browserbase** CLIs, retired 2026-08-07 in favour of Obscura.

## Changes

- **`zsh/zshrc`** — drop the `bb`/`browse` shims + their `unset -f` entries; add a comment so they don't get re-added. Kept `nvm`/`node`/`npm`/`npx`, which genuinely need `nvm.sh` sourced.
- **`npm/npm-requirements.txt`** — drop `@browserbasehq/cli` + `@browserbasehq/browse-cli` so a fresh machine stops installing retired tooling. Also records why `browse-gateway` (the `obscura` CLI) is *absent*: `npm ls -g` shows it as a symlink — it's an `npm link` from `~/Projects/browse-gateway`, **not a registry package**, so it could never be installed from this manifest.
- **`CLAUDE.md` / `AGENTS.md`** — the rule claimed every npm global *"must be added as a shim … or it won't be on PATH"*, in **three** places. Corrected to the real rule, keeping the one genuine exception: a global installed under a **non-default** node version, which the prepend does not cover.

## Verification

- `dot check` — clean (shellcheck, `zsh -n`, py_compile, dotbot dry-run parse)
- `zsh -i -c exit` — 270/280/290 ms, under the repo's 300 ms target
- fresh `zsh -i`: `obscura` resolves; `node` is still a lazy shim; `bb` now resolves straight to its real binary and still runs — which is itself the proof the shim was redundant

## Note

Unrelated to this diff, but found while checking for live consumers: the `fetch` skill on this Mac is still fully Browserbase-shaped (`curl https://api.browserbase.com/v1/fetch` + `BROWSERBASE_API_KEY`), despite the global CLAUDE.md listing it under *"Already repointed and working."* It uses the HTTP API rather than the `browse` CLI, so it doesn't block this cleanup. Flagged for a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011r11DbhGUtzywHicrNmp1D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified NVM lazy-loading behavior and that PATH prioritizes the highest installed Node version.
  * Documented differences between the selected Node version and NVM’s configured default.
  * Updated npm installation guidance, including local package handling and command shims.

* **Configuration**
  * Retired Browserbase CLI packages from global npm requirements.
  * Simplified lazy loading for supported Node and npm commands.
  * Continued support for commands installed under non-highest Node versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->