### PR TITLE
fix(herdr): `verify` must print the rebuild command `repair` would run

### DIFF
--- a/herdr/fleet-check.py
+++ b/herdr/fleet-check.py
@@ -318,11 +318,20 @@ def do_verify(rows):
             cmd = prev.get("command")
             print(f"\n  {r['label']}  tab={r['tab']}")
             if cmd:
+                # Print what `repair` would actually run, not the raw snapshot. A
+                # snapshot older than the 2026-08-27 template flip records the bare
+                # form, so pasting it verbatim rebuilds the pane into a BLANK
+                # session while `repair` would have resumed it — the two repair
+                # paths must not disagree.
+                cmd, upgraded = resume_variant(cmd)
                 node = {"type": "pane", "cwd": prev.get("cwd"), "command": cmd}
                 req = {"id": "1", "method": "layout.apply",
                        "params": {"tab_id": r["tab"], "focus": True, "root": node}}
                 print("    rebuild (omit pane_id so herdr replaces the pane):")
                 print(f"      echo '{json.dumps(req)}' | nc -U {SOCK}")
+                if upgraded:
+                    print("      (resume wrapper added — this snapshot predates the "
+                          "template flip; use `repair --no-resume` for a blank pane)")
             else:
                 print("    no command recorded in the snapshot — rebuild by hand")
     else:


### PR DESCRIPTION
Loose end from #180, found by running `verify` against the live fleet right after that merge.

## The disagreement

#180 made `repair` resume by default. `verify` was left printing a `layout.apply` built from the **raw snapshot** — and a snapshot older than the template flip records the bare `claude;` form. So on the same degraded pane:

| Path | Result |
|---|---|
| `repair` | resumes the conversation |
| the command `verify` prints for you to paste | **blank session** |

The printed one is the one a human actually runs, so the regression landed on the copy that gets used.

## Fix

`verify` applies `resume_variant` before printing, and says so when it changed anything:

```
  dotfiles ~  tab=w1:t7
    rebuild (omit pane_id so herdr replaces the pane):
      echo '{... "command": ["/bin/zsh", "-l", "-c", "claude --continue || claude; exec /bin/zsh -il"]}}}' | nc -U /Users/dvillavicencio/.config/herdr/herdr.sock
      (resume wrapper added — this snapshot predates the template flip; use `repair --no-resume` for a blank pane)
```

## Verification

Exercised live, not synthetically: this repo's own `dotfiles ~` pane is genuinely degraded and its snapshot still holds the pre-flip bare form, so it is exactly the case the bug affected. Output above is that run. `dot check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yrqiZhPKFC49UWytmhsuj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Verification now displays resumable commands when rebuilding layouts from older snapshots.
  * Added guidance for restoring a blank session with the `--no-resume` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->