### PR TITLE
chore(herdr): add atlas-tools ⚙ — remote Claude Code surface on openclaw-prod

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,7 +279,7 @@ install via Homebrew casks in `brew/Brewfile`, not a helper.)
   reuses the existing `claude-code` ssh alias (detection keys on the ssh child's
   process name, so two panes may share one alias with different args) and is told
   apart from `axiom` by `herdr agent rename`. The remote tmux is addressed with
-  `-L atlas-tools -f ~/.config/tmux/atlas-tools.conf` and `new-session -A`, which
+  `-L atlas-tools -f /home/node/.config/tmux/atlas-tools.conf` and `new-session -A`, which
   makes it self-healing across VPS reboots without a systemd unit. The conf file
   is required because tmux defaults `set-titles` to `off` and that option is what
   carries agent state out through a nested tmux. The `axiom` socket was given the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,6 +271,19 @@ install via Homebrew casks in `brew/Brewfile`, not a helper.)
   `vice ♠` is the first local **hermes** pane — the same template with
   `hermes chat` in place of `claude`; herdr's hermes manifest detects the
   venv process natively, so it needs no shim either.
+  `atlas-tools ⚙` (`prefix+t`) is a remote **Claude Code** surface, not a TUI
+  attach: the repo lives only at `/home/node/Projects/atlas-tools` on
+  openclaw-prod as user `node`, and **no Mac-side checkout exists**. herdr's pane
+  `cwd` is always local — it is where the ssh process starts — so a remote working
+  directory needs no local clone; the pane command establishes it remotely. It
+  reuses the existing `claude-code` ssh alias (detection keys on the ssh child's
+  process name, so two panes may share one alias with different args) and is told
+  apart from `axiom` by `herdr agent rename`. The remote tmux is addressed with
+  `-L atlas-tools -f ~/.config/tmux/atlas-tools.conf` and `new-session -A`, which
+  makes it self-healing across VPS reboots without a systemd unit. The conf file
+  is required because tmux defaults `set-titles` to `off` and that option is what
+  carries agent state out through a nested tmux; the `axiom` socket still runs
+  with it off, which likely explains its `unknown` status.
   A pane whose `layout.export` node has no `command` is degraded even though it
   still detects as an agent; rebuild it with `layout.apply` over the socket
   (recipe in CLAUDE.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,8 +282,11 @@ install via Homebrew casks in `brew/Brewfile`, not a helper.)
   `-L atlas-tools -f ~/.config/tmux/atlas-tools.conf` and `new-session -A`, which
   makes it self-healing across VPS reboots without a systemd unit. The conf file
   is required because tmux defaults `set-titles` to `off` and that option is what
-  carries agent state out through a nested tmux; the `axiom` socket still runs
-  with it off, which likely explains its `unknown` status.
+  carries agent state out through a nested tmux. The `axiom` socket was given the
+  same treatment on 2026-08-25. Note its `unknown` status turned out to have a
+  different cause: the pane had fallen through to the shim's clean-detach `zsh`
+  fallback, so no agent process existed to detect. Check `pane.process_info`
+  before blaming detection config.
   A pane whose `layout.export` node has no `command` is degraded even though it
   still detects as an agent; rebuild it with `layout.apply` over the socket
   (recipe in CLAUDE.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,7 +375,7 @@ conversations across server restarts via `claude --resume <id>`.
   do nest, tmux's `send-prefix` binding passes it through on a double-tap. Herdr
   can host tmux in a pane or run inside tmux, but agent detection does not see
   through a nested tmux.
-- **Remote agent surfaces (`atlas ⚓` / `axiom ∴`):** each workspace hosts a VPS
+- **Remote agent surfaces (`atlas ⚓` / `axiom ∴` / `atlas-tools ⚙`):** each workspace hosts a VPS
   TUI through an ssh shim whose *name* matches a detection-manifest alias —
   herdr identifies these ssh panes by process name. **The name trick is for ssh
   panes only** — a *local* TUI needs none of it: claude and hermes panes are
@@ -425,6 +425,40 @@ conversations across server restarts via `claude --resume <id>`.
   the TUIs' OSC titles drive herdr states through the nested tmux. Never
   restart `hermes-tmux.service` casually — it drops Atlas's in-memory history
   (see ~/Projects/agents docs for Hermes rules).
+- **`atlas-tools ⚙` — a remote CLAUDE CODE surface, not a TUI attach** (added
+  2026-08-25, `prefix+t`). It reuses the existing `claude-code` ssh alias rather
+  than adding a third shim: detection keys on the ssh child's *process name*, and
+  two panes may share one alias since the pane command supplies different args.
+  `herdr agent rename` is what tells them apart (`axiom` vs `atlas-tools`).
+
+  ```
+  cwd:     $HOME                        # local placeholder — herdr's cwd is ALWAYS local
+  command: ~/.local/bin/claude-code root@openclaw-prod -t \
+           "sudo -u node tmux -L atlas-tools -f /home/node/.config/tmux/atlas-tools.conf \
+            new-session -A -s ATLAS-TOOLS -c /home/node/Projects/atlas-tools"
+  ```
+
+  **A remote project needs no Mac-side checkout.** herdr's pane `cwd` is where the
+  local ssh process starts and nothing more; the working directory is established
+  remotely by the ssh command. The repo lives only at
+  `/home/node/Projects/atlas-tools` on openclaw-prod, owned by `node`, and every
+  git/uv/test/lint/Claude Code command runs there.
+
+  `new-session -A` makes the pane **self-healing**: it attaches if the session
+  exists and creates it otherwise, so a VPS reboot needs no systemd unit — the
+  auto-reconnect shim retries, and the first successful attach rebuilds the
+  session. This is why `atlas-tools` has no `*-tmux.service` twin.
+
+  **`-f <conf>` is load-bearing.** tmux's `set-titles` default is `off`, and that
+  option is what forwards the inner TUI's OSC title outward for herdr to read
+  state through a nested tmux. node has no `~/.tmux.conf`, and options set at
+  runtime die with the tmux server — so the socket gets its own conf file,
+  scoped with `-L`/`-f` so it cannot disturb the `axiom` or `default` sockets.
+  > ⚠ The `axiom` socket currently runs with `set-titles off` (tmux's default),
+  > despite this file previously claiming every remote tmux carries it on. That
+  > is likely why `axiom ∴` reports `agent_status: unknown`. Unfixed as of
+  > 2026-08-25 — fixing it means giving that socket a conf file too.
+
 - **Local agent pane template (fleet standard, revised 2026-08-19):** a local
   Claude Code agent runs as a declarative pane with command
   `["/bin/zsh", "-l", "-c", "claude; exec /bin/zsh -il"]` and its project dir as

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -454,10 +454,20 @@ conversations across server restarts via `claude --resume <id>`.
   state through a nested tmux. node has no `~/.tmux.conf`, and options set at
   runtime die with the tmux server — so the socket gets its own conf file,
   scoped with `-L`/`-f` so it cannot disturb the `axiom` or `default` sockets.
-  > ⚠ The `axiom` socket currently runs with `set-titles off` (tmux's default),
-  > despite this file previously claiming every remote tmux carries it on. That
-  > is likely why `axiom ∴` reports `agent_status: unknown`. Unfixed as of
-  > 2026-08-25 — fixing it means giving that socket a conf file too.
+  > The `axiom` socket ran with `set-titles off` (tmux's default) until
+  > 2026-08-25, despite this file claiming every remote tmux carried it on. It
+  > now has its own `~/.config/tmux/axiom.conf`, applied at runtime without a
+  > server restart.
+  >
+  > **That was NOT why `axiom ∴` read `agent_status: unknown`** — a first guess
+  > that the evidence killed. The pane was running `/bin/zsh -il`, the shim's
+  > clean-detach fallback: something detached the ssh, the wrapper exited 0, and
+  > the pane sat at a shell. No agent process, so nothing to detect. The remote
+  > side was healthy the whole time (`claude --continue` alive, session intact).
+  > **A workspace reading `unknown` means look at the pane's foreground process
+  > first** (`pane.process_info`) — a fallback `zsh` is the tell. Recovery is
+  > `layout.apply` over the existing tab, then `herdr agent rename`, since a
+  > recreated pane loses its name.
 
 - **Local agent pane template (fleet standard, revised 2026-08-19):** a local
   Claude Code agent runs as a declarative pane with command

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -431,7 +431,7 @@ conversations across server restarts via `claude --resume <id>`.
   two panes may share one alias since the pane command supplies different args.
   `herdr agent rename` is what tells them apart (`axiom` vs `atlas-tools`).
 
-  ```
+  ```text
   cwd:     $HOME                        # local placeholder — herdr's cwd is ALWAYS local
   command: ~/.local/bin/claude-code root@openclaw-prod -t \
            "sudo -u node tmux -L atlas-tools -f /home/node/.config/tmux/atlas-tools.conf \

--- a/herdr/config.toml
+++ b/herdr/config.toml
@@ -194,6 +194,15 @@ type = "shell"
 command = "/opt/homebrew/bin/herdr agent focus vice"
 description = "jump to Vice"
 
+[[keys.command]]
+# t as in a**t**las-**t**ools; free in herdr's defaults and unclaimed here.
+# Absolute path: [[keys.command]] shell commands run with the server's bare
+# launchd env, where /opt/homebrew/bin is not on PATH.
+key = "prefix+t"
+type = "shell"
+command = "/opt/homebrew/bin/herdr agent focus atlas-tools"
+description = "jump to Atlas Tools"
+
 # Legacy indexed shortcut config is still parsed for compatibility.
 # Prefer switch_tab, switch_workspace, and focus_agent for new configs.
 # [keys.indexed]


### PR DESCRIPTION
## What

A herdr workspace for **`atlas-tools`**, a VPS-side project. The repo lives only at `/home/node/Projects/atlas-tools` on openclaw-prod as user `node`; every git/uv/test/lint/Claude Code command runs there. This workspace is purely the control surface.

**No Mac-side checkout exists, and none is needed.** herdr's pane `cwd` is always local — it's where the `ssh` process starts, nothing more — so the remote working directory is established by the pane command rather than by a local clone.

```
cwd:     $HOME                         ← local placeholder
command: ~/.local/bin/claude-code root@openclaw-prod -t \
         "sudo -u node tmux -L atlas-tools -f /home/node/.config/tmux/atlas-tools.conf \
          new-session -A -s ATLAS-TOOLS -c /home/node/Projects/atlas-tools"
```

## Changes

- **`herdr/config.toml`** — jump key `prefix+t` (`t` as in a**t**las-**t**ools), free in both herdr's defaults and this config. Absolute path, per the bare-launchd-env rule.
- **`CLAUDE.md` / `AGENTS.md`** — document the surface and the two non-obvious mechanics below.

## Two things worth reviewing

**No third shim.** It reuses the existing `claude-code` ssh alias. Detection keys on the **ssh child's process name**, and two panes can share one alias because the pane command supplies different args — `herdr agent rename` is what distinguishes `atlas-tools` from `axiom`.

**`-f <conf>` is load-bearing.** tmux defaults `set-titles` to **off**, and that option is what forwards the inner TUI's OSC title outward so herdr can read agent state through a nested tmux. `node` has no `~/.tmux.conf`, and runtime-set options die with the tmux server — so the socket gets its own conf file, scoped by `-L`/`-f` so it cannot disturb the `axiom` or `default` sockets.

`new-session -A` makes the pane self-healing: attach if the session exists, create it otherwise. A VPS reboot needs no systemd unit, unlike `axiom-tmux.service`.

## Pre-existing issue found

The **`axiom` socket is running with `set-titles off`** (tmux's default), despite CLAUDE.md having claimed every remote tmux carries it on. That's the likely cause of `axiom ∴` reporting `agent_status: unknown`. Documented as a known issue rather than fixed here — it needs its own conf file and a restart of that socket, which would kill the live AXIOM session.

## Verification

- `herdr server reload-config` → `status: applied`, no diagnostics
- pane detected as `claude`, renamed `atlas-tools`, `agent_status: idle`
- `tmux -L atlas-tools list-clients` → attached; `pane_current_path=/home/node/Projects/atlas-tools`
- workspace has `tab_count: 1` — no stray pane from the `workspace.create` trap
- `dot check` clean, `dot doctor` 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011r11DbhGUtzywHicrNmp1D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `atlas-tools` remote Claude Code workspace in Herdr.
  * Added automatic reconnect and self-healing remote session support.
  * Added a `prefix+t` shortcut to quickly open Atlas Tools.

* **Documentation**
  * Clarified Claude configuration synchronization, migration, and permission safeguards.
  * Updated guidance for npm CLI installation and NVM behavior.
  * Documented remote workspace setup, session management, display states, reconnect behavior, and known permission-related limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->