### PR TITLE
feat(herdr): "blank" indicator for a context-free pane + copy-seed settings.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,8 @@ tmux/       tmux config + status-bar scripts + window-meta persistence
 topgrade/   Topgrade system-updater config
 vale/       Vale prose linter config
 zsh/        zshenv (env/PATH/BREW_PREFIX), zshrc, alias.sh, functions.sh, functions/
-claude/     Claude Code config: CLAUDE.md, settings.json, statusline, hooks/
+claude/     Claude Code config: CLAUDE.md, statusline, hooks/ (symlinked) +
+            settings.json (COPY-SEEDED, not symlinked — see gotchas)
             (all symlinked into ~/.claude/)
 bin/        Repo CLI — bin/dot (symlinked to ~/.local/bin/dot)
             bin/lib/*.py — Python helpers for doctor/bench, deliberately NOT heredocs
@@ -288,6 +289,19 @@ install via Homebrew casks in `brew/Brewfile`, not a helper.)
   `config.toml` + the user-authored iTerm2-imported theme only — the other 24 themes are
   app-seeded and regenerate. Full write-up:
   `docs/solutions/integration-issues/otty-config-symlink-hostile-atomic-rename-2026-08-07.md`.
+- **`claude/settings.json` is copy-seeded too — do not add a `link:` entry for it.**
+  Three writers besides this repo rewrite `~/.claude/settings.json` in place: Claude Code
+  itself, `herdr integration install`, and Otty's agent-integration installer. A symlink is
+  orphaned on the first write, exactly like Otty. This already bit once — the repo copy sat
+  stale from 2026-08-07 to 2026-08-25 while the live file regrew a legacy top-level
+  `allowedTools` key (18 rules) against a `permissions.allow` of 1, silently re-arming the
+  precedence trap PR #127 had removed: when both keys exist the legacy one WINS and
+  `permissions.allow` is inert. `helpers/install_claude_settings.sh` seeds when absent and
+  `--capture` records live changes back (dropping the machine-local keys `effortLevel`,
+  `autoMode`, `mcpServers`, `allowedTools`, and normalizing `$HOME` paths to `~/`).
+  `dot drift` compares capture-normalized forms and warns if `allowedTools` reappears.
+  Agents cannot write this file — the auto-mode classifier blocks it by design; run
+  `helpers/migrate_claude_settings.py` yourself on a machine that predates the scheme.
 - **`git/gitconfig` `core.pager = vim -`** is intentional; `diff`/`show` route through
   **delta** via the `[pager]` overrides.
 - **GCM credential-helper entries** in `git/gitconfig` are auto-generated — commit them

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,9 +53,9 @@ tmux/       tmux config + status-bar scripts + window-meta persistence
 topgrade/   Topgrade system-updater config
 vale/       Vale prose linter config
 zsh/        zshenv (env/PATH/BREW_PREFIX), zshrc, alias.sh, functions.sh, functions/
-claude/     Claude Code config: CLAUDE.md, statusline, hooks/ (symlinked) +
-            settings.json (COPY-SEEDED, not symlinked — see gotchas)
-            (all symlinked into ~/.claude/)
+claude/     Claude Code config, delivered into ~/.claude/ two different ways:
+            CLAUDE.md, statusline, hooks/  → symlinked
+            settings.json                  → COPY-SEEDED, never symlinked (see gotchas)
 bin/        Repo CLI — bin/dot (symlinked to ~/.local/bin/dot)
             bin/lib/*.py — Python helpers for doctor/bench, deliberately NOT heredocs
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -480,6 +480,28 @@ conversations across server restarts via `claude --resume <id>`.
   corrected upstream). Same PATH blindness: the settings→integrations panel
   probes agent CLIs with the server env, so `codex` reads "not found" even
   when installed — `herdr integration status` from a shell is authoritative.
+- **Display-only pane metadata is a supported channel** (`pane.report_metadata`,
+  CLI `herdr pane report-metadata`). It overlays presentation without touching
+  agent identity or lifecycle: `--display-agent`, `--title`, `--state-label
+  STATUS=TEXT` (retitles a state in the `state_text` row), and `--token
+  NAME=VALUE` (max 16, `[A-Za-z0-9_-]{1,32}`, rendered as `$name` if the
+  `[ui.sidebar.agents] rows` config references it). Every field has a matching
+  `--clear-*`, and `--ttl-ms` (max 24h) makes an entry self-expiring, so a
+  missed clear can't pin a pane forever. `--state-label` is the cheap one: it
+  reuses a row this repo's config already renders, so it needs no config.toml
+  change. Verified rendering live 2026-08-25.
+  - **Claude Code's `SessionStart` hook reports how a session began** — `startup`
+    / `clear` / `resume` / `compact` — which is what makes a *context-free* pane
+    detectable. `claude/hooks/herdr-blank-state.sh` maps `startup`+`clear` to a
+    `state_labels` override reading "blank", and clears it on `UserPromptSubmit`.
+    Two traps: `SessionStart` and `UserPromptSubmit` both **inject hook stdout
+    into the model's context**, so such a hook must stay silent on stdout; and
+    subagent events carry `agent_id` and must be ignored or they clear the label
+    spuriously.
+  - **herdr already receives `session_start_source`** — its own integration hook
+    sends it on `pane.report_agent_session` — but does not surface it in the
+    session snapshot or display it anywhere. The signal is flowing and unused;
+    a native "blank" indicator is a reasonable upstream request.
 - **Scripting:** NDJSON over `~/.config/herdr/herdr.sock`; `herdr api schema`
   emits the full machine-readable surface. Gotcha: `herdr agent wait --until
   done` never fires on a *focused* pane (done = finished-but-unseen) — wait on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,31 @@ boundary to the whole directory.
 (`Transient config not yet implemented`) — every config experiment persists, so back up
 `~/.config/otty/config.toml` first.
 
+### A hook symlinked into the repo is branch-fragile — land the file before wiring it
+`~/.claude/hooks/*.sh` are Dotbot symlinks **into this working tree**, so they resolve against
+whatever branch is checked out. A hook whose file exists only on a *feature* branch goes
+dangling the moment you switch away, and Claude Code then prints a non-blocking error on
+**every** `SessionStart` and `UserPromptSubmit`, in every session, across every project:
+
+```
+SessionStart:startup hook error
+Failed with non-blocking status code: /bin/sh: ~/.claude/hooks/<hook>.sh: No such file or directory
+```
+
+Observed 2026-08-25 with `herdr-blank-state.sh`: registered in `settings.json` and symlinked
+while on its feature branch, then broken by a routine `git checkout` of an unrelated branch.
+`tmux-attention.sh` never hit this only because it has been on `master` for months.
+
+**So: do not register a hook in `settings.json` until its file is on `master`.** If you need it
+live before the PR merges, install a *copy* rather than a symlink — a copy is branch-independent:
+
+```bash
+git show <branch>:claude/hooks/<hook>.sh > ~/.claude/hooks/<hook>.sh && chmod +x ~/.claude/hooks/<hook>.sh
+```
+
+Re-run `./install` after the merge to restore the tracked symlink, which is safe once the file
+is on the default branch and therefore present on every branch cut from it.
+
 ### Claude Code `settings.json` — copy-seeded, never symlinked
 `claude/settings.json` is the **second** tracked config delivered by copy rather than a
 Dotbot `link:` (Otty is the first, above). `helpers/install_claude_settings.sh` seeds

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,47 @@ boundary to the whole directory.
 (`Transient config not yet implemented`) — every config experiment persists, so back up
 `~/.config/otty/config.toml` first.
 
+### Claude Code `settings.json` — copy-seeded, never symlinked
+`claude/settings.json` is the **second** tracked config delivered by copy rather than a
+Dotbot `link:` (Otty is the first, above). `helpers/install_claude_settings.sh` seeds
+`~/.claude/settings.json` **only when absent**, so a live config is never clobbered.
+
+**Do not "fix" this by restoring a `link:` entry.** The file has three independent writers
+besides this repo — Claude Code itself (`effortLevel`, `tui`, notification prefs, `autoMode`),
+`herdr integration install`, and Otty's agent-integration installer — each rewriting it in
+place. A symlink there survives until the first write, after which the live file is a regular
+file and the repo copy is a silently-orphaned stale twin.
+
+That already happened. The link was replaced at some point before 2026-08-25 and the repo copy
+went stale from **2026-08-07** — its last commit — while the live file drifted for eighteen days.
+Nothing surfaced it: `git status` stayed clean, because from git's side nothing had changed.
+
+**The damage was not cosmetic.** In that window the live file regrew a legacy top-level
+`allowedTools` key holding 18 rules while `permissions.allow` fell to 1 — silently re-arming the
+precedence trap PR #127 removed (see "one allowlist, not two" below). It also accumulated an
+`autoMode.environment` block naming a *different project's* trusted repo and services, in the
+cross-machine user-scope file whose own `"//"` header forbids machine- or project-specific values.
+
+Because a copy can drift, `dot drift` reports Claude settings alongside Brewfile/npm/Otty, and
+**warns loudly if `allowedTools` ever reappears**. It compares **capture-normalized** forms —
+the live file legitimately carries machine-local keys that are deliberately untracked, so a raw
+diff would report permanent un-actionable drift. To record live changes:
+
+```bash
+dot drift                                            # see what diverged
+bash helpers/install_claude_settings.sh --capture    # regenerate claude/settings.json, then commit
+```
+
+`--capture` regenerates rather than `cp`s: it drops the machine-local keys
+(`effortLevel`, `autoMode`, `mcpServers`, and `allowedTools` — which must never be tracked),
+re-prepends the tracked `"//"` header, and rewrites absolute `$HOME` paths back to `~/`
+(installers write literal `/Users/<you>/...`; Claude Code expands `~` in hook commands).
+
+**Agents cannot write this file** — the auto-mode classifier blocks it by design, so it stops an
+agent widening its own permissions. `helpers/migrate_claude_settings.py` exists for a machine
+whose settings predate this scheme (folds `allowedTools` back, registers the blank-state hook);
+it is idempotent, backs up first, and **you run it yourself**, not an agent.
+
 ### Herdr — agent multiplexer (config symlinked; writes flow back)
 `herdr` (Brewfile) is a tmux-shaped client/server multiplexer with native agent
 awareness: it detects a Claude Code pane via screen manifests, tracks
@@ -679,6 +720,15 @@ Both lists are now consolidated into `permissions.allow` in
 `claude/settings.json`. If a permission rule ever appears to be ignored, check
 for a resurrected `allowedTools` **before** assuming the auto-mode classifier is
 gating the command.
+
+**This regressed once already, and will again.** On 2026-08-25 the live
+`~/.claude/settings.json` was found with `allowedTools` back at 18 rules and
+`permissions.allow` down to 1 — #127 silently undone, because the repo copy had
+been orphaned from its symlink and nobody was comparing (see "copy-seeded, never
+symlinked" above). The consolidation lives in a file three other installers
+rewrite, so treat it as a **recurring** hazard, not a closed one: `dot drift` now
+warns whenever the legacy key reappears, and
+`helpers/migrate_claude_settings.py` folds it back.
 
 Related but distinct: the auto-mode classifier **does** independently block
 agent edits to `~/.claude/settings.json` itself, regardless of allow rules. That

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,7 +268,7 @@ whatever branch is checked out. A hook whose file exists only on a *feature* bra
 dangling the moment you switch away, and Claude Code then prints a non-blocking error on
 **every** `SessionStart` and `UserPromptSubmit`, in every session, across every project:
 
-```
+```text
 SessionStart:startup hook error
 Failed with non-blocking status code: /bin/sh: ~/.claude/hooks/<hook>.sh: No such file or directory
 ```
@@ -281,8 +281,17 @@ while on its feature branch, then broken by a routine `git checkout` of an unrel
 live before the PR merges, install a *copy* rather than a symlink — a copy is branch-independent:
 
 ```bash
-git show <branch>:claude/hooks/<hook>.sh > ~/.claude/hooks/<hook>.sh && chmod +x ~/.claude/hooks/<hook>.sh
+tmp="$(mktemp)"
+git show <branch>:claude/hooks/<hook>.sh > "$tmp" && chmod +x "$tmp" &&
+  mv -f "$tmp" ~/.claude/hooks/<hook>.sh
 ```
+
+Write to a temp file and `mv` over the destination — **do not redirect straight at the hook
+path.** When that path is still the dangling symlink, `>` follows the link and creates its
+*target*: verified 2026-08-25, the redirect **succeeds silently**, the symlink stays a
+symlink, and the content lands at the target path inside the repo working tree. So the hook
+still does not exist where Claude Code looks for it, and you have also dropped an untracked
+file into the repo. `mv -f` replaces the link itself, atomically.
 
 Re-run `./install` after the merge to restore the tracked symlink, which is safe once the file
 is on the default branch and therefore present on every branch cut from it.

--- a/claude/hooks/herdr-blank-state.sh
+++ b/claude/hooks/herdr-blank-state.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+# herdr-blank-state.sh — show "blank" in herdr's agent sidebar for a
+# context-free Claude Code pane.
+#
+# Claude Code's SessionStart hook reports how the session began:
+#   startup  fresh launch, no context      -> blank
+#   clear    /clear was run, no context    -> blank
+#   resume   --resume/--continue, has hist -> NOT blank
+#   compact  post-compaction, has context  -> NOT blank
+#
+# On a blank start we set herdr's display-only `state_labels` override so the
+# `state_text` row renders "blank" instead of "idle". UserPromptSubmit clears
+# it — the first prompt is what makes the pane non-blank.
+#
+# Deliberately writes the socket directly rather than shelling out to `herdr`:
+# no PATH dependency, one fewer process, and it mirrors herdr's own
+# integration hook (~/.claude/hooks/herdr-agent-state.sh).
+#
+# NOTE: SessionStart and UserPromptSubmit both inject hook stdout into the
+# model's context. This hook must stay silent on stdout and always exit 0.
+
+set -eu
+
+# Which SessionStart sources count as blank. Edit this list to change the rule.
+BLANK_SOURCES="startup clear"
+
+# Safety net: if a clear is ever missed, the label expires on its own rather
+# than pinning a pane at "blank" forever. 12h.
+BLANK_TTL_MS=43200000
+
+action="${1:-}"
+case "$action" in
+  start|clear) ;;
+  *) exit 0 ;;
+esac
+
+# Not inside a herdr pane -> nothing to report.
+[ "${HERDR_ENV:-}" = "1" ] || exit 0
+[ -n "${HERDR_PANE_ID:-}" ] || exit 0
+[ -n "${HERDR_SOCKET_PATH:-}" ] || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+
+hook_input_file="$(mktemp "${TMPDIR:-/tmp}/herdr-blank-hook.XXXXXX")" || exit 0
+trap 'rm -f "$hook_input_file"' EXIT HUP INT TERM
+cat >"$hook_input_file" 2>/dev/null || true
+
+HERDR_ACTION="$action" \
+HERDR_HOOK_INPUT_FILE="$hook_input_file" \
+HERDR_BLANK_SOURCES="$BLANK_SOURCES" \
+HERDR_BLANK_TTL_MS="$BLANK_TTL_MS" \
+python3 - <<'PY' >/dev/null 2>&1 || true
+import json
+import os
+import socket
+import time
+
+action = os.environ.get("HERDR_ACTION", "")
+pane_id = os.environ.get("HERDR_PANE_ID")
+socket_path = os.environ.get("HERDR_SOCKET_PATH")
+hook_input_file = os.environ.get("HERDR_HOOK_INPUT_FILE")
+blank_sources = set(os.environ.get("HERDR_BLANK_SOURCES", "").split())
+try:
+    ttl_ms = int(os.environ.get("HERDR_BLANK_TTL_MS", "43200000"))
+except ValueError:
+    ttl_ms = 43200000
+
+if not pane_id or not socket_path:
+    raise SystemExit(0)
+
+hook_input = {}
+if hook_input_file:
+    try:
+        with open(hook_input_file, encoding="utf-8") as handle:
+            content = handle.read()
+        if content.strip():
+            hook_input = json.loads(content)
+    except Exception:
+        hook_input = {}
+
+# Subagents share the pane but are not the pane's session; ignore them.
+if hook_input.get("agent_id"):
+    raise SystemExit(0)
+
+params = {
+    "pane_id": pane_id,
+    "source": "dotfiles:blank-state",
+    "seq": time.time_ns(),
+}
+
+if action == "start":
+    source = hook_input.get("source")
+    if not isinstance(source, str) or source not in blank_sources:
+        # resume / compact / anything unrecognized: the pane has context.
+        # Clear rather than no-op, so a resume over a blank pane corrects it.
+        params["clear_state_labels"] = True
+    else:
+        params["state_labels"] = {"idle": "blank"}
+        params["ttl_ms"] = ttl_ms
+else:  # clear — the first prompt means the pane is no longer blank
+    params["clear_state_labels"] = True
+
+request = {
+    "id": "dotfiles:blank-state:%d" % time.time_ns(),
+    "method": "pane.report_metadata",
+    "params": params,
+}
+
+try:
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    client.settimeout(0.5)
+    client.connect(socket_path)
+    client.sendall((json.dumps(request) + "\n").encode())
+    try:
+        client.recv(4096)
+    except Exception:
+        pass
+    client.close()
+except Exception:
+    pass
+PY
+
+exit 0

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,15 +1,14 @@
 {
   "//": "Tracked cross-machine baseline. Claude Code loads this as the user-scope ~/.claude/settings.json (lowest precedence). Keep machine-/session-specific values (model & effortLevel pins, host-specific allow rules, per-machine MCP servers) OUT of this shared file. Higher-precedence layers Claude Code loads: managed settings and CLI flags, plus per-project .claude/settings.local.json (gitignored) for project-scoped overrides. There is no user-level *.local override layer, so genuinely per-machine user settings must live on that machine's own ~/.claude/settings.json (not committed here).",
   "permissions": {
-    "defaultMode": "auto",
     "allow": [
+      "Bash(gh pr merge:*)",
       "Bash(git branch*)",
       "Bash(git log*)",
       "Bash(git status*)",
       "Bash(git diff*)",
       "Bash(gh pr list*)",
       "Bash(gh pr view*)",
-      "Bash(gh pr merge:*)",
       "Bash(ls*)",
       "Bash(cat*)",
       "Bash(which*)",
@@ -21,41 +20,26 @@
       "Bash(npm uninstall*)",
       "Bash(claude *)",
       "Bash(tmux -V*)"
-    ]
+    ],
+    "defaultMode": "auto"
   },
   "hooks": {
-    "SessionStart": [
+    "PermissionRequest": [
       {
         "matcher": "*",
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/hooks/tmux-attention.sh clear",
+            "command": "~/.claude/hooks/tmux-attention.sh waiting",
             "timeout": 5
           }
         ]
-      }
-    ],
-    "UserPromptSubmit": [
+      },
       {
-        "matcher": "*",
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/hooks/tmux-attention.sh spinner",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
-    "PreToolUse": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/hooks/tmux-attention.sh spinner",
-            "timeout": 5
+            "command": "OTTY_CLI='/Applications/Otty.app/Contents/MacOS/otty-cli' '/Applications/Otty.app/Contents/Resources/agent-integration/claude/otty-hook.sh' awaiting \"$PPID\" ctx"
           }
         ]
       }
@@ -70,15 +54,71 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "OTTY_CLI='/Applications/Otty.app/Contents/MacOS/otty-cli' '/Applications/Otty.app/Contents/Resources/agent-integration/claude/otty-hook.sh' processing \"$PPID\""
+          }
+        ]
       }
     ],
-    "PermissionRequest": [
+    "PreToolUse": [
       {
         "matcher": "*",
         "hooks": [
           {
             "type": "command",
-            "command": "~/.claude/hooks/tmux-attention.sh waiting",
+            "command": "~/.claude/hooks/tmux-attention.sh spinner",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "OTTY_CLI='/Applications/Otty.app/Contents/MacOS/otty-cli' '/Applications/Otty.app/Contents/Resources/agent-integration/claude/otty-hook.sh' processing \"$PPID\""
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/tmux-attention.sh clear",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "OTTY_CLI='/Applications/Otty.app/Contents/MacOS/otty-cli' '/Applications/Otty.app/Contents/Resources/agent-integration/claude/otty-hook.sh' idle \"$PPID\""
+          }
+        ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash '~/.claude/hooks/herdr-agent-state.sh' session",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/herdr-blank-state.sh start",
             "timeout": 5
           }
         ]
@@ -94,6 +134,44 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "OTTY_CLI='/Applications/Otty.app/Contents/MacOS/otty-cli' '/Applications/Otty.app/Contents/Resources/agent-integration/claude/otty-hook.sh' idle \"$PPID\""
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/tmux-attention.sh spinner",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "OTTY_CLI='/Applications/Otty.app/Contents/MacOS/otty-cli' '/Applications/Otty.app/Contents/Resources/agent-integration/claude/otty-hook.sh' processing \"$PPID\""
+          }
+        ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/herdr-blank-state.sh clear",
+            "timeout": 5
+          }
+        ]
       }
     ]
   },
@@ -102,20 +180,19 @@
     "command": "sh \"$HOME/.claude/statusline-command.sh\""
   },
   "enabledPlugins": {
-    "frontend-design@claude-plugins-official": true,
     "compound-engineering@compound-engineering-plugin": true,
-    "vercel@claude-plugins-official": true,
     "dv@villavicencio-skills": true,
+    "frontend-design@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
-    "codex@openai-codex": true
+    "vercel@claude-plugins-official": true,
+    "coderabbit@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
-    "compound-engineering-plugin": {
+    "claude-code-plugins": {
       "source": {
         "source": "github",
-        "repo": "EveryInc/compound-engineering-plugin"
-      },
-      "autoUpdate": true
+        "repo": "anthropics/claude-code"
+      }
     },
     "claude-plugins-official": {
       "source": {
@@ -123,16 +200,17 @@
         "repo": "anthropics/claude-plugins-official"
       }
     },
+    "compound-engineering-plugin": {
+      "source": {
+        "source": "github",
+        "repo": "EveryInc/compound-engineering-plugin"
+      },
+      "autoUpdate": true
+    },
     "villavicencio-skills": {
       "source": {
         "source": "github",
         "repo": "villavicencio/skills"
-      }
-    },
-    "openai-codex": {
-      "source": {
-        "source": "github",
-        "repo": "openai/codex-plugin-cc"
       }
     }
   },
@@ -144,11 +222,5 @@
   "remoteControlAtStartup": true,
   "inputNeededNotifEnabled": true,
   "agentPushNotifEnabled": true,
-  "skipAutoPermissionPrompt": true,
-  "mcpServers": {
-    "eagle": {
-      "type": "streamable-http",
-      "url": "http://127.0.0.1:41596/mcp"
-    }
-  }
+  "skipAutoPermissionPrompt": true
 }

--- a/dotbot-conf/darwin.yaml
+++ b/dotbot-conf/darwin.yaml
@@ -39,6 +39,7 @@
     ~/.claude/settings.json: claude/settings.json
     ~/.claude/statusline-command.sh: claude/statusline-command.sh
     ~/.claude/hooks/tmux-attention.sh: claude/hooks/tmux-attention.sh
+    ~/.claude/hooks/herdr-blank-state.sh: claude/hooks/herdr-blank-state.sh
     # iTerm2 Dynamic Profile. `create: true` makes the DynamicProfiles parent dir
     # if iTerm hasn't yet. Replaces the live-synced full prefs plist (which leaked
     # usernames/hostname/window arrangements).

--- a/dotbot-conf/darwin.yaml
+++ b/dotbot-conf/darwin.yaml
@@ -32,11 +32,15 @@
     # the config path and would orphan a symlink. Hence a shell step here rather
     # than an entry in the `link:` block below.
     - [bash helpers/install_otty.sh, "Seeding Otty config (if absent)"]
+    # Claude Code's settings.json is likewise seeded by COPY, not linked: Claude
+    # Code itself, `herdr integration install`, and Otty's agent-integration
+    # installer all rewrite it in place, so a symlink there is orphaned on the
+    # first write. Capture live changes with --capture; `dot drift` shows the gap.
+    - [bash helpers/install_claude_settings.sh, "Seeding Claude Code settings (if absent)"]
     - [bash helpers/install_herdr_agents.sh, "Linking herdr agent ssh shims"]
 
 - link:
     ~/.claude/CLAUDE.md: claude/CLAUDE.md
-    ~/.claude/settings.json: claude/settings.json
     ~/.claude/statusline-command.sh: claude/statusline-command.sh
     ~/.claude/hooks/tmux-attention.sh: claude/hooks/tmux-attention.sh
     ~/.claude/hooks/herdr-blank-state.sh: claude/hooks/herdr-blank-state.sh

--- a/helpers/install_claude_settings.sh
+++ b/helpers/install_claude_settings.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# install_claude_settings.sh — seed Claude Code's user-scope settings.json.
+#
+# SEED-ONLY BY DESIGN, for the same reason as Otty (see install_otty.sh):
+# ~/.claude/settings.json has THREE independent writers besides this repo —
+# Claude Code itself (effortLevel, tui, notification prefs, autoMode),
+# `herdr integration install`, and Otty's agent-integration installer. Each
+# rewrites the file in place, so a Dotbot `link:` there survives only until the
+# next write, after which the live file is a regular file and the repo copy is a
+# silently-orphaned stale twin.
+#
+# That is not hypothetical: the link was replaced at some point before
+# 2026-08-25, and the repo copy went stale from 2026-08-07 (the last commit that
+# touched it) until the drift was found. In the meantime the live file had
+# regrown a legacy top-level `allowedTools` key holding 18 rules while
+# `permissions.allow` was down to 1 — silently re-arming the precedence trap that
+# PR #127 had removed, because the legacy key wins when both exist.
+#
+# So: copy in only what is absent, never clobber a live config, and let
+# `dot drift` surface the gap. Use --capture to fold live changes back.
+#
+# Usage:
+#   install_claude_settings.sh            seed ~/.claude/settings.json if absent
+#   install_claude_settings.sh --capture  the reverse — record live changes into the repo
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC="$REPO_ROOT/claude/settings.json"
+DEST="$HOME/.claude/settings.json"
+
+# Keys that are machine- or session-specific and must never be tracked. The
+# file's own "//" header states the rule; these are the observed offenders.
+#   effortLevel  session pin
+#   autoMode     per-project classifier context (has leaked a project's
+#                trusted-repo path and service list into user scope before)
+#   mcpServers   per-machine server definitions
+#   allowedTools LEGACY key — silently overrides permissions.allow. Never track
+#                it; capture drops it so a stale live file cannot reintroduce it.
+STRIP_KEYS="effortLevel autoMode mcpServers allowedTools"
+
+if [ "${1:-}" = "--capture" ]; then
+  [ -f "$DEST" ] || { echo "Error: no live settings at $DEST" >&2; exit 1; }
+  [ -f "$SRC" ]  || { echo "Error: tracked settings missing at $SRC" >&2; exit 1; }
+  command -v python3 >/dev/null 2>&1 || { echo "Error: python3 not on PATH" >&2; exit 1; }
+
+  STRIP_KEYS="$STRIP_KEYS" SRC="$SRC" DEST="$DEST" python3 - <<'PY' || exit 1
+import json, collections, os, sys
+
+src, dest = os.environ["SRC"], os.environ["DEST"]
+strip = set(os.environ["STRIP_KEYS"].split())
+
+try:
+    live = json.load(open(dest), object_pairs_hook=collections.OrderedDict)
+except Exception as e:
+    print("Error: live settings is not valid JSON (%s) — nothing captured" % e, file=sys.stderr)
+    raise SystemExit(1)
+tracked = json.load(open(src), object_pairs_hook=collections.OrderedDict)
+
+dropped = [k for k in strip if k in live]
+for k in dropped:
+    live.pop(k)
+
+# Preserve the tracked file's "//" header comment; it explains the whole scheme
+# and Claude Code never writes it back.
+if "//" in tracked:
+    rebuilt = collections.OrderedDict()
+    rebuilt["//"] = tracked["//"]
+    for k, v in live.items():
+        if k != "//":
+            rebuilt[k] = v
+    live = rebuilt
+
+# Absolute $HOME paths are unportable across the two Macs; installers write them
+# (herdr's integration does). Claude Code expands ~ in hook commands, so fold
+# them back. Only $HOME is rewritten — /Applications paths are machine-stable.
+blob = json.dumps(live, indent=2)
+home = os.path.expanduser("~")
+before = blob
+blob = blob.replace(home + "/", "~/")
+normalized = blob != before
+
+tmp = src + ".tmp.%d" % os.getpid()
+try:
+    with open(tmp, "w") as fh:
+        fh.write(blob + "\n")
+    json.load(open(tmp))          # parse-check before replacing
+    os.replace(tmp, src)
+except Exception:
+    if os.path.exists(tmp):
+        os.remove(tmp)
+    raise
+
+print("Captured live Claude settings into %s" % src)
+if dropped:
+    print("  dropped machine-local keys: %s" % ", ".join(sorted(dropped)))
+if normalized:
+    print("  normalized absolute $HOME paths to ~/")
+print("  review with: git diff claude/settings.json")
+PY
+  exit 0
+fi
+
+if [ "${DOTFILES_DRY_RUN:-0}" = "1" ]; then
+  echo "[dry-run] would seed ~/.claude/settings.json from claude/settings.json if absent"
+  exit 0
+fi
+
+[ -f "$SRC" ] || { echo "Error: tracked settings missing at $SRC" >&2; exit 1; }
+mkdir -p "$HOME/.claude" || { echo "Error: cannot create $HOME/.claude" >&2; exit 1; }
+
+if [ -e "$DEST" ] || [ -L "$DEST" ]; then
+  echo "Claude settings already present, leaving it alone (run 'dot drift' to compare)."
+  exit 0
+fi
+
+cp "$SRC" "$DEST" && echo "Seeded Claude settings -> $DEST"

--- a/helpers/install_claude_settings.sh
+++ b/helpers/install_claude_settings.sh
@@ -39,6 +39,17 @@ DEST="$HOME/.claude/settings.json"
 #                it; capture drops it so a stale live file cannot reintroduce it.
 STRIP_KEYS="effortLevel autoMode mcpServers allowedTools"
 
+# Dry-run guard comes FIRST so it covers --capture too: capture writes to the
+# repo, and `DOTFILES_DRY_RUN=1 ... --capture` must not mutate anything.
+if [ "${DOTFILES_DRY_RUN:-0}" = "1" ]; then
+  if [ "${1:-}" = "--capture" ]; then
+    echo "[dry-run] would capture ~/.claude/settings.json into claude/settings.json"
+  else
+    echo "[dry-run] would seed ~/.claude/settings.json from claude/settings.json if absent"
+  fi
+  exit 0
+fi
+
 if [ "${1:-}" = "--capture" ]; then
   [ -f "$DEST" ] || { echo "Error: no live settings at $DEST" >&2; exit 1; }
   [ -f "$SRC" ]  || { echo "Error: tracked settings missing at $SRC" >&2; exit 1; }
@@ -56,6 +67,24 @@ except Exception as e:
     print("Error: live settings is not valid JSON (%s) — nothing captured" % e, file=sys.stderr)
     raise SystemExit(1)
 tracked = json.load(open(src), object_pairs_hook=collections.OrderedDict)
+
+# `allowedTools` is dropped rather than tracked — but dropping it while it still
+# holds rules absent from permissions.allow would SILENTLY DELETE them from the
+# tracked baseline, and the legacy key is the one Claude Code actually enforces.
+# Refuse, and point at the migration that folds them back.
+legacy = live.get("allowedTools") or []
+allow_now = (live.get("permissions") or {}).get("allow") or []
+unmerged = [r for r in legacy if r not in allow_now]
+if unmerged:
+    print(
+        "Error: live settings still has a legacy 'allowedTools' key with %d rule(s)\n"
+        "       not present in permissions.allow. Capturing now would silently drop\n"
+        "       them. Run this first, then re-capture:\n"
+        "           python3 helpers/migrate_claude_settings.py\n"
+        "       Unmerged: %s" % (len(unmerged), ", ".join(unmerged[:5])),
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
 
 dropped = [k for k in strip if k in live]
 for k in dropped:
@@ -98,11 +127,6 @@ if normalized:
     print("  normalized absolute $HOME paths to ~/")
 print("  review with: git diff claude/settings.json")
 PY
-  exit 0
-fi
-
-if [ "${DOTFILES_DRY_RUN:-0}" = "1" ]; then
-  echo "[dry-run] would seed ~/.claude/settings.json from claude/settings.json if absent"
   exit 0
 fi
 

--- a/helpers/migrate_claude_settings.py
+++ b/helpers/migrate_claude_settings.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""One-time repair for a ~/.claude/settings.json that predates the copy-seed scheme.
+
+Two fixes, both idempotent — safe to re-run, and a no-op once applied:
+
+1. Undo a resurrected legacy top-level `allowedTools` key. When both it and
+   `permissions.allow` exist, the LEGACY KEY WINS and permissions.allow is
+   silently inert — rules sit there looking active while nothing consults them.
+   PR #127 consolidated onto permissions.allow; this machine's live file had
+   regrown allowedTools with 18 rules against a permissions.allow of 1.
+   Folds allowedTools into permissions.allow (dedup, order-preserving) and
+   deletes the legacy key.
+
+2. Register the herdr blank-state hook on SessionStart + UserPromptSubmit, so a
+   pane that has been /clear'd reads "blank" in herdr's agent sidebar. Fresh
+   machines get this from the seeded baseline instead (see
+   install_claude_settings.sh); this covers a machine that already had a
+   settings.json and so was never seeded.
+
+Run it on any machine whose settings.json predates 2026-08-25. Writes a
+timestamped backup first and parse-checks before replacing.
+
+NOTE: Claude Code's auto-mode classifier blocks agents from writing this file
+(by design — it stops an agent widening its own permissions), so this is a
+human-run script. Invoke it yourself:
+
+    python3 helpers/migrate_claude_settings.py
+"""
+import collections
+import json
+import os
+import shutil
+import sys
+import time
+
+SETTINGS = os.path.expanduser("~/.claude/settings.json")
+HOOKS = [
+    ("SessionStart", "~/.claude/hooks/herdr-blank-state.sh start"),
+    ("UserPromptSubmit", "~/.claude/hooks/herdr-blank-state.sh clear"),
+]
+
+
+def main():
+    if os.environ.get("DOTFILES_DRY_RUN", "0") == "1":
+        print("[dry-run] would repair %s (allowedTools fold + blank-state hooks)" % SETTINGS)
+        return 0
+    if not os.path.exists(SETTINGS):
+        print("No settings at %s — nothing to migrate." % SETTINGS)
+        return 0
+
+    try:
+        data = json.load(open(SETTINGS), object_pairs_hook=collections.OrderedDict)
+    except Exception as exc:
+        print("Error: %s is not valid JSON (%s) — refusing to touch it" % (SETTINGS, exc),
+              file=sys.stderr)
+        return 1
+
+    backup = "%s.bak-%d" % (SETTINGS, int(time.time()))
+    shutil.copy2(SETTINGS, backup)
+
+    legacy = data.pop("allowedTools", [])
+    allow = data.setdefault("permissions", collections.OrderedDict()).setdefault("allow", [])
+    merged = list(dict.fromkeys(list(allow) + list(legacy)))
+    data["permissions"]["allow"] = merged
+
+    hooks = data.setdefault("hooks", collections.OrderedDict())
+    added = []
+    for event, command in HOOKS:
+        groups = hooks.setdefault(event, [])
+        if any(h.get("command") == command for g in groups for h in g.get("hooks", [])):
+            continue
+        groups.append({"matcher": "*",
+                       "hooks": [{"type": "command", "command": command, "timeout": 5}]})
+        added.append(event)
+
+    tmp = SETTINGS + ".tmp.%d" % os.getpid()
+    try:
+        with open(tmp, "w") as fh:
+            json.dump(data, fh, indent=2)
+            fh.write("\n")
+        json.load(open(tmp))            # parse-check before replacing
+        os.replace(tmp, SETTINGS)
+    except Exception:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+        raise
+
+    print("backup:            %s" % backup)
+    print("allowedTools:      %s" % ("removed, %d rules folded in" % len(legacy) if legacy
+                                     else "absent (already migrated)"))
+    print("permissions.allow: %d rules" % len(merged))
+    print("blank-state hooks: %s" % (", ".join(added) if added else "already registered"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/helpers/report_drift.sh
+++ b/helpers/report_drift.sh
@@ -249,5 +249,65 @@ else
   fi
 fi
 
+# ---------------------------------------------------------------------------
+# Claude Code settings.json
+# ---------------------------------------------------------------------------
+# Seeded by COPY, not symlinked: Claude Code itself, `herdr integration install`,
+# and Otty's agent-integration installer all rewrite the file in place, so a
+# symlink there is orphaned on the first write (see helpers/install_claude_settings.sh).
+#
+# Compare the CAPTURE-NORMALIZED forms, not the raw files — the live file carries
+# machine-local keys (effortLevel, autoMode, mcpServers) that are deliberately
+# untracked, so a plain diff would report permanent, un-actionable drift.
+CLAUDE_TRACKED="$REPO_ROOT/claude/settings.json"
+CLAUDE_LIVE="$HOME/.claude/settings.json"
+
+hr "Claude Code: tracked settings.json vs live ~/.claude/settings.json"
+if [ ! -f "$CLAUDE_TRACKED" ]; then
+  echo "ERROR: tracked Claude settings missing at $CLAUDE_TRACKED" >&2
+  status=1
+elif [ ! -f "$CLAUDE_LIVE" ]; then
+  echo "  (not seeded on this machine yet — ./install will copy it in)"
+elif ! command -v python3 >/dev/null 2>&1; then
+  echo "  (python3 not on PATH — cannot normalize; skipping)"
+else
+  # Emits the live file reduced to what capture would track, so the diff shows
+  # only real, actionable drift.
+  claude_norm() {
+    CLAUDE_FILE="$1" python3 - <<'PYEOF'
+import collections, json, os, sys
+strip = {"effortLevel", "autoMode", "mcpServers", "allowedTools"}
+try:
+    d = json.load(open(os.environ["CLAUDE_FILE"]), object_pairs_hook=collections.OrderedDict)
+except Exception as exc:
+    print("UNPARSEABLE: %s" % exc); sys.exit(0)
+for k in list(d):
+    if k in strip or k == "//":
+        d.pop(k)
+blob = json.dumps(d, indent=2, sort_keys=True)
+print(blob.replace(os.path.expanduser("~") + "/", "~/"))
+PYEOF
+  }
+  claude_live_norm="$(claude_norm "$CLAUDE_LIVE")"
+  claude_tracked_norm="$(claude_norm "$CLAUDE_TRACKED")"
+  if printf '%s' "$claude_live_norm" | grep -q '^UNPARSEABLE'; then
+    echo "ERROR: live settings is not valid JSON — cannot compute drift" >&2
+    status=1
+  elif [ "$claude_live_norm" = "$claude_tracked_norm" ]; then
+    echo "  (in sync)"
+  else
+    echo "  live differs from tracked ('<' = live, '>' = repo):"
+    diff <(printf '%s\n' "$claude_live_norm") <(printf '%s\n' "$claude_tracked_norm") | indent
+    echo "  to record: bash helpers/install_claude_settings.sh --capture"
+  fi
+  # The legacy key silently overrides permissions.allow — always worth shouting about.
+  if grep -q '"allowedTools"' "$CLAUDE_LIVE"; then
+    echo "  WARNING: live settings has a legacy top-level 'allowedTools' key."
+    echo "           It OVERRIDES permissions.allow, which is then silently inert."
+    echo "           Repair with: python3 helpers/migrate_claude_settings.py"
+    status=1
+  fi
+fi
+
 hr "Done (read-only — no manifests were modified)"
 exit "$status"

--- a/helpers/report_drift.sh
+++ b/helpers/report_drift.sh
@@ -293,6 +293,9 @@ PYEOF
   if printf '%s' "$claude_live_norm" | grep -q '^UNPARSEABLE'; then
     echo "ERROR: live settings is not valid JSON — cannot compute drift" >&2
     status=1
+  elif printf '%s' "$claude_tracked_norm" | grep -q '^UNPARSEABLE'; then
+    echo "ERROR: tracked claude/settings.json is not valid JSON — cannot compute drift" >&2
+    status=1
   elif [ "$claude_live_norm" = "$claude_tracked_norm" ]; then
     echo "  (in sync)"
   else


### PR DESCRIPTION
Started as *"can herdr show that a Claude Code pane is blank after `/clear`?"* — yes, and wiring it up surfaced a settings.json regression that turned out to matter more.

## 1. The blank indicator

Claude Code's `SessionStart` hook reports how a session began (`startup` / `clear` / `resume` / `compact`). herdr's `pane.report_metadata` accepts a **display-only** `state_labels` override that feeds the `state_text` row `[ui.sidebar.agents]` already renders. Wiring the two makes a `/clear`'d pane read **`blank · vice`** instead of `idle · vice` — **with no `config.toml` change**.

`claude/hooks/herdr-blank-state.sh` writes the socket directly rather than shelling out to `herdr`: no PATH dependency (cf. the bare-launchd-env gotcha), one fewer process, and it mirrors herdr's own integration hook.

Verified live — all five transitions, plus the safety properties:

| case | result |
|---|---|
| `SessionStart source=clear` | `{"idle": "blank"}` |
| `SessionStart source=startup` | `{"idle": "blank"}` |
| `SessionStart source=resume` | cleared (corrects a stale blank) |
| `UserPromptSubmit` | cleared |
| subagent event (`agent_id`) | ignored |

stdout empty (both `SessionStart` and `UserPromptSubmit` **inject hook stdout into model context**), exit 0 on malformed/empty stdin, no-op outside a herdr pane, no temp-file leaks. A 12h `--ttl-ms` backstops a missed clear.

> **Upstream note:** herdr *already receives* `session_start_source` — its own integration hook sends it on `pane.report_agent_session` — but never surfaces it in the snapshot or displays it. The signal is flowing and unused; a native indicator is a reasonable feature request.

## 2. The settings.json regression (the real find)

`~/.claude/settings.json` **had stopped being the dotbot symlink.** Three writers besides this repo rewrite it in place — Claude Code itself, `herdr integration install`, and Otty's agent-integration installer. Same failure mode as Otty, on a second file.

The repo copy sat stale from **2026-08-07** (its last commit) to **2026-08-25**. Nothing surfaced it — from git's side, nothing had changed.

**The drift was not cosmetic:**

- The live file had regrown a legacy top-level **`allowedTools` with 18 rules** while `permissions.allow` was down to **1** — silently re-arming the precedence trap **PR #127** removed. When both keys exist the legacy one wins and `permissions.allow` is inert, so the allowlist you read is not the one enforced.
- It had accumulated an `autoMode.environment` block naming a **different project's** trusted repo and service list, in the cross-machine user-scope file whose own `"//"` header forbids exactly that.

### The fix

- **`helpers/install_claude_settings.sh`** — seed-when-absent (mirrors `install_otty.sh`) plus `--capture`. Capture drops machine-local keys (`effortLevel`, `autoMode`, `mcpServers`, `allowedTools`), re-prepends the tracked `"//"` header, and rewrites absolute `$HOME` paths to `~/` (installers write literal `/Users/<you>/…`; Claude Code expands `~` in hook commands).
- **`helpers/migrate_claude_settings.py`** — idempotent repair for a machine predating the scheme. **Human-run**: the auto-mode classifier blocks agents from writing this file by design, and that block is worth keeping. *(The work Mac likely needs this.)*
- **`dotbot-conf/darwin.yaml`** — drop the `link:`, add the seed step beside Otty's.
- **`helpers/report_drift.sh`** — compare **capture-normalized** forms (a raw diff would report permanent un-actionable drift from the untracked keys), and **warn loudly** if `allowedTools` reappears.
- **`claude/settings.json`** — recaptured. Now carries all four integrations' hooks (tmux-attention 6, otty 6, herdr-agent-state 1, blank-state 2) the orphaned copy had never seen. Stripping `mcpServers` also removes a tracked path for the retired `browserbase` entry's embedded API key.

## Verification

- `dot check` clean; `dot doctor` **0 fail**
- `dot drift` reports in-sync, and **correctly detects a planted difference** then clears
- seed is a no-op when present; `--capture` round-trips; migration idempotent (re-run = verified no-op, byte-identical)
- no hardcoded usernames remain in the tracked baseline; gitleaks passed

## Reviewer note

`claude/settings.json` has a large diff because it is a **recapture of an 18-day-stale file**, not hand edits — most of it is integration hooks the orphaned copy never had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011r11DbhGUtzywHicrNmp1D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Herdr blank-state indicators for Claude Code startup and cleared sessions.
  * Added integrations for session events, permission requests, prompts, and tool activity.
  * Enabled the CodeRabbit plugin and GitHub pull request merge permissions.

* **Improvements**
  * Added tools to install, migrate, capture, validate, and compare Claude Code settings.
  * Added safeguards, backups, dry-run support, and actionable configuration warnings.

* **Documentation**
  * Clarified Claude Code settings management, migration, drift detection, session-state metadata, and Node/npm command behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->