### PR TITLE
feat(herdr): make `claude --continue || claude` the fleet pane-template default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,9 +272,12 @@ install via Homebrew casks in `brew/Brewfile`, not a helper.)
   self-closes" rule — drop to an interactive shell on clean detach rather than
   closing. Local agents get the same rule via the pane template
   `["/bin/zsh", "-l", "-c", "claude --continue || claude; exec /bin/zsh -il"]`,
-  whose `--continue || claude` pair also relaunches the agent into its previous
-  conversation (the bare fallback catches a directory with no prior session,
-  where `--continue` exits 1).
+  whose `--continue || claude` pair also relaunches the agent into the **most
+  recent session for that working directory** — usually, but not always, the
+  pane's own last conversation: where a Claude Code slug is shared with another
+  surface, the thread handed back may be that surface's. The bare fallback
+  catches a directory with no prior session, where `--continue` exits 1. Full
+  caveats: the pane-template section of CLAUDE.md.
   Local project agents (`melos ♪`, `sites ✦`, `borealis ❆`, `argus ◉`,
   `skills ⚒`, `obscura ✇`, `eidos ❖`, `orrery ☉` — roster table in CLAUDE.md)
   need no shim — herdr detects a local claude pane natively; they use the pane

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,7 +271,10 @@ install via Homebrew casks in `brew/Brewfile`, not a helper.)
   loop, so remote panes survive sleep/network loss and — the fleet "a pane never
   self-closes" rule — drop to an interactive shell on clean detach rather than
   closing. Local agents get the same rule via the pane template
-  `["/bin/zsh", "-l", "-c", "claude; exec /bin/zsh -il"]`.
+  `["/bin/zsh", "-l", "-c", "claude --continue || claude; exec /bin/zsh -il"]`,
+  whose `--continue || claude` pair also relaunches the agent into its previous
+  conversation (the bare fallback catches a directory with no prior session,
+  where `--continue` exits 1).
   Local project agents (`melos ♪`, `sites ✦`, `borealis ❆`, `argus ◉`,
   `skills ⚒`, `obscura ✇`, `eidos ❖`, `orrery ☉` — roster table in CLAUDE.md)
   need no shim — herdr detects a local claude pane natively; they use the pane

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -523,23 +523,48 @@ conversations across server restarts via `claude --resume <id>`.
   > Check the remote before repairing anything local: the VPS session usually
   > outlives the disconnect, so reattaching restores the conversation intact.
 
-- **Local agent pane template (fleet standard, revised 2026-08-19):** a local
+- **Local agent pane template (fleet standard, revised 2026-08-27):** a local
   Claude Code agent runs as a declarative pane with command
-  `["/bin/zsh", "-l", "-c", "claude; exec /bin/zsh -il"]` and its project dir as
-  cwd. Two deliberate parts: the **login zsh** (`-l`) rebuilds PATH from `zshenv`
-  because the herdr server spawns pane commands with its bare launchd env (so
-  both `claude` and its subshells resolve tools); the **`; exec /bin/zsh -il`
-  fallback** is the fleet's "a pane never self-closes" rule — when claude exits
-  (a stray `/exit`, a crash), the pane drops to an interactive shell instead of
-  vanishing and closing its tab. Type `claude` to relaunch. No ssh shim for local
-  agents — herdr's claude integration detects them natively and resume-on-restore
-  carries the conversation across server restarts. Rename with `herdr agent
-  rename`; renames don't survive pane recreation — reapply after a degraded
-  restore, along with `layout.apply` if the command was dropped (#2966). The same
-  never-self-close rule is baked into the remote shim wrappers (`herdr/shims/`),
-  so it holds fleet-wide. **When building any new agent, use this template and
-  route the change through the standard flow** (see the global CLAUDE.md
-  "Herdr fleet & agent building").
+  `["/bin/zsh", "-l", "-c", "claude --continue || claude; exec /bin/zsh -il"]`
+  and its project dir as cwd. Three deliberate parts: the **login zsh** (`-l`)
+  rebuilds PATH from `zshenv` because the herdr server spawns pane commands with
+  its bare launchd env (so both `claude` and its subshells resolve tools); the
+  **`--continue || claude` pair** relaunches the agent into its previous
+  conversation instead of a blank session, and the bare fallback is load-bearing
+  because `--continue` exits 1 in a directory with no prior session — without it
+  a first-run pane would land at a shell; the **`; exec /bin/zsh -il` fallback**
+  is the fleet's "a pane never self-closes" rule — when claude exits (a stray
+  `/exit`, a crash), the pane drops to an interactive shell instead of vanishing
+  and closing its tab. Type `claude` to relaunch. No ssh shim for local agents —
+  herdr's claude integration detects them natively, and `resume_agents_on_restore`
+  carries the conversation across a clean server restart. Rename with `herdr
+  agent rename`; the binding releases when the agent *process* dies, so reapply
+  after a degraded restore, along with `layout.apply` if the command was dropped
+  (#2966). The same never-self-close rule is baked into the remote shim wrappers
+  (`herdr/shims/`), so it holds fleet-wide. **When building any new agent, use
+  this template and route the change through the standard flow** (see the global
+  CLAUDE.md "Herdr fleet & agent building").
+  - **Why `--continue` is the template default and not a repair-time opt-in**
+    (2026-08-27). herdr's `resume_agents_on_restore` covers the clean path, but
+    it cannot help a pane whose *command* was dropped — and upstream closed
+    herdrdev/herdr#3306 `NOT_PLANNED`, ruling that post-restart panes returning
+    as fresh shells is documented behaviour. The rebuild is therefore the fleet's
+    job permanently, so the template does the resuming rather than every repair
+    remembering a flag. The live fleet had already been fully converted by
+    `repair --resume` before the docs said so; this change reconciles them, and
+    needs no pane rebuilt.
+  - **Two caveats, both flowing from "the most recent session in that cwd".**
+    `--continue` picks by recency, not by which conversation the pane held.
+    Rebuild a pane wanting a fresh start and the old thread comes back (`/clear`
+    after). And in a **shared-slug project the thread may not be the pane's own**:
+    `orrery ☉` shares its Claude Code slug with Forge's embedded ACP sessions, so
+    a rebuild there can resume whichever surface spoke last. List them by mtime
+    before relying on it — note `/bin/ls`, because `ls` is aliased to `eza`, whose
+    `-t` takes a field name instead of sorting:
+
+    ```bash
+    /bin/ls -t ~/.claude/projects/-Users-dvillavicencio--forge-projects-tranquil-dune/*.jsonl | head -3
+    ```
   - **Before/after a server restart, use `herdr/fleet-check.py`.** `snapshot`
     before `brew services restart herdr`, `verify` after reattaching. It walks
     every tab's `layout.export`, flags panes whose `command` is missing (#2966),
@@ -551,14 +576,17 @@ conversations across server restarts via `claude --resume <id>`.
       after a restart a resumed pane and a bare shell are indistinguishable in
       `layout.export` (both lost their command), so a blind rebuild destroys live
       conversations to fix metadata that only matters at the *next* restart.
-    - **`repair --resume` relaunches the agent into its conversation** rather than
-      a blank session, rewriting `claude;` → `claude --continue || claude;` (and
-      the `hermes chat` equivalent). The `||` fallback is load-bearing:
-      `--continue` exits 1 in a directory with no prior session, and without it
-      the pane would land at a shell. Remote shim commands are deliberately not
-      rewritten — their agent lives in tmux on the VPS and was never killed.
+    - **`repair` relaunches the agent into its conversation by default** (since
+      2026-08-27, matching the pane template; `--no-resume` opts out for a
+      deliberately blank pane). The rewrite still matters because a snapshot
+      taken before the template flip records the bare `claude;` form, so repair
+      upgrades it to `claude --continue || claude;` (and the `hermes chat`
+      equivalent) on the way back in — a pane already built from the current
+      template is left alone, since the pattern anchors on `claude;` and does not
+      match `claude --continue`. Remote shim commands are never rewritten — their
+      agent lives in tmux on the VPS and was never killed.
       **Caveat:** `--continue` resumes the *most recent* session in that cwd, so
-      run it before typing into a blank pane; a new session would otherwise become
+      repair before typing into a blank pane; a new session would otherwise become
       the most recent one.
   - **Diagnosing and rebuilding a degraded pane.** `layout.export` is the test:
     a pane node with **no `command`** key is degraded — it came back as a bare
@@ -579,7 +607,7 @@ conversations across server restarts via `claude --resume <id>`.
     ```bash
     S=~/.config/herdr/herdr.sock
     echo '{"id":"1","method":"layout.export","params":{"tab_id":"w1:t1"}}' | nc -U $S
-    echo '{"id":"1","method":"layout.apply","params":{"tab_id":"w1:t1","focus":true,"root":{"type":"pane","cwd":"'"$HOME"'/Projects/Personal/dotfiles","command":["/bin/zsh","-l","-c","claude; exec /bin/zsh -il"]}}}' | nc -U $S
+    echo '{"id":"1","method":"layout.apply","params":{"tab_id":"w1:t1","focus":true,"root":{"type":"pane","cwd":"'"$HOME"'/Projects/Personal/dotfiles","command":["/bin/zsh","-l","-c","claude --continue || claude; exec /bin/zsh -il"]}}}' | nc -U $S
     ```
 
     Two API gotchas, both fail-fast: `layout.apply` takes **`tab_id` or
@@ -613,7 +641,7 @@ conversations across server restarts via `claude --resume <id>`.
     don't survive pane recreation, and the jump key targets the agent name):
 
     ```bash
-    echo '{"id":"1","method":"layout.apply","params":{"tab_id":"<wN:tN>","focus":true,"root":{"type":"pane","cwd":"'"$HOME"'/Obsidian/vice","command":["/bin/zsh","-l","-c","hermes chat; exec /bin/zsh -il"]}}}' | nc -U ~/.config/herdr/herdr.sock
+    echo '{"id":"1","method":"layout.apply","params":{"tab_id":"<wN:tN>","focus":true,"root":{"type":"pane","cwd":"'"$HOME"'/Obsidian/vice","command":["/bin/zsh","-l","-c","hermes chat --continue || hermes chat; exec /bin/zsh -il"]}}}' | nc -U ~/.config/herdr/herdr.sock
     /opt/homebrew/bin/herdr agent rename <pane-id> vice
     ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -529,8 +529,9 @@ conversations across server restarts via `claude --resume <id>`.
   and its project dir as cwd. Three deliberate parts: the **login zsh** (`-l`)
   rebuilds PATH from `zshenv` because the herdr server spawns pane commands with
   its bare launchd env (so both `claude` and its subshells resolve tools); the
-  **`--continue || claude` pair** relaunches the agent into its previous
-  conversation instead of a blank session, and the bare fallback is load-bearing
+  **`--continue || claude` pair** relaunches the agent into the most recent
+  session for that cwd instead of a blank one (see the caveats below — that is
+  not always the pane's own thread), and the bare fallback is load-bearing
   because `--continue` exits 1 in a directory with no prior session — without it
   a first-run pane would land at a shell; the **`; exec /bin/zsh -il` fallback**
   is the fleet's "a pane never self-closes" rule — when claude exits (a stray

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -260,10 +260,12 @@ workspace, changing a pane command, adding/renaming an agent, editing the shims 
 keys — follow the one documented flow in the **dotfiles project CLAUDE.md "Herdr" section**
 rather than improvising a different shape in whatever project you're in:
 
-- **New agents use the fleet pane template** — local: `["/bin/zsh", "-l", "-c", "claude;
-  exec /bin/zsh -il"]` (login shell rebuilds PATH from the bare launchd env; the trailing
-  `exec zsh` is the "a pane never self-closes on `/exit`/crash" rule). Remote surfaces use
-  the repo-tracked auto-reconnect shims in `dotfiles/herdr/shims/`.
+- **New agents use the fleet pane template** — local: `["/bin/zsh", "-l", "-c", "claude
+  --continue || claude; exec /bin/zsh -il"]` (login shell rebuilds PATH from the bare
+  launchd env; `--continue || claude` resumes the pane's last conversation, falling back
+  to a fresh one where none exists; the trailing `exec zsh` is the "a pane never
+  self-closes on `/exit`/crash" rule). Remote surfaces use the repo-tracked
+  auto-reconnect shims in `dotfiles/herdr/shims/`.
 - **Config, shims, and the helper are dotfiles-tracked** — herdr changes ride a dotfiles
   branch/PR (config.toml is symlinked and writes back), never an ad-hoc edit to
   `~/.config/herdr/`.

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -262,9 +262,11 @@ rather than improvising a different shape in whatever project you're in:
 
 - **New agents use the fleet pane template** — local: `["/bin/zsh", "-l", "-c", "claude
   --continue || claude; exec /bin/zsh -il"]` (login shell rebuilds PATH from the bare
-  launchd env; `--continue || claude` resumes the pane's last conversation, falling back
-  to a fresh one where none exists; the trailing `exec zsh` is the "a pane never
-  self-closes on `/exit`/crash" rule). Remote surfaces use the repo-tracked
+  launchd env; `--continue || claude` resumes the most recent session for that working
+  directory — not necessarily the pane's own, where a slug is shared with another
+  surface — falling back to a fresh one where none exists; the trailing `exec zsh` is
+  the "a pane never self-closes on `/exit`/crash" rule; canonical caveats live in the
+  dotfiles CLAUDE.md pane-template section). Remote surfaces use the repo-tracked
   auto-reconnect shims in `dotfiles/herdr/shims/`.
 - **Config, shims, and the helper are dotfiles-tracked** — herdr changes ride a dotfiles
   branch/PR (config.toml is symlinked and writes back), never an ad-hoc edit to

--- a/docs/solutions/best-practices/displayed-commands-must-be-runnable-verbatim.md
+++ b/docs/solutions/best-practices/displayed-commands-must-be-runnable-verbatim.md
@@ -12,12 +12,15 @@ applies_when:
   - "The user dictates with speech-to-text, or runs any tool that writes to the pasteboard, so the clipboard is clobbered between copy and paste"
   - "Handing over a remote command with nested quoting, e.g. `ssh host` wrapping a quoted `cp && sed -i && bash -n` chain"
   - "The command mutates state, so a partially-executed prefix leaves a half-applied result"
+  - "A displayed command uses a bare tool name that `zsh/alias.sh` aliases to a different binary — `ls` is `eza`"
 symptoms:
   - "`python3: can't open file '...': [Errno 2] No such file or directory` — the literal ellipsis from the displayed text was pasted and run"
   - "`sed: -e expression #1, char 1: unknown command: '.'` — an elided remote one-liner ran with the ellipsis inside the quoted payload"
   - "The user reports the command failed even though what the agent put on the clipboard was correct"
   - "A multi-step `&&` chain ran only its first stage: the `cp -n` backup exists but the edit never applied"
   - "The user says \"I lost my clipboard\" or asks for a payload to be re-copied"
+  - "`error: invalid value '<filename>' for '--time <FIELD>'` — `ls -t` hit the eza alias instead of ls"
+  - "A listing written with `2>/dev/null` prints nothing and is misread as an empty directory"
 root_cause: design_limitation
 resolution_type: workflow_improvement
 related_components:
@@ -29,6 +32,8 @@ tags:
   - pbcopy
   - agent-output
   - shell-pitfalls
+  - aliases
+  - eza
   - quoting
   - ssh
   - macos
@@ -175,6 +180,40 @@ keep run-now blocks free of anything angle-bracketed.
 The clipboard holds exactly one thing. When staging several handoffs, do them one at a time,
 say which target the current contents belong to, and do not stage the next until the first is
 consumed — a convention the user asked for directly on 2026-08-24 *(session history)*.
+
+### 4. A verbatim command still lands in *this* machine's alias layer
+
+Runnability is not a property of the command text alone — it is the text plus the shell it
+arrives in, and this repo's shell is not a stock one. Three different `ls` resolve here:
+
+```
+ls is an alias for eza --group-directories-first     <- wins in command position
+ls is /opt/homebrew/opt/coreutils/libexec/gnubin/ls  <- GNU ls, first on PATH
+ls is /bin/ls                                        <- BSD ls
+```
+
+The alias wins, and **eza reads `-t` as `--time <FIELD>`, not "sort by mtime"**. So a line
+that looks portable and correct everywhere:
+
+```bash
+ls -t ~/.claude/projects/<slug>/*.jsonl | head -3
+```
+
+dies with `error: invalid value '<first filename>' for '--time <FIELD>'`. Worse, a listing
+that may legitimately be empty is usually written with `2>/dev/null` — which suppresses that
+error and prints **nothing**, so the result reads as "this project has no transcripts"
+rather than "wrong tool." Observed 2026-08-27 while documenting the `--continue` pane
+template: an empty result was briefly taken as evidence that `orrery ☉` had no session
+history, when it had three transcripts.
+
+**Fix: name the binary, not the alias.** `/bin/ls -t …` in anything displayed — it is
+unambiguous, and unlike `command ls` it does not silently depend on which `ls` PATH resolves
+to first. `command ls` does bypass the alias and is fine interactively; it just lands on GNU
+`ls` here rather than BSD `ls`, so it is the weaker guarantee for a written-down command.
+
+This generalizes past `ls`: before displaying a command built from a bare tool name, ask
+whether the name is aliased in `zsh/alias.sh`. Most aliases only change *defaults* and stay
+compatible. `ls` bites because its alias changes flag **semantics**.
 
 ### The self-check before you display
 

--- a/docs/solutions/best-practices/displayed-commands-must-be-runnable-verbatim.md
+++ b/docs/solutions/best-practices/displayed-commands-must-be-runnable-verbatim.md
@@ -12,14 +12,14 @@ applies_when:
   - "The user dictates with speech-to-text, or runs any tool that writes to the pasteboard, so the clipboard is clobbered between copy and paste"
   - "Handing over a remote command with nested quoting, e.g. `ssh host` wrapping a quoted `cp && sed -i && bash -n` chain"
   - "The command mutates state, so a partially-executed prefix leaves a half-applied result"
-  - "A displayed command uses a bare tool name that `zsh/alias.sh` aliases to a different binary — `ls` is `eza`"
+  - "A displayed command uses a bare tool name that `zsh/alias.sh` aliases to a different binary — `ls` is `eza` on any machine where eza is installed"
 symptoms:
   - "`python3: can't open file '...': [Errno 2] No such file or directory` — the literal ellipsis from the displayed text was pasted and run"
   - "`sed: -e expression #1, char 1: unknown command: '.'` — an elided remote one-liner ran with the ellipsis inside the quoted payload"
   - "The user reports the command failed even though what the agent put on the clipboard was correct"
   - "A multi-step `&&` chain ran only its first stage: the `cp -n` backup exists but the edit never applied"
   - "The user says \"I lost my clipboard\" or asks for a payload to be re-copied"
-  - "`error: invalid value '<filename>' for '--time <FIELD>'` — `ls -t` hit the eza alias instead of ls"
+  - "`error: invalid value '<filename>' for '--time <FIELD>'` — with eza installed, `ls -t` hit its alias instead of ls"
   - "A listing written with `2>/dev/null` prints nothing and is misread as an empty directory"
 root_cause: design_limitation
 resolution_type: workflow_improvement
@@ -181,16 +181,22 @@ The clipboard holds exactly one thing. When staging several handoffs, do them on
 say which target the current contents belong to, and do not stage the next until the first is
 consumed — a convention the user asked for directly on 2026-08-24 *(session history)*.
 
-### 4. A verbatim command still lands in *this* machine's alias layer
+### 7. A verbatim command still lands in *this* machine's alias layer
 
 Runnability is not a property of the command text alone — it is the text plus the shell it
 arrives in, and this repo's shell is not a stock one. Three different `ls` resolve here:
 
+```text
+$ type -a ls
+ls is an alias for eza --group-directories-first        <- wins in command position
+ls is <BREW_PREFIX>/opt/coreutils/libexec/gnubin/ls     <- GNU ls, first on PATH
+ls is /bin/ls                                           <- BSD ls
 ```
-ls is an alias for eza --group-directories-first     <- wins in command position
-ls is /opt/homebrew/opt/coreutils/libexec/gnubin/ls  <- GNU ls, first on PATH
-ls is /bin/ls                                        <- BSD ls
-```
+
+The eza alias is guarded by `command -v eza`, so a machine without eza falls back to
+`alias ls="command ls ${colorflag}"` — still an alias, but a benign one that leaves `-t`
+alone. That is what makes this trap machine-dependent rather than obvious: the same doc
+command works on a plain host and fails here.
 
 The alias wins, and **eza reads `-t` as `--time <FIELD>`, not "sort by mtime"**. So a line
 that looks portable and correct everywhere:

--- a/herdr/fleet-check.py
+++ b/herdr/fleet-check.py
@@ -14,11 +14,14 @@ own, but two do not, and both fail *quietly*:
 Usage:
     fleet-check.py snapshot    # before `brew services restart herdr`
     fleet-check.py verify      # after reattaching
-    fleet-check.py repair      # rebuild lost panes that have no live agent
-    fleet-check.py repair --resume   # ...and relaunch their agent into its conversation
+    fleet-check.py repair      # rebuild lost panes that have no live agent,
+                               #   relaunching each into its conversation
+    fleet-check.py repair --no-resume   # ...into a blank session instead
     fleet-check.py             # verify if a snapshot exists, else snapshot
 
-Read-only: it never mutates herdr state. Repairs are printed for you to run.
+`snapshot` and `verify` are read-only — `verify` prints the repairs rather than
+running them. `repair` is the one subcommand that mutates: it calls `layout.apply`,
+which kills and replaces the pane it rebuilds.
 """
 import json
 import os
@@ -161,11 +164,14 @@ def do_snapshot(rows):
     print("  3. python3 ~/Projects/Personal/dotfiles/herdr/fleet-check.py verify")
 
 
-# A rebuilt pane runs its recorded command, which launches the agent FRESH — the
-# pane looks blank and the previous conversation sits unloaded on disk. These
-# rewrites make it resume instead. `|| <bare>` matters: `--continue` exits 1 when
-# the directory has no prior session, and without the fallback the pane would land
-# at a shell instead of a usable agent.
+# The fleet pane template carries `--continue || <bare>` since 2026-08-27, so a
+# pane built from it already resumes. These rewrites upgrade the ones that do not:
+# a snapshot taken before the flip records the bare form, and restoring it verbatim
+# would launch the agent FRESH — the pane looks blank while the previous
+# conversation sits unloaded on disk. The patterns anchor on the bare form, so a
+# command that already resumes is left untouched rather than rewritten twice.
+# `|| <bare>` is load-bearing: `--continue` exits 1 when the directory has no prior
+# session, and without the fallback the pane would land at a shell.
 RESUME_REWRITES = [
     (re.compile(r"^claude;"), "claude --continue || claude;"),
     (re.compile(r"^hermes chat;"), "hermes chat --continue || hermes chat;"),
@@ -190,7 +196,7 @@ def resume_variant(cmd):
     return cmd, False
 
 
-def do_repair(rows, force=False, resume=False):
+def do_repair(rows, force=False, resume=True):
     """Rebuild panes whose command was lost — but never one with a live agent.
 
     After a restart the two populations look identical in `layout.export` (both
@@ -233,10 +239,17 @@ def do_repair(rows, force=False, resume=False):
     print(f"REBUILDING {len(todo)} pane(s) with no live agent:")
     for r, cmd in todo:
         prev = by_key[key(r)]
-        tag = ""
-        if resume:
+        if not resume:
+            tag = "  [--no-resume: blank session]"
+        else:
             cmd, rewritten = resume_variant(cmd)
-            tag = "  [resume]" if rewritten else "  [no local agent to resume]"
+            shell = cmd[-1] if cmd and isinstance(cmd[-1], str) else ""
+            if rewritten:
+                tag = "  [resume: rewritten from a pre-2026-08-27 snapshot]"
+            elif "--continue" in shell:
+                tag = "  [resume: already in the recorded command]"
+            else:
+                tag = "  [no local agent to resume]"
         node = {"type": "pane", "cwd": prev.get("cwd"), "command": cmd}
         res = call("layout.apply", {"tab_id": r["tab"], "focus": False, "root": node})
         new = res.get("layout", {}).get("root", {}).get("pane_id")
@@ -319,8 +332,9 @@ def main():
     if cmd == "verify":
         return do_verify(rows)
     if cmd == "repair":
+        # --resume is accepted as a no-op so older muscle memory still works.
         return do_repair(rows, force="--force" in sys.argv,
-                         resume="--resume" in sys.argv)
+                         resume="--no-resume" not in sys.argv)
     sys.exit(f"unknown command: {cmd} (expected snapshot|verify|repair)")
 
 

--- a/herdr/fleet-check.py
+++ b/herdr/fleet-check.py
@@ -164,36 +164,65 @@ def do_snapshot(rows):
     print("  3. python3 ~/Projects/Personal/dotfiles/herdr/fleet-check.py verify")
 
 
-# The fleet pane template carries `--continue || <bare>` since 2026-08-27, so a
-# pane built from it already resumes. These rewrites upgrade the ones that do not:
-# a snapshot taken before the flip records the bare form, and restoring it verbatim
-# would launch the agent FRESH — the pane looks blank while the previous
-# conversation sits unloaded on disk. The patterns anchor on the bare form, so a
-# command that already resumes is left untouched rather than rewritten twice.
-# `|| <bare>` is load-bearing: `--continue` exits 1 when the directory has no prior
-# session, and without the fallback the pane would land at a shell.
-RESUME_REWRITES = [
-    (re.compile(r"^claude;"), "claude --continue || claude;"),
-    (re.compile(r"^hermes chat;"), "hermes chat --continue || hermes chat;"),
-]
+# The two forms a local agent launch can take, from one source of truth so the
+# resume and blank directions can never drift apart. The fleet pane template
+# carries the resuming form since 2026-08-27; a snapshot taken before that flip
+# records the bare one, and restoring it verbatim would launch the agent FRESH —
+# the pane looks blank while the previous conversation sits unloaded on disk.
+# `|| <bare>` is load-bearing: `--continue` exits 1 when the directory has no
+# prior session, and without the fallback the pane would land at a shell.
+AGENT_LAUNCHERS = ["claude", "hermes chat"]
 
 
-def resume_variant(cmd):
-    """Rewrite a LOCAL agent launch to resume. Returns (command, rewritten?).
+def _bare(agent):
+    return f"{agent};"
 
-    Remote shim commands are deliberately untouched: their agent lives in tmux on
-    the VPS and was never killed, so the shim reattaches to a live session and
-    there is nothing local to resume.
+
+def _resuming(agent):
+    return f"{agent} --continue || {agent};"
+
+
+# Each table anchors on the form it converts FROM, so applying either to a command
+# already in the target form is a no-op — the rewrites are idempotent, and a
+# remote shim command matches neither.
+RESUME_REWRITES = [(re.compile("^" + re.escape(_bare(a))), _resuming(a))
+                   for a in AGENT_LAUNCHERS]
+BLANK_REWRITES = [(re.compile("^" + re.escape(_resuming(a))), _bare(a))
+                  for a in AGENT_LAUNCHERS]
+
+
+def _rewrite(cmd, table):
+    """Swap the launcher in a pane command's final shell string.
+
+    Remote shim commands are deliberately untouched by both tables: their agent
+    lives in tmux on the VPS and was never killed, so the shim reattaches to a
+    live session and there is nothing local to resume or blank.
     """
     if not cmd or len(cmd) < 2:
         return cmd, False
     shell = cmd[-1]
     if not isinstance(shell, str):
         return cmd, False
-    for pat, repl in RESUME_REWRITES:
+    for pat, repl in table:
         if pat.match(shell):
-            return cmd[:-1] + [pat.sub(repl, shell, count=1)], True
+            # A lambda replacement so a backslash in `repl` is never read as a
+            # backreference.
+            return cmd[:-1] + [pat.sub(lambda m, r=repl: r, shell, count=1)], True
     return cmd, False
+
+
+def resume_variant(cmd):
+    """Upgrade a bare LOCAL agent launch to resume. Returns (command, changed?)."""
+    return _rewrite(cmd, RESUME_REWRITES)
+
+
+def blank_variant(cmd):
+    """Strip the resume wrapper from a LOCAL agent launch, for `--no-resume`.
+
+    Needed because the pane template now records the resuming form: without this
+    the opt-out would restore that form verbatim and silently resume anyway.
+    """
+    return _rewrite(cmd, BLANK_REWRITES)
 
 
 def do_repair(rows, force=False, resume=True):
@@ -240,7 +269,9 @@ def do_repair(rows, force=False, resume=True):
     for r, cmd in todo:
         prev = by_key[key(r)]
         if not resume:
-            tag = "  [--no-resume: blank session]"
+            cmd, stripped = blank_variant(cmd)
+            tag = ("  [--no-resume: resume wrapper stripped, blank session]" if stripped
+                   else "  [--no-resume: blank session]")
         else:
             cmd, rewritten = resume_variant(cmd)
             shell = cmd[-1] if cmd and isinstance(cmd[-1], str) else ""


### PR DESCRIPTION
Closes the open call carried in HANDOFF: adopt `claude --continue || claude` as the fleet pane-template default.

## Why now

Upstream closed **herdrdev/herdr#3306 `NOT_PLANNED`** — post-restart panes returning as fresh shells is documented behaviour. Rebuilding a dropped pane is therefore the fleet's job permanently, not a bug to wait out, so the template does the resuming rather than every repair remembering a flag.

## This is a reconciliation, not a rollout

Read the live fleet before editing: **all 11 local panes already run the resume form** (`vice ♠` the `hermes chat` twin), converted at some point by `repair --resume`, while all four documented templates still specified bare `claude;`. The docs were the drift. **No pane needs rebuilding**, so this carries none of the usual `layout.apply` risk.

| Surface | Before | After |
|---|---|---|
| `CLAUDE.md` template + 2 `layout.apply` examples | `claude;` | `claude --continue \|\| claude;` |
| `AGENTS.md` (tool-neutral brief) | `claude;` | same |
| `claude/CLAUDE.md` (global fleet rule) | `claude;` | same |
| `fleet-check.py repair` | `--resume` opt-in | resumes by default, `--no-resume` opts out |

## `fleet-check.py`

- `repair` resumes by default; `--resume` still accepted as a no-op for muscle memory.
- The rewrite table **stays** — a snapshot taken before the flip records the bare form (this repo's own `dotfiles ~` entry does). Verified idempotent: the patterns anchor on `claude;` and do not match `claude --continue`, and remote shim commands are untouched.
- Per-pane tags now distinguish *rewritten from an old snapshot* / *already resuming* / *no local agent*, instead of the old misleading "no local agent to resume".
- Two fixes found while editing: `cmd[-1]` guarded against an empty list, and a docstring that claimed the tool never mutates when `repair` calls `layout.apply`.

## Caveats documented, not hidden

`--continue` picks **the most recent session in that cwd**, not the pane's own thread. Two consequences now written down:

1. A rebuild intended to start clean drags the old conversation back — `/clear` after.
2. In a **shared-slug project the thread may belong to another surface**: `orrery ☉` shares its Claude Code slug with Forge's embedded ACP sessions, so a rebuild there can resume whichever spoke last. Verified concretely — orrery's most recent transcript is a 106K file from 08:15, not the 12M one.

## Incidental catch

Writing that verification command surfaced a real trap: `ls` is aliased to `eza`, whose `-t` is `--time <FIELD>` rather than sort-by-mtime. A documented `ls -t … 2>/dev/null` prints **nothing** and reads as an empty directory — it briefly looked like orrery had no transcripts when it had three. Landed as rule 4 in `docs/solutions/best-practices/displayed-commands-must-be-runnable-verbatim.md`; displayed commands now use `/bin/ls`.

## Verification

- `dot check` — clean (shellcheck, `zsh -n`, `py_compile`, dotbot parse).
- `dot doctor` — 0 fail, 4 warn (all pre-existing toolchain-shadowing warnings).
- `resume_variant` exercised over 5 command shapes: both bare forms rewritten, both resume forms untouched, remote shim untouched, and rewriting twice equals rewriting once.

Docs-only paths plus one Python file, so `install-matrix` runs (`herdr/fleet-check.py` is outside `paths-ignore`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yrqiZhPKFC49UWytmhsuj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Local Claude and Hermes sessions now resume the most recent conversation for the working directory by default.
  - Added support for starting blank sessions when resumption is not desired.
  - Repair operations now resume sessions by default; use `--no-resume` to create blank sessions.
  - Repair, snapshot, and verification behavior is now clearly distinguished.

- **Documentation**
  - Clarified session-resumption caveats and recovery guidance.
  - Added best practices for reliable, runnable command examples, including explicit system command paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->