### PR TITLE
feat(uv): install uv via its native installer, not the Brewfile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,15 @@ Copy an existing `_load_X` block. Direct-sourcing heavy tools (NVM alone is +200
 blows the shell-startup budget — the lazy pattern keeps `zsh -i -c exit` under 300 ms.
 Use `command <tool>` (not bare `<tool>`) after `_load_*` to avoid infinite shim recursion.
 
+### Add a vendor-installed CLI (uv, Claude Code)
+Some tools ship via their vendor's installer into `~/.local/bin` rather than the Brewfile,
+because `zshenv` puts that dir ahead of Homebrew — a brewed copy would be permanently
+shadowed — and because they self-update. `helpers/install_uv.sh` and
+`helpers/install_claude_code.sh` are the two; both skip when already present.
+When adding another, check whether its installer edits shell rc files and suppress that
+(uv needs `UV_NO_MODIFY_PATH=1`): `.zshrc`/`.zshenv` are Dotbot symlinks into this repo, so
+an unguarded installer dirties tracked files.
+
 ### NVM lazy-loader shims
 A globally-installed npm CLI needs **no** NVM shim — the lazy-loader block prepends the default
 node version's `bin` dir to `PATH` at startup, and `#!/usr/bin/env node` shebangs resolve through

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,25 @@ When adding a new lazy loader, copy an existing one as a template. Never duplica
 logic across multiple wrapper functions. Use `command <tool>` (not bare `<tool>`) after
 `_load_*` to prevent infinite recursion when the shim name matches the binary name.
 
+### uv — native installer, deliberately not the Brewfile
+`helpers/install_uv.sh` installs uv from Astral's own installer to `~/.local/bin/uv`
+(and `uvx`), skipping if already present. Same reasoning as `install_claude_code.sh`:
+`zshenv` puts `~/.local/bin` **ahead of** Homebrew, so a `brew install uv` would sit at a
+lower-precedence path and never be the copy that runs — two uvs, the tracked one permanently
+shadowed. uv also self-updates (`uv self update`), so a Homebrew copy would drift behind.
+
+**`UV_NO_MODIFY_PATH=1` is required, not cosmetic.** Left unset, the installer appends PATH
+lines to `.zshrc` **and** `.zshenv` — both Dotbot symlinks into this repo — so an unguarded
+run edits tracked files and dirties the working tree. That is the "Post-installer audit"
+hazard, avoidable in advance rather than cleaned up after. `zshenv` already puts
+`~/.local/bin` on PATH, so there is nothing for the installer to add. The helper also pins
+`UV_INSTALL_DIR` so the destination never depends on the installer's own defaults.
+
+**Do not add a Homebrew `python@3.x` for uv's benefit.** uv provisions and manages its own
+interpreters under `~/.local/share/uv/python/` (`uv python install`); a brewed Python would
+be dead weight nothing resolves. The Hermes runtime's venv, for instance, is backed by a
+uv-managed CPython, not by any system or Homebrew Python.
+
 ### NVM lazy loader shims — globals do NOT need one
 NVM is lazy-loaded for startup speed. **A globally-installed npm CLI does not need a shim.**
 The block prepends the highest installed node version's `bin` dir to `PATH` at shell startup, and these

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,10 +178,16 @@ hazard, avoidable in advance rather than cleaned up after. `zshenv` already puts
 `~/.local/bin` on PATH, so there is nothing for the installer to add. The helper also pins
 `UV_INSTALL_DIR` so the destination never depends on the installer's own defaults.
 
-**Do not add a Homebrew `python@3.x` for uv's benefit.** uv provisions and manages its own
-interpreters under `~/.local/share/uv/python/` (`uv python install`); a brewed Python would
-be dead weight nothing resolves. The Hermes runtime's venv, for instance, is backed by a
-uv-managed CPython, not by any system or Homebrew Python.
+**No Homebrew `python@3.x` is needed for uv's benefit.** uv prefers the interpreters it
+manages under `~/.local/share/uv/python/` and provisions one on demand (`uv python install`),
+so nothing has to be installed ahead of it. The Hermes runtime's venv is backed by a
+uv-managed CPython rather than a system or Homebrew one.
+
+uv *will* discover and use a suitable system interpreter when no managed one satisfies the
+request — `uv python list` on this Mac shows the Homebrew 3.12/3.14 builds as usable
+candidates — so a brewed Python is redundant here, not unusable. `--managed-python` /
+`UV_MANAGED_PYTHON=1` forces the managed path when a project needs that guarantee;
+`--no-managed-python` does the opposite.
 
 ### NVM lazy loader shims — globals do NOT need one
 NVM is lazy-loaded for startup speed. **A globally-installed npm CLI does not need a shim.**

--- a/dotbot-conf/darwin.yaml
+++ b/dotbot-conf/darwin.yaml
@@ -28,6 +28,11 @@
     - [bash helpers/install_nvm.sh, "Installing nvm"]
     - [bash helpers/install_node.sh, "Installing node + modules"]
     - [bash helpers/install_claude_code.sh, "Installing Claude Code (native installer)"]
+    # uv likewise ships via its vendor installer rather than the Brewfile: zshenv puts
+    # ~/.local/bin ahead of Homebrew, so a brewed uv would be permanently shadowed, and
+    # uv self-updates. The helper sets UV_NO_MODIFY_PATH=1 — without it the installer
+    # appends PATH lines to .zshrc/.zshenv, which are Dotbot symlinks into this repo.
+    - [bash helpers/install_uv.sh, "Installing uv (native installer)"]
     # Otty is seeded by COPY, not linked — `otty config set` atomic-renames over
     # the config path and would orphan a symlink. Hence a shell step here rather
     # than an entry in the `link:` block below.

--- a/helpers/install_uv.sh
+++ b/helpers/install_uv.sh
@@ -26,6 +26,7 @@ set -uo pipefail
 
 INSTALL_DIR="$HOME/.local/bin"
 UV_BIN="$INSTALL_DIR/uv"
+UVX_BIN="$INSTALL_DIR/uvx"
 INSTALLER_URL="https://astral.sh/uv/install.sh"
 
 if [ "${DOTFILES_DRY_RUN:-0}" = "1" ]; then
@@ -38,14 +39,17 @@ if [ "$(uname)" != "Darwin" ]; then
   exit 0
 fi
 
-# Present AND runnable — a binary that will not report its version is not a working
-# install, and skipping on mere existence would strand a corrupt one forever.
-if [ -x "$UV_BIN" ]; then
-  if uv_version="$("$UV_BIN" --version 2>/dev/null)" && [ -n "$uv_version" ]; then
-    echo "uv already installed at $UV_BIN ($uv_version) — skipping (self-updates via 'uv self update')"
+# Both binaries must be present AND runnable. The installer places uv and uvx
+# together, so a working uv beside a missing or broken uvx is still a half install —
+# and skipping on mere existence would strand it forever.
+runnable() { [ -x "$1" ] && out="$("$1" --version 2>/dev/null)" && [ -n "$out" ]; }
+
+if [ -e "$UV_BIN" ] || [ -e "$UVX_BIN" ]; then
+  if runnable "$UV_BIN" && runnable "$UVX_BIN"; then
+    echo "uv already installed at $UV_BIN ($("$UV_BIN" --version)) — skipping (self-updates via 'uv self update')"
     exit 0
   fi
-  echo "Found $UV_BIN but it does not run ('--version' failed) — reinstalling over it." >&2
+  echo "Found an incomplete uv install at $INSTALL_DIR (uv or uvx missing / not runnable) — reinstalling over it." >&2
 fi
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -62,14 +66,11 @@ if ! curl -LsSf "$INSTALLER_URL" \
   exit 1
 fi
 
-if [ ! -x "$UV_BIN" ]; then
-  echo "Error: installer reported success but $UV_BIN is not executable" >&2
-  exit 1
-fi
+for bin in "$UV_BIN" "$UVX_BIN"; do
+  if ! runnable "$bin"; then
+    echo "Error: installer reported success but $bin is missing or does not run ('--version' failed)" >&2
+    exit 1
+  fi
+done
 
-if ! uv_version="$("$UV_BIN" --version 2>/dev/null)" || [ -z "$uv_version" ]; then
-  echo "Error: $UV_BIN installed but does not run ('--version' failed)" >&2
-  exit 1
-fi
-
-echo "Installed uv -> $UV_BIN ($uv_version)"
+echo "Installed uv -> $UV_BIN ($("$UV_BIN" --version)), uvx -> $UVX_BIN"

--- a/helpers/install_uv.sh
+++ b/helpers/install_uv.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# install_uv.sh — install uv via Astral's native installer.
+#
+# Authoritative entry point is ~/.local/bin/uv. Deliberately NOT in the Brewfile:
+# zsh/zshenv puts ~/.local/bin ahead of Homebrew on PATH, so a `brew install uv`
+# would sit at a lower-precedence path and never be the copy that runs — two uvs,
+# with the tracked one permanently shadowed. uv also self-updates
+# (`uv self update`), so a Homebrew copy would drift behind the live one anyway.
+# Same reasoning, and the same shape, as helpers/install_claude_code.sh.
+#
+# UV_NO_MODIFY_PATH=1 is REQUIRED, not cosmetic. Left unset, the installer appends
+# PATH lines to `.zshrc` and `.zshenv` (see add_install_dir_to_path in the
+# installer). Those paths are Dotbot symlinks into this repo, so an unguarded run
+# edits tracked files and dirties the working tree — exactly the hazard the
+# "Post-installer audit" section of CLAUDE.md exists for. zshenv already puts
+# ~/.local/bin on PATH, so there is nothing for the installer to add.
+#
+# Who needs uv: the Hermes runtime, and any project pinning its own Python
+# (`uv python install`). uv manages its own interpreters under
+# ~/.local/share/uv/python — do not add a Homebrew python@3.x for those; it would
+# be dead weight nothing resolves.
+set -uo pipefail
+
+INSTALL_DIR="$HOME/.local/bin"
+UV_BIN="$INSTALL_DIR/uv"
+INSTALLER_URL="https://astral.sh/uv/install.sh"
+
+if [ "${DOTFILES_DRY_RUN:-0}" = "1" ]; then
+  echo "[dry-run] would install uv via curl -LsSf $INSTALLER_URL | sh (UV_NO_MODIFY_PATH=1)"
+  exit 0
+fi
+
+if [ "$(uname)" != "Darwin" ]; then
+  echo "install_uv.sh: non-Darwin host, skipping"
+  exit 0
+fi
+
+if [ -x "$UV_BIN" ]; then
+  echo "uv already installed at $UV_BIN ($("$UV_BIN" --version 2>/dev/null || echo 'version unknown')) — skipping (self-updates via 'uv self update')"
+  exit 0
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "Error: curl not found; cannot install uv" >&2
+  exit 1
+fi
+
+mkdir -p "$INSTALL_DIR" || { echo "Error: cannot create $INSTALL_DIR" >&2; exit 1; }
+
+echo "Installing uv via Astral's native installer..."
+if ! curl -LsSf "$INSTALLER_URL" \
+     | env UV_NO_MODIFY_PATH=1 UV_INSTALL_DIR="$INSTALL_DIR" sh; then
+  echo "Error: uv installation failed" >&2
+  exit 1
+fi
+
+if [ ! -x "$UV_BIN" ]; then
+  echo "Error: installer reported success but $UV_BIN is not executable" >&2
+  exit 1
+fi
+
+echo "Installed uv -> $UV_BIN ($("$UV_BIN" --version 2>/dev/null || echo 'version unknown'))"

--- a/helpers/install_uv.sh
+++ b/helpers/install_uv.sh
@@ -17,9 +17,11 @@
 # ~/.local/bin on PATH, so there is nothing for the installer to add.
 #
 # Who needs uv: the Hermes runtime, and any project pinning its own Python
-# (`uv python install`). uv manages its own interpreters under
-# ~/.local/share/uv/python — do not add a Homebrew python@3.x for those; it would
-# be dead weight nothing resolves.
+# (`uv python install`). uv prefers the interpreters it manages under
+# ~/.local/share/uv/python and provisions one on demand, so no Homebrew python@3.x
+# has to be installed for it. uv will still discover and use a suitable system
+# interpreter when no managed one fits, so a brewed Python is redundant here rather
+# than unusable.
 set -uo pipefail
 
 INSTALL_DIR="$HOME/.local/bin"
@@ -36,9 +38,14 @@ if [ "$(uname)" != "Darwin" ]; then
   exit 0
 fi
 
+# Present AND runnable — a binary that will not report its version is not a working
+# install, and skipping on mere existence would strand a corrupt one forever.
 if [ -x "$UV_BIN" ]; then
-  echo "uv already installed at $UV_BIN ($("$UV_BIN" --version 2>/dev/null || echo 'version unknown')) — skipping (self-updates via 'uv self update')"
-  exit 0
+  if uv_version="$("$UV_BIN" --version 2>/dev/null)" && [ -n "$uv_version" ]; then
+    echo "uv already installed at $UV_BIN ($uv_version) — skipping (self-updates via 'uv self update')"
+    exit 0
+  fi
+  echo "Found $UV_BIN but it does not run ('--version' failed) — reinstalling over it." >&2
 fi
 
 if ! command -v curl >/dev/null 2>&1; then
@@ -60,4 +67,9 @@ if [ ! -x "$UV_BIN" ]; then
   exit 1
 fi
 
-echo "Installed uv -> $UV_BIN ($("$UV_BIN" --version 2>/dev/null || echo 'version unknown'))"
+if ! uv_version="$("$UV_BIN" --version 2>/dev/null)" || [ -z "$uv_version" ]; then
+  echo "Error: $UV_BIN installed but does not run ('--version' failed)" >&2
+  exit 1
+fi
+
+echo "Installed uv -> $UV_BIN ($uv_version)"


### PR DESCRIPTION
## What

`uv` was installed out-of-band and untracked — a fresh Mac got nothing. This tracks it the way Claude Code is tracked.

## Why not the Brewfile

`zshenv` puts `~/.local/bin` at **PATH position 4**, Homebrew at **6**. A `brew install uv` would sit at the lower-precedence path and never be the copy that runs — two uvs, with the tracked one permanently shadowed. uv also self-updates (`uv self update`), so the brewed copy would drift behind the live one.

Same shape and same reasoning as `helpers/install_claude_code.sh`, whose header already spells this out for `claude`.

## `UV_NO_MODIFY_PATH=1` is load-bearing

The installer's `add_install_dir_to_path` writes PATH lines into **`.zshrc` and `.zshenv`** — both Dotbot symlinks into this repo. An unguarded run therefore edits tracked files and dirties the working tree, which is the "Post-installer audit" hazard, avoided in advance rather than cleaned up after. `zshenv` already puts `~/.local/bin` on PATH, so there is nothing to add.

`UV_INSTALL_DIR` is pinned as well, so the destination never depends on the installer's own defaults.

## Also recorded: don't add a Homebrew Python for uv

uv provisions and manages its own interpreters under `~/.local/share/uv/python/`. The Hermes venv is backed by one of those, not by any system or brewed Python — so a `python@3.x` formula would be dead weight nothing resolves. This closes the second half of the original follow-up.

## Verification

- Installer URL **301s to `releases.astral.sh`** and is an MIT-licensed POSIX `sh` script (fetched 2026-08-25 19:48 PDT)
- `shellcheck` clean; `dot check` clean; `dot doctor` 0 fail
- Dry-run guard prints without acting; skip-if-present is idempotent
- **Full install into a sandboxed `HOME`**: placed `uv` + `uvx` in the right dir, and left seeded `.zshrc` / `.zshenv` / `.profile` **byte-identical** — proving the no-modify guard actually works rather than assuming it
- Fresh-host `dotbot --dry-run` still creates **zero** files outside the documented `com.apple.python` cache noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011r11DbhGUtzywHicrNmp1D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated macOS installation of `uv` and `uvx` using the native installer.
  - Existing installations are skipped only when both tools are functional; incomplete installations are repaired.
  - Added validation of both executables and support for dry-run mode.
  - Prevented installer changes to shell configuration files while preserving PATH precedence.

- **Documentation**
  - Documented vendor-installed CLI locations, PATH precedence, self-updates, and existing helper scripts.
  - Clarified `uv`’s managed Python interpreter preferences, system/Homebrew fallback, and configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review triage

**Round 1** — both fixed:
- *Narrow the non-managed Python claim* — I had written that a Homebrew `python@3.x` "would be dead weight nothing resolves." False, and this Mac disproves it: `uv python list` shows `/opt/homebrew/bin/python3.12` and `python3.14` as usable candidates. uv prefers managed interpreters but discovers and uses system ones. Policy kept, overstatement removed.
- *Require a runnable uv* — the skip check swallowed a failing `--version`, so a broken binary reported success and was then skipped forever. Both checks now require it to run.

**Round 2** — one fixed, one declined:
- *Validate uvx too* — **fixed.** Same strand-forever bug via the other binary: the installer places `uv` and `uvx`, only `uv` was checked. Both now required, either one bad triggers reinstall.
- *Use `$HOME` instead of `~` in the documented Python path* — **declined.** The repo convention is `~` in helper comments: `install_claude_code.sh:5`, `install_claude_settings.sh:6`, `install_herdr_agents.sh:17`, `install_nvim.sh:3`, `install_pre_commit.sh:10` all use it. CLAUDE.md:94 ("never hardcode `/Users/<username>/`") targets literal usernames in code paths, not tildes in prose — the only `$HOME`-in-comment uses (`install_claude_settings.sh:103-105`) are in a comment specifically about `$HOME` rewriting. Applying it would make this the sole helper that differs. Recorded on the thread as well.
